### PR TITLE
docs: comprehensive in-package API documentation for all npm packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Comprehensive API reference in all package READMEs (`packages/*/README.md`) for LLM/agent consumption from node_modules — 325 exports documented across core (220), react (18), vue (19), angular (13), plugins (40), widget (12), server (3)
+- Root README rewritten as LLM navigation hub with package decision tree and API overview
+- Re-exported `CellStyleRef`, `SelectionType`, `BorderStyle` types from `packages/core/src/index.ts`
 - Performance benchmark suite with `BenchmarkRunner`, `measureMultiRun`, `computeStats`, `measureThroughput` utilities
 - `npm run benchmark` script for running performance benchmarks
 - Baseline metrics for 6 categories across 1K/10K/100K row datasets

--- a/README.md
+++ b/README.md
@@ -1,54 +1,17 @@
-<div align="center">
-
 # @witqq/spreadsheet
 
-**Canvas-based spreadsheet & datagrid engine for React, Vue, Angular — zero dependencies**
-
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6.svg)](https://www.typescriptlang.org/)
-[![npm](https://img.shields.io/npm/v/@witqq/spreadsheet.svg)](https://www.npmjs.com/package/@witqq/spreadsheet)
-
-<br />
-
-[![Live Demo](https://img.shields.io/badge/Live_Demo-Try_Now-brightgreen?style=for-the-badge&logo=google-chrome&logoColor=white)](https://spreadsheet.witqq.dev/)
-[![Documentation](https://img.shields.io/badge/Docs-Read_the_Docs-blue?style=for-the-badge&logo=readthedocs&logoColor=white)](https://spreadsheet.witqq.dev/getting-started/)
-[![API Reference](https://img.shields.io/badge/API-Reference-8B5CF6?style=for-the-badge&logo=typescript&logoColor=white)](https://spreadsheet.witqq.dev/api/wit-engine/)
-[![Getting Started](https://img.shields.io/badge/Quick_Start-5_min_Setup-orange?style=for-the-badge&logo=rocket&logoColor=white)](https://spreadsheet.witqq.dev/getting-started/quick-start/)
-
-</div>
-
----
-
-A high-performance spreadsheet and datagrid engine built on Canvas 2D with zero external dependencies. Renders 100K+ rows at 60fps with full editing, selection, undo/redo, clipboard, sorting, filtering, frozen panes, merged cells, formulas, and real-time collaboration.
-
-Official wrappers for **React**, **Vue 3**, and **Angular**. Embeddable widget bundle under 36KB gzip.
-
-## ✨ Features
-
-| Category | Features |
-|----------|----------|
-| **Rendering** | Canvas 2D multi-layer pipeline, 100K+ rows at 60fps, progressive loading, auto row height with text wrapping |
-| **Editing** | Inline editor, date picker, datetime picker, custom cell editors via CellEditorRegistry, undo/redo (100 steps), clipboard (TSV + HTML), autofill |
-| **Layout** | Column stretch (`'all'` / `'last'`), frozen panes, auto row sizing, container resize observation |
-| **Data** | Sort (multi-column), filter (14 operators), merged cells |
-| **Plugins** | Formulas, conditional formatting, collaboration (OT), Excel I/O, context menu with submenus |
-| **Theming** | Light/dark built-in, fully customizable via `WitTheme` |
-| **Localization** | Built-in English and Russian locales, custom locale packs, runtime switching |
-| **Accessibility** | WCAG 2.1 AA: role=grid, aria-live, keyboard-only, print support |
-| **Frameworks** | React, Vue 3, Angular, vanilla JS widget (<36KB gzip) |
-
-## 🚀 Quick Start
+Canvas-based spreadsheet and datagrid engine for React, Vue, Angular, and vanilla JS. Zero external dependencies in the core package.
 
 ```bash
 npm install @witqq/spreadsheet @witqq/spreadsheet-react
 ```
 
 ```tsx
-import { WitTable } from '@witqq/spreadsheet-react';
+import { Spreadsheet } from '@witqq/spreadsheet-react';
 
 const columns = [
-  { id: 'name', header: 'Name', width: 200 },
-  { id: 'value', header: 'Value', width: 120, type: 'number' },
+  { key: 'name', title: 'Name', width: 200 },
+  { key: 'value', title: 'Value', width: 120, type: 'number' },
 ];
 
 const data = [
@@ -57,110 +20,99 @@ const data = [
 ];
 
 function App() {
-  return <WitTable columns={columns} data={data} />;
+  return <Spreadsheet columns={columns} data={data} />;
 }
 ```
 
-> **Vue, Angular, vanilla JS?** See framework guides:
-> [Vue 3](https://spreadsheet.witqq.dev/frameworks/vue/) ·
-> [Angular](https://spreadsheet.witqq.dev/frameworks/angular/) ·
-> [Widget](https://spreadsheet.witqq.dev/frameworks/widget/)
+## Packages
 
-## ⚡ Performance
+| Package | Path | npm | Description |
+|---------|------|-----|-------------|
+| [`@witqq/spreadsheet`](packages/core/README.md) | `packages/core/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet.svg)](https://www.npmjs.com/package/@witqq/spreadsheet) | Canvas engine — rendering, editing, selection, data model, commands, theming, localization. 220 exports. |
+| [`@witqq/spreadsheet-react`](packages/react/README.md) | `packages/react/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet-react.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-react) | React wrapper component. 18 exports. |
+| [`@witqq/spreadsheet-vue`](packages/vue/README.md) | `packages/vue/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet-vue.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-vue) | Vue 3 wrapper component. 19 exports. |
+| [`@witqq/spreadsheet-angular`](packages/angular/README.md) | `packages/angular/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet-angular.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-angular) | Angular wrapper component. 13 exports. |
+| [`@witqq/spreadsheet-plugins`](packages/plugins/README.md) | `packages/plugins/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet-plugins.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-plugins) | Formulas, conditional formatting, collaboration (OT), Excel I/O, context menu, progressive loader. 40 exports. |
+| [`@witqq/spreadsheet-widget`](packages/widget/README.md) | `packages/widget/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet-widget.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-widget) | IIFE/UMD bundle for `<script>` tag embedding. 12 exports. |
+| `@witqq/spreadsheet-server` | `packages/server/` | private | WebSocket collaboration relay server. [README](packages/server/README.md) |
+
+Each package README contains full API documentation with all exported functions, classes, interfaces, and types — sufficient for LLM agents to use the library from `node_modules` without internet access.
+
+## Package Decision Tree
+
+```
+Need a spreadsheet in your app?
+├── Using React?       → @witqq/spreadsheet-react
+├── Using Vue 3?       → @witqq/spreadsheet-vue
+├── Using Angular?     → @witqq/spreadsheet-angular
+├── No framework / plain HTML?
+│   ├── Build step available? → @witqq/spreadsheet (use SpreadsheetEngine directly)
+│   └── No build step?       → @witqq/spreadsheet-widget (<script> tag)
+└── Need server-side collab?  → @witqq/spreadsheet-server
+
+Need plugins?
+├── Formulas (SUM, IF, etc.)        → @witqq/spreadsheet-plugins → FormulaPlugin
+├── Conditional formatting          → @witqq/spreadsheet-plugins → ConditionalFormattingPlugin
+├── Excel import/export             → @witqq/spreadsheet-plugins → ExcelPlugin
+├── Real-time collaboration (OT)    → @witqq/spreadsheet-plugins → CollaborationPlugin
+├── Right-click context menu        → @witqq/spreadsheet-plugins → createContextMenuPlugin
+└── Progressive loading (100K+ rows)→ @witqq/spreadsheet-plugins → ProgressiveLoaderPlugin
+```
+
+All framework wrappers re-export core types (`ColumnDef`, `CellData`, `SpreadsheetTheme`, etc.) so you typically don't need to import from `@witqq/spreadsheet` directly. The wrapper packages list `@witqq/spreadsheet` as a regular dependency (installed automatically).
+
+## Core API Overview
+
+The core package (`@witqq/spreadsheet`) provides `SpreadsheetEngine` — the main class that manages the entire spreadsheet lifecycle. See [packages/core/README.md](packages/core/README.md) for the full 220-export API reference.
+
+Key areas:
+
+| Area | Key Exports | Description |
+|------|-------------|-------------|
+| Engine | `SpreadsheetEngine`, `SpreadsheetEngineConfig` | Main class: mount, destroy, data, plugins, events |
+| Columns | `ColumnDef`, `CellType`, `CellTypeRenderer` | Column definition, type system, custom renderers |
+| Data | `CellData`, `CellValue`, `CellAddress`, `CellStore` | Cell data model, addresses, storage |
+| Selection | `Selection`, `SelectionManager` | Current selection, multi-range, keyboard navigation |
+| Commands | `Command`, `CommandManager` | Undo/redo command pattern |
+| Events | `EventBus`, `CellChangeEvent`, `SelectionChangeEvent` | Event system for all state changes |
+| Rendering | `RenderLayer`, `CanvasManager`, `GridRenderer` | Canvas rendering pipeline, custom layers |
+| Theming | `SpreadsheetTheme`, `lightTheme`, `darkTheme` | Theme definitions, built-in themes |
+| Localization | `SpreadsheetLocale`, `enLocale`, `ruLocale`, `resolveLocale` | i18n, locale packs, partial overrides |
+| Editing | `CellEditor`, `CellEditorRegistry`, `InlineEditor` | Cell editing, custom editors, date pickers |
+| Layout | `LayoutEngine`, `ViewportManager` | Float64Array positions, virtualized scrolling |
+
+## Performance
 
 | Metric | Value |
 |--------|-------|
-| Init time (10K rows, 41 cols) | ~120ms |
-| Init time (100K rows) | ~350ms |
-| Scroll FPS | 60fps stable |
+| Initial render (10K rows, 41 columns) | ~120ms |
+| Initial render (100K rows) | ~350ms |
+| Scroll FPS | 60fps |
 | Widget bundle | <36KB gzip |
-| Core bundle | Zero external deps |
+| Core dependencies | 0 |
 | Memory (100K rows) | ~45MB |
 
-## 📦 Packages
-
-| Package | Description |
-|---------|-------------|
-| [`@witqq/spreadsheet`](https://www.npmjs.com/package/@witqq/spreadsheet) | Canvas engine (core) |
-| [`@witqq/spreadsheet-react`](https://www.npmjs.com/package/@witqq/spreadsheet-react) | React wrapper |
-| [`@witqq/spreadsheet-vue`](https://www.npmjs.com/package/@witqq/spreadsheet-vue) | Vue 3 wrapper |
-| [`@witqq/spreadsheet-angular`](https://www.npmjs.com/package/@witqq/spreadsheet-angular) | Angular wrapper |
-| [`@witqq/spreadsheet-widget`](https://www.npmjs.com/package/@witqq/spreadsheet-widget) | Embeddable IIFE/UMD bundle |
-| [`@witqq/spreadsheet-plugins`](https://www.npmjs.com/package/@witqq/spreadsheet-plugins) | Official plugins |
-
-## 📖 Documentation
-
-Full documentation with interactive demos at **[spreadsheet.witqq.dev](https://spreadsheet.witqq.dev/)**
-
-- [Getting Started](https://spreadsheet.witqq.dev/getting-started/) — Installation, quick start, configuration
-- [Guides](https://spreadsheet.witqq.dev/guides/features/) — Selection, sorting, filtering, frozen panes, and more
-- [Plugins](https://spreadsheet.witqq.dev/plugins/overview/) — Formulas, collaboration, Excel I/O
-- [API Reference](https://spreadsheet.witqq.dev/api/wit-engine/) — WitEngine, types, cell types
-- [Migration from Handsontable](https://spreadsheet.witqq.dev/guides/migration-from-handsontable/) — Side-by-side API mapping
-
-## 🌐 Localization
-
-Built-in English and Russian locale packs. Create custom locales for any language:
-
-```tsx
-import { WitTable } from '@witqq/spreadsheet-react';
-import { ruLocale } from '@witqq/spreadsheet';
-
-<WitTable columns={columns} data={data} locale={ruLocale} />
-```
-
-Custom partial locales are merged over English defaults:
-
-```ts
-import { resolveLocale } from '@witqq/spreadsheet';
-
-const myLocale = resolveLocale({
-  contextMenu: { cut: 'Cortar', copy: 'Copiar', paste: 'Pegar' },
-  formatLocale: 'es-ES',
-});
-```
-
-Locale covers: context menu labels, date picker, filter panel, accessibility announcements, aggregate labels, print notices, and number/date formatting.
-
-## 🔌 Custom Cell Editors
-
-Register custom overlay editors for specific column types via `CellEditorRegistry`:
-
-```ts
-import type { CellEditor } from '@witqq/spreadsheet';
-
-class ColorPickerEditor implements CellEditor {
-  readonly id = 'color-picker';
-  // ... implement open(), close(), setTheme(), setLocale(), destroy()
-}
-
-const engine = new SpreadsheetEngine({ columns, data });
-engine.registerCellEditor(new ColorPickerEditor(), 'color');
-```
-
-Built-in editors: `DatePickerEditor` (registered for `type: 'date'`), `DateTimeEditor` (registered for `type: 'datetime'` — calendar + hour/minute controls, commits ISO `YYYY-MM-DDTHH:mm`), `InlineEditor` (textarea fallback). The registry resolves editors by priority — higher priority wins when multiple editors match.
-
-## 🛠 Development
+## Development
 
 ```bash
 npm install          # Install dependencies
-npm run dev          # Start dev server (Docker, port 3150)
 npm run build        # Build all packages
 npm run test         # Unit tests (Vitest)
 npm run test:e2e     # E2E tests (Playwright)
-npm run typecheck    # TypeScript check
+npm run typecheck    # TypeScript strict mode
 npm run lint         # ESLint
+npm run dev          # Docker dev server on port 3150
 ```
 
-## 📄 License
+## License
 
-[BSL 1.1](LICENSE) — Free for non-commercial use. Commercial use requires a paid license. Converts to Apache 2.0 on 2030-03-01.
+[BSL 1.1](LICENSE) — Free for non-commercial use. Commercial use requires a paid license. Change Date: 2030-03-01 → Apache License 2.0.
 
-## 🤝 Contributing
+## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## 📬 Contact
+## Contact
 
 - Website: [spreadsheet.witqq.dev](https://spreadsheet.witqq.dev/)
 - Email: belyiwork@mail.ru

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -676,6 +676,7 @@ Defaults are applied inline using nullish coalescing (`??`) in the constructor a
 - **Stack**: Astro + Starlight
 - **Content**: `packages/site/src/content/docs/` (47 MDX files)
 - **API reference**: TypeDoc → `docs/api/` (auto-generated HTML)
+- **In-package docs**: Each `packages/*/README.md` contains comprehensive API reference for npm consumers
 
 ## Development
 

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -37,6 +37,7 @@ Pre-merge quality gates for @witqq/spreadsheet.
 - [ ] New public APIs have TSDoc comments
 - [ ] Complex algorithms have inline comments explaining "why"
 - [ ] Demo page updated if feature is user-visible
+- [ ] Package README.md updated if public API changed (each `packages/*/README.md`)
 
 ## Review Criteria
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,6 +1,6 @@
 # @witqq/spreadsheet-angular
 
-Angular wrapper for the witqq Canvas spreadsheet engine.
+> Angular wrapper for the witqq Canvas spreadsheet engine.
 
 ## Installation
 
@@ -8,49 +8,224 @@ Angular wrapper for the witqq Canvas spreadsheet engine.
 npm install @witqq/spreadsheet-angular @witqq/spreadsheet
 ```
 
-## Usage
+**Peer dependencies:** `@angular/core` and `@angular/common` version 17+.
+
+## Exports
+
+```ts
+import { SpreadsheetComponent, SpreadsheetEngine, lightTheme, darkTheme } from '@witqq/spreadsheet-angular';
+import type {
+  CellData,
+  CellValue,
+  CellStyle,
+  CellType,
+  ColumnDef,
+  Selection,
+  SpreadsheetEvents,
+  SpreadsheetPlugin,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet-angular';
+```
+
+---
+
+## Quick Start
+
+`SpreadsheetComponent` is a standalone component with selector `witqq-spreadsheet`:
 
 ```typescript
-import { WitTableComponent } from '@witqq/spreadsheet-angular';
+import { Component } from '@angular/core';
+import { SpreadsheetComponent } from '@witqq/spreadsheet-angular';
+import type { ColumnDef } from '@witqq/spreadsheet-angular';
+import type { CellChangeEvent } from '@witqq/spreadsheet';
 
 @Component({
+  selector: 'app-root',
   standalone: true,
-  imports: [WitTableComponent],
+  imports: [SpreadsheetComponent],
   template: `
-    <witqq spreadsheet
+    <witqq-spreadsheet
       [columns]="columns"
-      [rows]="rows"
-      [height]="400"
+      [data]="data"
+      [editable]="true"
       (cellChange)="onCellChange($event)"
     />
   `,
 })
-export class MyComponent {
+export class AppComponent {
   columns: ColumnDef[] = [
-    { key: 'name', title: 'Name', width: 150 },
-    { key: 'value', title: 'Value', width: 100 },
+    { key: 'name', header: 'Name', width: 150 },
+    { key: 'age', header: 'Age', width: 80, type: 'number' },
+    { key: 'email', header: 'Email', width: 200 },
   ];
-  rows = [
-    { name: 'Item 1', value: 100 },
-    { name: 'Item 2', value: 200 },
+
+  data = [
+    { name: 'Alice', age: 30, email: 'alice@example.com' },
+    { name: 'Bob', age: 25, email: 'bob@example.com' },
   ];
+
+  onCellChange(event: CellChangeEvent) {
+    console.log('Changed:', event);
+  }
 }
 ```
 
+---
+
 ## Inputs
 
-| Input | Type | Description |
-|-------|------|-------------|
-| `columns` | `ColumnDef[]` | Column definitions |
-| `rows` | `TRow[]` | Data rows |
-| `height` | `number` | Container height in pixels |
-| `theme` | `WitTheme` | Theme configuration |
-| `options` | `WitEngineOptions` | Engine options |
+All inputs map to `SpreadsheetEngineConfig` fields:
 
-## Documentation
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `columns` | `ColumnDef[]` | Yes | — | Column definitions |
+| `data` | `Record<string, unknown>[]` | No | — | Row data array |
+| `rowCount` | `number` | No | `data.length` | Total row count |
+| `theme` | `SpreadsheetTheme` | No | `lightTheme` | Visual theme |
+| `frozenRows` | `number` | No | — | Rows frozen at top |
+| `frozenColumns` | `number` | No | — | Columns frozen at left |
+| `editable` | `boolean` | No | `false` | Enable inline cell editing |
+| `sortable` | `boolean` | No | `false` | Enable column header click-to-sort |
+| `showGridLines` | `boolean` | No | `true` | Show grid lines between cells |
+| `showRowNumbers` | `boolean` | No | `true` | Show row number column |
+| `rowHeight` | `number` | No | — | Default row height (pixels) |
+| `headerHeight` | `number` | No | — | Header row height (pixels) |
+| `width` | `number \| string` | No | — | Container width |
+| `height` | `number \| string` | No | — | Container height |
 
-Full documentation: https://spreadsheet.witqq.dev/frameworks/angular
+### Input reactivity (ngOnChanges)
+
+| Input | Reactive | Behavior |
+|-------|----------|----------|
+| `theme` | Yes | Calls `engine.setTheme()` on change (skips first change) |
+| `data` | Yes | Clears cell store, bulk-loads new data, updates row count, re-renders (skips first change) |
+| Other inputs | No | Read once at `ngOnInit` |
+
+---
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `cellChange` | `EventEmitter<CellChangeEvent>` | Cell value changes |
+| `selectionChange` | `EventEmitter<SelectionChangeEvent>` | Selection changes |
+| `sortChange` | `EventEmitter<SortChangeEvent>` | Sort state changes |
+| `filterChange` | `EventEmitter<FilterChangeEvent>` | Filter state changes |
+| `scroll` | `EventEmitter<ScrollEvent>` | Viewport scrolls |
+| `ready` | `EventEmitter<void>` | Engine initialization completes |
+
+> **Note:** Event payload types (`CellChangeEvent`, `SelectionChangeEvent`, `SortChangeEvent`, `FilterChangeEvent`, `ScrollEvent`) are not re-exported from this package. Import them from `@witqq/spreadsheet`.
+
+```html
+<witqq-spreadsheet
+  [columns]="columns"
+  [data]="data"
+  (cellChange)="onCellChange($event)"
+  (selectionChange)="onSelectionChange($event)"
+  (ready)="onReady()"
+/>
+```
+
+---
+
+## Public Methods (ViewChild API)
+
+Access the component instance via `@ViewChild` for imperative operations:
+
+```typescript
+import { Component, ViewChild } from '@angular/core';
+import { SpreadsheetComponent } from '@witqq/spreadsheet-angular';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [SpreadsheetComponent],
+  template: `
+    <witqq-spreadsheet #spreadsheet [columns]="columns" [data]="data" />
+    <button (click)="handleExport()">Export</button>
+  `,
+})
+export class AppComponent {
+  @ViewChild('spreadsheet') spreadsheet!: SpreadsheetComponent;
+
+  handleExport() {
+    const engine = this.spreadsheet.getInstance();
+    // use engine API directly
+  }
+}
+```
+
+### Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `getInstance` | `(): SpreadsheetEngine` | Get the underlying engine instance |
+| `focus` | `(): void` | Focus the container element |
+| `getSelection` | `(): Selection` | Get current selection state |
+| `selectCell` | `(row: number, col: number): void` | Select a cell |
+| `getCell` | `(row: number, col: number): CellData \| undefined` | Get cell data at position |
+| `setCell` | `(row: number, col: number, value: CellValue): void` | Set cell value at position |
+| `undo` | `(): void` | Undo the last command |
+| `redo` | `(): void` | Redo the last undone command |
+| `scrollTo` | `(x: number, y: number): void` | Scroll to position |
+| `requestRender` | `(): void` | Force a re-render |
+| `installPlugin` | `(plugin: SpreadsheetPlugin): void` | Install a plugin |
+| `removePlugin` | `(name: string): void` | Remove a plugin by name |
+| `print` | `(): void` | Trigger print dialog |
+
+`getInstance` and `getSelection` throw `Error('Spreadsheet not initialized')` if called before `ngOnInit`. Other methods silently no-op.
+
+---
+
+## Theme Switching
+
+The `theme` input is reactive via `ngOnChanges`:
+
+```typescript
+import { lightTheme, darkTheme } from '@witqq/spreadsheet-angular';
+import type { SpreadsheetTheme } from '@witqq/spreadsheet-angular';
+
+@Component({
+  template: `
+    <button (click)="toggleTheme()">Toggle Theme</button>
+    <witqq-spreadsheet [columns]="columns" [data]="data" [theme]="currentTheme" />
+  `,
+})
+export class AppComponent {
+  currentTheme: SpreadsheetTheme = lightTheme;
+
+  toggleTheme() {
+    this.currentTheme = this.currentTheme === lightTheme ? darkTheme : lightTheme;
+  }
+}
+```
+
+---
+
+## Re-exported Values and Types
+
+**Values:** `SpreadsheetEngine`, `lightTheme`, `darkTheme` — re-exported from `@witqq/spreadsheet`.
+
+**Data types:** `CellData`, `CellValue`, `CellStyle`, `CellType`, `ColumnDef`, `Selection`
+
+**System types:** `SpreadsheetEvents`, `SpreadsheetPlugin`, `SpreadsheetTheme`
+
+---
+
+## Component Lifecycle
+
+1. **`ngOnInit`:** Engine created with input values, mounted to template container `<div>`. EventBus handlers wired to `EventEmitter` outputs.
+2. **`ngOnChanges` (`data`):** Cell store cleared, new data bulk-loaded, row count updated, re-render triggered (skips first change).
+3. **`ngOnChanges` (`theme`):** `engine.setTheme()` called if theme reference changed (skips first change).
+4. **`ngOnDestroy`:** All EventBus handlers unsubscribed. Engine destroyed.
+
+---
 
 ## License
 
-BSL 1.1 — see [LICENSE](./LICENSE)
+Licensed under the [Business Source License 1.1](https://github.com/witqq/spreadsheet/blob/master/LICENSE).
+
+**Free** for non-commercial use (personal, educational, academic, non-commercial open source).
+**Commercial use** requires a paid license — see [spreadsheet.witqq.dev/pricing](https://spreadsheet.witqq.dev/pricing).
+
+Change Date: 2030-03-01 → Apache License 2.0.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,16 +11,20 @@
 npm install @witqq/spreadsheet
 ```
 
+No peer dependencies required. The core package is framework-agnostic with zero external dependencies.
+
+For framework wrappers see: `@witqq/spreadsheet-react`, `@witqq/spreadsheet-vue`, `@witqq/spreadsheet-angular`.
+
 ## Quick Start
 
 ```typescript
-import { WitEngine } from '@witqq/spreadsheet';
+import { SpreadsheetEngine } from '@witqq/spreadsheet';
 import type { ColumnDef } from '@witqq/spreadsheet';
 
 const columns: ColumnDef[] = [
-  { key: 'name', header: 'Name', width: 150 },
-  { key: 'age', header: 'Age', width: 80, type: 'number' },
-  { key: 'email', header: 'Email', width: 200 },
+  { key: 'name', title: 'Name', width: 150 },
+  { key: 'age', title: 'Age', width: 80, type: 'number' },
+  { key: 'email', title: 'Email', width: 200 },
 ];
 
 const data = [
@@ -28,57 +32,2829 @@ const data = [
   { name: 'Bob', age: 25, email: 'bob@example.com' },
 ];
 
-const engine = new WitEngine({
-  container: document.getElementById('grid')!,
-  columns,
-  data,
+const engine = new SpreadsheetEngine({ columns, data });
+engine.mount(document.getElementById('grid')!);
+
+// Listen to events
+engine.on('cellChange', (event) => {
+  console.log(`Cell (${event.row}, ${event.col}) changed to ${event.value}`);
+});
+
+// Clean up
+engine.destroy();
+```
+
+---
+
+## SpreadsheetEngine
+
+Main entry point. Create an instance with configuration, mount to a DOM container, interact via the public API, and destroy when done.
+
+### Constructor
+
+```typescript
+new SpreadsheetEngine(config: SpreadsheetEngineConfig)
+```
+
+### SpreadsheetEngineConfig
+
+```typescript
+interface SpreadsheetEngineConfig {
+  columns: ColumnDef[];                          // Column definitions (required)
+  data?: Record<string, unknown>[];              // Initial row data keyed by column key
+  rowCount?: number;                             // Total rows (default: data.length or 0)
+  width?: number | string;                       // Container width (pixels or CSS string)
+  height?: number | string;                      // Container height (pixels or CSS string)
+  editable?: boolean;                            // Enable inline cell editing (default: false)
+  sortable?: boolean;                            // Enable header click-to-sort (default: false)
+  frozenRows?: number;                           // Rows frozen at top
+  frozenColumns?: number;                        // Columns frozen at left
+  rowHeight?: number;                            // Default row height in pixels
+  headerHeight?: number;                         // Header row height in pixels
+  showGridLines?: boolean;                       // Show grid lines (default: true)
+  showRowNumbers?: boolean;                      // Show row number column (default: true)
+  theme?: SpreadsheetTheme;                      // Visual theme (default: lightTheme)
+  autoRowHeight?: boolean | AutoRowSizeConfig;   // Auto row height from content (default: false)
+  stretchColumns?: 'all' | 'last';              // Stretch columns to fill width
+  locale?: SpreadsheetLocale;                    // Locale for UI strings (default: English)
+}
+```
+
+### Lifecycle
+
+```typescript
+engine.mount(container: HTMLElement): void    // Mount to DOM, initialize subsystems, render
+engine.destroy(): void                        // Unmount, clean up all resources
+engine.resize(): void                         // Force layout recalculation (auto via ResizeObserver)
+engine.render(): void                         // Full re-render (sync fallback if no scheduler)
+engine.requestRender(): void                  // Schedule re-render via animation frame (no-op without scheduler)
+```
+
+### Data API
+
+```typescript
+engine.getCell(row: number, col: number): CellData | undefined
+engine.setCell(row: number, col: number, value: CellValue): void
+engine.getCellStore(): CellStore
+engine.getRowStore(): RowStore
+engine.setRowHeight(row: number, height: number): void
+engine.setAutoRowHeights(updates: Map<number, number>): void  // Batch-set auto heights with scroll compensation
+engine.setRowCount(count: number): void       // Update row count across all subsystems
+engine.getRowCount(): number                  // Get total physical row count
+```
+
+All row/col indices in the engine API are **logical** (visible) indices. The engine translates to physical indices via DataView internally.
+
+### Selection API
+
+```typescript
+engine.getSelection(): Selection
+engine.selectCell(row: number, col: number): void
+engine.getSelectionManager(): SelectionManager
+engine.getKeyboardNavigator(): KeyboardNavigator | null
+```
+
+### Event API
+
+```typescript
+engine.on<K extends keyof SpreadsheetEvents>(event: K, handler: SpreadsheetEvents[K]): void
+engine.off<K extends keyof SpreadsheetEvents>(event: K, handler: SpreadsheetEvents[K]): void
+engine.getEventBus(): EventBus
+```
+
+### Scroll API
+
+```typescript
+engine.scrollTo(x: number, y: number): void
+engine.getVisibleRange(): CellRange           // Currently visible cell range
+engine.getScrollManager(): ScrollManager | null
+```
+
+### Sort API
+
+```typescript
+engine.sortBy(columns: SortColumn[]): void    // Sort programmatically
+engine.clearSort(): void                      // Remove all sorting
+engine.getSortColumns(): readonly SortColumn[]
+engine.getSortEngine(): SortEngine
+```
+
+### Filter API
+
+```typescript
+engine.setColumnFilter(col: number, conditions: FilterCondition[]): void
+engine.removeColumnFilter(col: number): void
+engine.clearFilters(): void
+engine.getFilteredRowCount(): number
+engine.getFilterEngine(): FilterEngine
+engine.openFilterPanel(col: number): void
+engine.closeFilterPanel(): void
+engine.isFilterPanelOpen: boolean             // Getter property
+```
+
+### Merge API
+
+```typescript
+engine.mergeCells(region: MergedRegion, value?: CellValue): boolean
+engine.unmergeCells(startRow: number, startCol: number): boolean
+engine.getMergedRegion(row: number, col: number): MergedRegion | null
+engine.getMergeManager(): MergeManager
+```
+
+### Row Group API
+
+```typescript
+engine.setRowGroups(groups: RowGroupDef[]): void
+engine.toggleRowGroup(logicalRow: number): void
+engine.expandAllGroups(): void
+engine.collapseAllGroups(): void
+engine.clearRowGroups(): void
+engine.setGroupAggregates(aggregates: ColumnAggregate[]): void
+engine.getRowGroupManager(): RowGroupManager
+```
+
+### Validation API
+
+```typescript
+engine.setColumnValidation(col: number, rules: SpreadsheetValidationRule[]): void
+engine.setCellValidation(row: number, col: number, rules: SpreadsheetValidationRule[]): void
+engine.removeColumnValidation(col: number): void
+engine.removeCellValidation(row: number, col: number): void
+engine.getValidationEngine(): ValidationEngine
+```
+
+### Change Tracking API
+
+```typescript
+engine.setCellStatus(row: number, col: number, status: 'changed' | 'error' | 'saving' | 'saved', errorMessage?: string): void
+engine.getCellStatus(row: number, col: number): CellMetadata['status'] | undefined
+engine.getChangedCells(): Array<{ row: number; col: number }>
+engine.clearChanges(): void
+engine.getChangeTracker(): ChangeTracker
+```
+
+### Theme API
+
+```typescript
+engine.getTheme(): SpreadsheetTheme
+engine.setTheme(theme: SpreadsheetTheme): void      // Switch theme at runtime
+engine.getLocale(): ResolvedLocale
+engine.setLocale(locale: SpreadsheetLocale): void    // Switch locale at runtime
+```
+
+### Plugin API
+
+```typescript
+engine.installPlugin(plugin: SpreadsheetPlugin): void
+engine.removePlugin(name: string): void
+engine.getPlugin(name: string): SpreadsheetPlugin | undefined
+engine.getPluginNames(): string[]
+```
+
+### Editor API
+
+```typescript
+engine.getCellEditorRegistry(): CellEditorRegistry
+engine.registerCellEditor(editor: CellEditor, type: string, priority?: number): void
+engine.getInlineEditor(): InlineEditor | null
+```
+
+### Render Layer API
+
+```typescript
+engine.addRenderLayer(layer: RenderLayer): void
+engine.insertRenderLayerBefore(layer: RenderLayer, beforeLayer: RenderLayer): void
+engine.getRenderLayer<T extends RenderLayer>(layerClass: new (...args: unknown[]) => T): T | undefined
+engine.removeRenderLayer(layer: RenderLayer): void
+```
+
+### Other Accessors
+
+```typescript
+engine.getConfig(): SpreadsheetEngineConfig
+engine.getCanvasElement(): HTMLCanvasElement | null
+engine.getLayoutEngine(): LayoutEngine | null
+engine.getViewportManager(): ViewportManager | null
+engine.getDirtyTracker(): DirtyTracker | null
+engine.getDataView(): DataView
+engine.getCommandManager(): CommandManager
+engine.getClipboardManager(): ClipboardManager | null
+engine.getContextMenuManager(): ContextMenuManager | null
+engine.getCellTypeRegistry(): CellTypeRegistry
+engine.getAutoRowSizeManager(): AutoRowSizeManager | null
+engine.print(): void
+```
+
+---
+
+## Data Model
+
+### CellStore
+
+Sparse cell storage using Map with `"row:col"` string keys. Only stores non-empty cells. O(1) get/set/delete.
+
+```typescript
+import { CellStore } from '@witqq/spreadsheet';
+
+const store = new CellStore();
+
+store.set(0, 0, { value: 'Hello' });
+store.setValue(0, 1, 42);
+store.get(0, 0);                               // { value: 'Hello' }
+store.has(0, 0);                                // true
+store.delete(0, 0);                             // true
+store.clear();
+
+// Metadata
+store.setMetadata(0, 0, { status: 'changed' });
+store.clearMetadata(0, 0);
+
+// Bulk loading
+store.bulkLoad(rows, columnKeys);               // Load from array of row objects
+store.bulkLoadChunk(startRow, rows, columnKeys); // Load chunk at offset
+store.bulkGenerate(startRow, count, columnKeys, generateRow); // Generate rows in-place
+
+// Iteration
+store.iterateRange(range);                      // Yields { row, col, data } in range
+store.entries();                                // Yields all { row, col, data }
+
+// Properties
+store.size;                                     // Number of stored cells
+store.version;                                  // Increments on each mutation
+```
+
+### RowStore
+
+Row metadata storage: height overrides and hidden rows. Rows without overrides use the default height from theme.
+
+Height overrides are separated into **manual** (user drag-resized) and **auto** (computed by measurement). Manual overrides always take priority.
+
+```typescript
+import { RowStore } from '@witqq/spreadsheet';
+
+const rowStore = new RowStore();
+
+rowStore.getHeight(row, defaultHeight);         // Resolve: hidden→manual→auto→default
+rowStore.setHeight(row, height);                // Set manual height override
+rowStore.setAutoHeight(row, height);            // Set auto-measured height
+rowStore.setAutoHeightsBatch(updates, default); // Batch set auto heights, returns changed Set
+rowStore.clearHeight(row);                      // Clear manual override
+rowStore.clearAutoHeight(row);                  // Clear auto override
+rowStore.clearAllAutoHeights();                 // Clear all auto overrides
+rowStore.isManual(row);                         // Has manual override?
+rowStore.isAuto(row);                           // Has auto override?
+
+// Row visibility
+rowStore.isHidden(row);
+rowStore.hide(row);
+rowStore.show(row);
+rowStore.visibleRowsInRange(startRow, endRow);  // Iterator of visible row indices
+
+// Bookkeeping
+rowStore.shiftRowsUp(deletedRow);               // Shift metadata after row deletion
+rowStore.clear();
+
+// Properties
+rowStore.version;
+rowStore.overrideCount;
+rowStore.manualOverrideCount;
+rowStore.autoOverrideCount;
+rowStore.hiddenCount;
+```
+
+### ColStore
+
+Column definitions store with hidden column tracking.
+
+```typescript
+import { ColStore } from '@witqq/spreadsheet';
+
+const colStore = new ColStore(columns);
+
+colStore.getColumn(index): ColumnDef | undefined
+colStore.getColumns(): ReadonlyArray<ColumnDef>
+colStore.setColumns(columns: ColumnDef[]): void
+colStore.findByKey(key: string): number         // Column index by key, -1 if not found
+
+// Visibility
+colStore.isHidden(index): boolean
+colStore.hide(index): void
+colStore.show(index): void
+colStore.visibleColumns();                      // Iterator of { index, column }
+colStore.visibleColumnsInRange(start, end);     // Iterator of visible column indices
+colStore.clear();                               // Reset to empty
+
+// Properties
+colStore.columnCount;
+colStore.visibleColumnCount;
+colStore.hiddenCount;
+colStore.version;
+```
+
+### StylePool
+
+Flyweight pool that deduplicates CellStyle objects by content. Returns a ref string for each interned style. Multiple identical styles share the same ref.
+
+```typescript
+import { StylePool } from '@witqq/spreadsheet';
+
+const pool = new StylePool();
+
+const ref = pool.intern({ bgColor: '#ff0', fontWeight: 'bold' });
+const style = pool.resolve(ref);               // { bgColor: '#ff0', fontWeight: 'bold' }
+pool.has(ref);                                  // true
+pool.size;                                      // 1
+pool.clear();
+```
+
+### DataView
+
+Logical↔physical row index mapping layer. Sits between CellStore (physical rows) and the engine (logical rows). When no sort/filter is active, operates as a zero-overhead passthrough.
+
+```typescript
+import { DataView } from '@witqq/spreadsheet';
+import type { DataViewConfig } from '@witqq/spreadsheet';
+
+const config: DataViewConfig = { totalRowCount: 1000 };
+const view = new DataView(config);
+
+view.getPhysicalRow(logicalRow);               // Logical → physical row index
+view.getLogicalRow(physicalRow);               // Physical → logical (undefined if hidden)
+view.visibleRowCount;                          // Rows after filtering
+view.totalRowCount;                            // All physical rows
+view.isPassthrough();                          // true when no sort/filter active
+
+view.recompute(physicalIndices);               // Apply sorted/filtered mapping
+view.reset();                                  // Reset to identity mapping
+view.setTotalRowCount(count);                  // Update total (e.g. row insert)
+```
+
+---
+
+## Types
+
+### Cell Types
+
+```typescript
+type CellValue = string | number | boolean | Date | null;
+
+interface CellData {
+  readonly value: CellValue;
+  readonly displayValue?: string;               // Overrides default rendering
+  readonly formula?: string;                    // Formula expression (e.g. "=SUM(A1:A10)")
+  readonly style?: CellStyleRef;                // Reference to shared style in StylePool
+  readonly type?: CellType;                     // Cell type for rendering/editing
+  readonly metadata?: CellMetadata;             // Status, errors, links, comments
+}
+
+interface CellMetadata {
+  readonly status?: 'changed' | 'error' | 'saving' | 'saved';
+  readonly errorMessage?: string;               // Tooltip on hover
+  readonly link?: { url: string; label?: string };
+  readonly comment?: string;                    // Tooltip on hover
+}
+
+type CellType =
+  | 'string' | 'number' | 'boolean' | 'date' | 'datetime'
+  | 'select' | 'dynamicSelect' | 'formula' | 'link'
+  | 'image' | 'progressBar' | 'rating' | 'badge' | 'custom';
+```
+
+### Style Types
+
+```typescript
+interface CellStyleRef {
+  readonly ref: string;                         // Unique hash key from StylePool.intern()
+  readonly style: CellStyle;                    // The resolved style object
+}
+```
+
+```typescript
+interface CellStyle {
+  readonly bgColor?: string;                    // CSS color
+  readonly textColor?: string;                  // CSS color
+  readonly fontFamily?: string;
+  readonly fontSize?: number;                   // Pixels
+  readonly fontWeight?: 'normal' | 'bold';
+  readonly fontStyle?: 'normal' | 'italic';
+  readonly textAlign?: 'left' | 'center' | 'right';
+  readonly verticalAlign?: 'top' | 'middle' | 'bottom';
+  readonly borderTop?: BorderStyle;
+  readonly borderRight?: BorderStyle;
+  readonly borderBottom?: BorderStyle;
+  readonly borderLeft?: BorderStyle;
+  readonly numberFormat?: string;               // e.g. "#,##0.00"
+  readonly textWrap?: boolean;                  // Note: use ColumnDef.wrapText instead for rendering
+  readonly indent?: number;
+}
+
+interface BorderStyle {
+  readonly width: number;
+  readonly color: string;
+  readonly style: 'solid' | 'dashed' | 'dotted';
+}
+```
+
+**Important:** `CellStyle.textWrap` is defined in the interface but the renderer reads `ColumnDef.wrapText` instead. Use `ColumnDef.wrapText: true` to enable text wrapping.
+
+### Geometry Types
+
+```typescript
+interface CellAddress {
+  readonly row: number;
+  readonly col: number;
+}
+
+interface CellRange {
+  readonly startRow: number;
+  readonly startCol: number;
+  readonly endRow: number;
+  readonly endCol: number;
+}
+
+interface CellRect {
+  readonly x: number;                           // Pixel position on canvas
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+```
+
+### Column Definition
+
+```typescript
+interface ColumnDef {
+  readonly key: string;                         // Unique ID for data binding
+  readonly title: string;                       // Header display text
+  readonly width: number;                       // Width in pixels
+  readonly minWidth?: number;                   // Min width for resize
+  readonly maxWidth?: number;                   // Max width for resize
+  readonly type?: CellType;                     // Cell type (rendering/editing)
+  readonly frozen?: boolean;                    // Pin to frozen pane
+  readonly sortable?: boolean;                  // Enable header sort
+  readonly filterable?: boolean;                // Enable column filter
+  readonly editable?: boolean;                  // Allow inline editing
+  readonly resizable?: boolean;                 // Allow drag-to-resize
+  readonly hidden?: boolean;                    // Hide from display
+  readonly wrapText?: boolean;                  // Enable text wrapping
+  readonly validation?: SpreadsheetValidationRule[];  // Validation rules
+}
+```
+
+### Selection Types
+
+```typescript
+type SelectionType = 'cell' | 'range' | 'row' | 'column' | 'all';
+
+interface Selection {
+  readonly type: SelectionType;
+  readonly ranges: readonly CellRange[];
+  readonly activeCell: CellAddress;
+  readonly anchorCell: CellAddress;
+}
+```
+
+### Merge Types
+
+```typescript
+interface MergedRegion {
+  readonly startRow: number;
+  readonly startCol: number;
+  readonly endRow: number;                      // Inclusive
+  readonly endCol: number;                      // Inclusive
+}
+```
+
+### Validation Types
+
+```typescript
+interface ValidationRule {
+  readonly type: string;
+  readonly message?: string;
+  readonly severity?: 'error' | 'warning' | 'info';
+}
+
+interface ValidationResult {
+  readonly valid: boolean;
+  readonly message?: string;
+  readonly severity?: 'error' | 'warning' | 'info';
+}
+```
+
+### Conditional Format Types
+
+```typescript
+type ComparisonOperator =
+  | 'greaterThan' | 'lessThan' | 'greaterThanOrEqual' | 'lessThanOrEqual'
+  | 'equal' | 'notEqual' | 'between' | 'notBetween';
+
+interface ValueCondition {
+  readonly type: 'value';
+  readonly operator: ComparisonOperator;
+  readonly value: number;
+  readonly value2?: number;                     // For between/notBetween
+}
+
+interface GradientScaleCondition {
+  readonly type: 'gradientScale';
+  readonly stops: readonly GradientStop[];
+}
+
+interface GradientStop {
+  readonly value: number;
+  readonly color: string;
+}
+
+interface DataBarCondition {
+  readonly type: 'dataBar';
+  readonly minValue?: number;
+  readonly maxValue?: number;
+  readonly color: string;
+  readonly showValue?: boolean;
+}
+
+interface IconSetCondition {
+  readonly type: 'iconSet';
+  readonly iconSet: IconSetName;
+  readonly thresholds: readonly IconSetThreshold[];
+  readonly showValue?: boolean;
+}
+
+type IconSetName = 'arrows' | 'circles' | 'flags' | 'stars';
+
+interface IconSetThreshold {
+  readonly value: number;
+  readonly icon: string;
+}
+
+type ConditionalFormatCondition =
+  | ValueCondition | GradientScaleCondition | DataBarCondition | IconSetCondition;
+
+interface ConditionalFormatRule {
+  readonly id: string;
+  readonly priority: number;
+  readonly range: CellRange;
+  readonly condition: ConditionalFormatCondition;
+  readonly style?: Partial<CellStyle>;
+  readonly stopIfTrue?: boolean;
+}
+```
+
+### Change Tracking Types
+
+```typescript
+interface CellChange {
+  readonly row: number;
+  readonly col: number;
+  readonly oldValue: CellValue;
+  readonly newValue: CellValue;
+  readonly timestamp: number;
+  readonly userId?: string;
+  readonly source: string;
+}
+```
+
+---
+
+## Cell Type Registry
+
+Maps `CellType` identifiers to render and format functions. Built-in types: `string`, `number`, `boolean`, `date`.
+
+```typescript
+import { CellTypeRegistry } from '@witqq/spreadsheet';
+import type { CellTypeRenderer, CellAlignment } from '@witqq/spreadsheet';
+
+interface CellTypeRenderer {
+  format(value: CellValue): string;            // Format value for text display
+  align: CellAlignment;                        // 'left' | 'center' | 'right'
+  render?: (                                   // Optional custom canvas rendering
+    ctx: CanvasRenderingContext2D,
+    value: CellValue,
+    x: number, y: number,
+    width: number, height: number,
+    theme: SpreadsheetTheme,
+  ) => void;
+  measureHeight?: (                            // Optional height for auto row sizing
+    ctx: CanvasRenderingContext2D,
+    value: CellValue,
+    width: number,
+    theme: SpreadsheetTheme,
+  ) => number;
+}
+```
+
+### Usage
+
+```typescript
+// Register a custom cell type renderer
+engine.getCellTypeRegistry().register('rating', {
+  format: (value) => '★'.repeat(Number(value) || 0),
+  align: 'center',
+  render: (ctx, value, x, y, w, h, theme) => {
+    const stars = Number(value) || 0;
+    ctx.fillStyle = theme.colors.cellText;
+    ctx.fillText('★'.repeat(stars), x + 4, y + h / 2);
+  },
+});
+
+// Access built-in renderer
+const numRenderer = engine.getCellTypeRegistry().get('number');
+numRenderer.format(1234.5);                    // "1,234.5"
+
+// Set format locale (affects number and date formatting)
+engine.getCellTypeRegistry().setFormatLocale('de-DE');
+engine.getCellTypeRegistry().getFormatLocale();  // 'de-DE'
+
+// Detect type from value
+engine.getCellTypeRegistry().detectType(42);   // 'number'
+engine.getCellTypeRegistry().detectType(true); // 'boolean'
+```
+
+---
+
+## Editing
+
+### InlineEditor
+
+Built-in textarea-based editor. Opens on double-click, F2, or type-to-edit. Commits on Enter, cancels on Escape, navigates on Tab.
+
+```typescript
+import { InlineEditor } from '@witqq/spreadsheet';
+import type { InlineEditorConfig, EditorCloseReason } from '@witqq/spreadsheet';
+
+interface InlineEditorConfig {
+  container: HTMLElement;                       // Parent container for textarea positioning
+  scrollContainer: HTMLElement;                 // Scroll container for scroll events
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  cellStore: CellStore;
+  dataView: DataView;
+  theme: SpreadsheetTheme;
+  onCommit: (row: number, col: number, oldValue: CellValue, newValue: CellValue) => void;
+  onClose: (reason: EditorCloseReason) => void;
+  frozenRows?: number;
+  frozenColumns?: number;
+}
+
+type EditorCloseReason =
+  | 'enter'           // Enter key — commits, moves down
+  | 'shift-enter'     // Shift+Enter — commits, moves up
+  | 'tab'             // Tab — commits, moves right
+  | 'shift-tab'       // Shift+Tab — commits, moves left
+  | 'escape'          // Escape — cancels, no commit
+  | 'blur'            // Click outside — commits
+  | 'scroll'          // Grid scroll — commits
+  | 'programmatic';   // Closed by code
+
+// InlineEditor is managed by SpreadsheetEngine internally.
+// Access via:
+const editor = engine.getInlineEditor();
+editor?.isEditing;                             // Whether editor is open
+editor?.editingRow;                            // Current row (-1 if not editing)
+editor?.editingCol;                            // Current column (-1 if not editing)
+```
+
+### CellEditor Interface
+
+Generic interface for overlay cell editors (calendars, dropdowns, color pickers). The engine delegates lifecycle management via this interface.
+
+```typescript
+import type {
+  CellEditor,
+  CellEditorContext,
+  CellEditorCommit,
+  CellEditorClose,
+  CellEditorMatcher,
+  CellEditorRegistration,
+} from '@witqq/spreadsheet';
+
+interface CellEditor {
+  readonly id: string;                         // Unique editor type ID
+  readonly isOpen: boolean;
+  readonly editingRow: number;
+  readonly editingCol: number;
+
+  open(context: CellEditorContext, commitFn: CellEditorCommit, closeFn: CellEditorClose): void;
+  close(reason: EditorCloseReason): void;
+  setTheme(theme: SpreadsheetTheme): void;
+  setLocale(locale: ResolvedLocale): void;
+  destroy(): void;
+}
+
+interface CellEditorContext {
+  row: number;
+  col: number;
+  value: CellValue;
+  column: ColumnDef;
+  container: HTMLElement;
+  scrollContainer: HTMLElement;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  cellStore: CellStore;
+  dataView: DataView;
+  theme: SpreadsheetTheme;
+  locale: ResolvedLocale;
+  mergeManager: MergeManager | null;
+  frozenRows: number;
+  frozenColumns: number;
+}
+
+type CellEditorCommit = (row: number, col: number, oldValue: CellValue, newValue: CellValue) => void;
+type CellEditorClose = (reason: EditorCloseReason) => void;
+type CellEditorMatcher = (column: ColumnDef, value: CellValue) => boolean;
+
+interface CellEditorRegistration {
+  editor: CellEditor;
+  matcher: CellEditorMatcher;
+  priority: number;                            // Higher wins when multiple match
+}
+```
+
+### CellEditorRegistry
+
+Maps column types / predicates to CellEditor instances. The engine queries the registry to find the best editor. InlineEditor (textarea) is the fallback when no registered editor matches.
+
+```typescript
+import { CellEditorRegistry } from '@witqq/spreadsheet';
+
+const registry = engine.getCellEditorRegistry();
+
+// Register by predicate
+registry.register(myEditor, (column, value) => column.type === 'color', 10);
+
+// Register by column type string
+registry.registerForType(myDateEditor, 'date', 0);
+
+// Resolve best editor for a cell
+const editor = registry.resolve(column, value); // CellEditor | null
+
+// Get all registered editors
+registry.getAll();                             // CellEditor[] (deduplicated)
+
+// Propagate theme/locale to all registered editors
+registry.setTheme(theme);
+registry.setLocale(locale);
+
+// Cleanup
+registry.destroy();                            // Destroy all editors and clear
+```
+
+### Built-in Editors
+
+**DatePickerEditor** — Calendar overlay for `type: 'date'` columns. Auto-registered during mount.
+
+```typescript
+import { DatePickerEditor } from '@witqq/spreadsheet';
+// Auto-registered for column type 'date' at priority 0
+```
+
+**DateTimeEditor** — Date+time picker for `type: 'datetime'` columns. Auto-registered during mount.
+
+```typescript
+import { DateTimeEditor } from '@witqq/spreadsheet';
+// Auto-registered for column type 'datetime' at priority 0
+```
+
+**DatePickerOverlay** — Low-level calendar DOM widget used by DatePickerEditor.
+
+```typescript
+import { DatePickerOverlay } from '@witqq/spreadsheet';
+import type { DatePickerConfig } from '@witqq/spreadsheet';
+
+interface DatePickerConfig {
+  container: HTMLElement;
+  scrollContainer: HTMLElement;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  theme: SpreadsheetTheme;
+  onCommit: (row: number, col: number, oldValue: CellValue, newValue: CellValue) => void;
+  onClose: (reason: EditorCloseReason) => void;
+  frozenRows?: number;
+  frozenColumns?: number;
+}
+```
+
+### Registering a Custom Editor
+
+```typescript
+import type { CellEditor, CellEditorContext, CellEditorCommit, CellEditorClose } from '@witqq/spreadsheet';
+
+class ColorPickerEditor implements CellEditor {
+  readonly id = 'color-picker';
+  private _isOpen = false;
+  private _editingRow = -1;
+  private _editingCol = -1;
+
+  get isOpen() { return this._isOpen; }
+  get editingRow() { return this._editingRow; }
+  get editingCol() { return this._editingCol; }
+
+  open(ctx: CellEditorContext, commitFn: CellEditorCommit, closeFn: CellEditorClose) {
+    this._isOpen = true;
+    this._editingRow = ctx.row;
+    this._editingCol = ctx.col;
+    // Create DOM overlay, position it, handle input...
+    // Call commitFn(row, col, oldValue, newColor) to persist
+    // Call closeFn('enter') when done
+  }
+
+  close(reason: EditorCloseReason) {
+    this._isOpen = false;
+    // Remove DOM overlay
+  }
+
+  setTheme(theme: SpreadsheetTheme) { /* update styling */ }
+  setLocale(locale: ResolvedLocale) { /* update labels */ }
+  destroy() { this.close('programmatic'); }
+}
+
+// Register before or after mount
+engine.registerCellEditor(new ColorPickerEditor(), 'color', 10);
+```
+
+---
+
+## Selection
+
+### SelectionManager
+
+Manages selection state: active cell, anchor cell, selected ranges, and selection type. Pure state management — no rendering.
+
+```typescript
+import { SelectionManager } from '@witqq/spreadsheet';
+import type { SelectionManagerConfig } from '@witqq/spreadsheet';
+
+interface SelectionManagerConfig {
+  rowCount: number;
+  colCount: number;
+  onChange?: (selection: Selection, previousSelection: Selection) => void;
+}
+
+const sm = engine.getSelectionManager();
+
+// Selection actions
+sm.selectCell(row, col);                       // Single cell (click)
+sm.extendSelection(row, col);                  // Extend from anchor (Shift+click)
+sm.addRange(row, col);                         // Add range (Ctrl+click)
+sm.selectRow(row);                             // Entire row (row number click)
+sm.selectColumn(col);                          // Entire column (header click)
+sm.selectAll();                                // All cells (Ctrl+A or corner click)
+
+// Query
+sm.getSelection(): Selection                   // Immutable snapshot
+sm.isSelected(row, col): boolean               // Cell in any selected range?
+sm.isActiveCell(row, col): boolean             // Is the active cell?
+sm.rowCount: number
+sm.colCount: number
+
+// Update bounds
+sm.setRowCount(count);                         // After filtering changes visible rows
+sm.setMergeManager(mm);                        // For merge-aware selection
+```
+
+All selection methods are merge-aware: clicking a merged cell selects the entire merge region, and the active cell is redirected to the merge anchor.
+
+### KeyboardNavigator
+
+Handles keyboard events for spreadsheet navigation. Merge-aware: skips hidden cells in merged regions.
+
+```typescript
+import { KeyboardNavigator } from '@witqq/spreadsheet';
+import type { KeyboardNavigatorConfig } from '@witqq/spreadsheet';
+
+interface KeyboardNavigatorConfig {
+  selectionManager: SelectionManager;
+  getVisibleRowCount: () => number;            // For Page Up/Down distance
+}
+
+const nav = engine.getKeyboardNavigator();
+
+// Process a keyboard event — returns new CellAddress for auto-scroll, or null
+nav?.handleKeyDown(event): CellAddress | null
+
+// Set merge manager for merge-aware navigation
+nav?.setMergeManager(mm);
+```
+
+**Supported keys:**
+- Arrow keys — move active cell
+- Shift+Arrow — extend selection range
+- Tab / Shift+Tab — move right/left
+- Enter / Shift+Enter — move down/up
+- Home / End — jump to row start/end
+- Ctrl+Home / Ctrl+End — jump to grid corners
+- Page Up / Page Down — scroll by visible row count
+- Ctrl+A — select all
+
+---
+
+## Plugin Types
+
+```typescript
+interface SpreadsheetPlugin {
+  readonly name: string;
+  readonly dependencies?: string[];            // Names of required plugins
+  install(api: PluginAPI): void;
+  destroy?(): void;
+}
+
+interface PluginAPI {
+  readonly engine: SpreadsheetEngine;
+  getPluginState<T>(key: string): T | undefined;
+  setPluginState<T>(key: string, value: T): void;
+}
+```
+
+See `@witqq/spreadsheet-plugins` for official plugin implementations.
+
+---
+
+## Constants
+
+```typescript
+import { LINE_HEIGHT_MULTIPLIER } from '@witqq/spreadsheet';
+// Value: 1.2 — used in text measurement for auto row height
+```
+
+---
+
+## Common Patterns
+
+### Controlled Data Updates
+
+```typescript
+const engine = new SpreadsheetEngine({
+  columns: [{ key: 'name', title: 'Name', width: 200 }],
+  data: initialData,
+});
+engine.mount(container);
+
+// Update a single cell
+engine.setCell(0, 0, 'New Value');
+
+// Bulk update via CellStore
+const store = engine.getCellStore();
+store.bulkLoadChunk(100, newRows, ['name', 'age', 'email']);
+engine.setRowCount(store.size);
+engine.render();
+```
+
+### Theme Switching
+
+```typescript
+import { SpreadsheetEngine, lightTheme, darkTheme } from '@witqq/spreadsheet';
+
+const engine = new SpreadsheetEngine({ columns, data, theme: lightTheme });
+engine.mount(container);
+
+// Switch at runtime
+document.querySelector('#dark-mode').addEventListener('change', (e) => {
+  engine.setTheme(e.target.checked ? darkTheme : lightTheme);
 });
 ```
 
-## Features
+### Frozen Panes
 
-- **Canvas 2D Rendering** — High-performance rendering for 100K+ rows
-- **Zero Dependencies** — Pure TypeScript, no external libraries
-- **Cell Types** — Text, number, date, boolean, custom renderers
-- **Selection** — Multi-cell, row, column, and range selection
-- **Keyboard Navigation** — Arrow keys, Tab, Enter, Home/End, Page Up/Down
-- **Inline Editing** — Double-click or F2 to edit, Enter to commit
-- **Undo/Redo** — Full command history (100 steps)
-- **Clipboard** — Copy/cut/paste with TSV and HTML support (Excel/Sheets interop)
-- **Column/Row Resize** — Drag borders to resize
-- **Sorting** — Multi-column stable sort, type-aware
-- **Filtering** — 14 operators (equals, contains, between, isEmpty, etc.)
-- **Frozen Panes** — Freeze rows and columns
-- **Merged Cells** — Merge/unmerge with spatial index
-- **Autofill** — Drag handle with pattern detection (numbers, dates, text)
-- **Validation** — Required, min/max, regex, custom functions
-- **Change Tracking** — Cell status lifecycle (changed → saving → saved)
-- **Conditional Formatting** — Gradients, data bars, icon sets (via plugin)
-- **Formulas** — Custom formula engine (via plugin)
-- **Theming** — Light and dark themes, fully customizable
-- **Print** — @media print support with DOM table generation
-- **Accessibility** — WCAG 2.1 AA (role=grid, aria-live announcements)
-- **Touch Support** — Tap to select, double-tap to edit
+```typescript
+const engine = new SpreadsheetEngine({
+  columns,
+  data,
+  frozenRows: 1,      // Freeze first row
+  frozenColumns: 2,    // Freeze first two columns
+});
+```
 
-## Framework Integration
+### Auto Row Height
 
-| Framework | Package |
-|-----------|---------|
-| React | [@witqq/spreadsheet-react](https://www.npmjs.com/package/@witqq/spreadsheet-react) |
+```typescript
+const engine = new SpreadsheetEngine({
+  columns: [
+    { key: 'description', title: 'Description', width: 300, wrapText: true },
+  ],
+  data,
+  autoRowHeight: true,  // or { minRowHeight: 28, maxRowHeight: 200 }
+});
+```
 
-## Plugins
+### Programmatic Sort and Filter
 
-Official plugins: [@witqq/spreadsheet-plugins](https://www.npmjs.com/package/@witqq/spreadsheet-plugins)
+```typescript
+// Sort by age descending
+engine.sortBy([{ col: 1, direction: 'desc' }]);
 
-- Context Menu — Right-click menu with keyboard navigation
-- Formula Engine — Tokenizer, parser, evaluator, dependency graph
-- Conditional Formatting — Gradients, data bars, icon sets
-- Excel I/O — Import/export via SheetJS (lazy-loaded)
-- Collaboration — Real-time OT with remote cursors
+// Filter name column to contain "Alice"
+engine.setColumnFilter(0, [{ col: 0, operator: 'contains', value: 'Alice' }]);
 
-## Documentation
+// Clear
+engine.clearSort();
+engine.clearFilters();
+```
 
-Full documentation and live demos: [spreadsheet.witqq.dev](https://spreadsheet.witqq.dev)
+## Rendering
+
+### CanvasManager
+
+DPI-aware canvas element manager. Creates and sizes a `<canvas>` inside a container, handles device pixel ratio changes (browser zoom).
+
+```typescript
+import { CanvasManager, CanvasManagerConfig } from '@witqq/spreadsheet';
+
+interface CanvasManagerConfig {
+  container: HTMLElement;
+  dpr?: number; // device pixel ratio override; defaults to window.devicePixelRatio
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `syncSize` | `(): void` | Sync canvas size with container dimensions; applies DPR transform |
+| `getContext` | `(): CanvasRenderingContext2D` | Get the 2D drawing context |
+| `getCanvas` | `(): HTMLCanvasElement` | Get the raw canvas element |
+| `getDpr` | `(): number` | Current device pixel ratio |
+| `getCssWidth` | `(): number` | Canvas CSS width |
+| `getCssHeight` | `(): number` | Canvas CSS height |
+| `getPixelWidth` | `(): number` | Canvas pixel width (`canvas.width`) |
+| `getPixelHeight` | `(): number` | Canvas pixel height (`canvas.height`) |
+| `setDprChangeCallback` | `(callback: () => void): void` | Callback on DPR change |
+| `destroy` | `(): void` | Cleanup DPR watcher, remove canvas from DOM |
+
+### LayoutEngine
+
+Pre-computed cumulative row/column positions using `Float64Array`. All coordinate lookups are O(1); row/column-at-pixel lookups use O(log n) binary search.
+
+```typescript
+import { LayoutEngine, LayoutEngineConfig } from '@witqq/spreadsheet';
+
+interface LayoutEngineConfig {
+  columns: ColumnDef[];
+  rowCount: number;
+  rowHeight: number;
+  headerHeight: number;
+  rowNumberWidth: number;
+  rowStore?: RowStore;
+}
+```
+
+**Getters:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `rowCount` | `number` | Current effective row count |
+| `columnCount` | `number` | Number of visible columns |
+| `rowHeight` | `number` | Default row height |
+| `headerHeight` | `number` | Header height |
+| `rowNumberWidth` | `number` | Row number gutter width |
+| `contentWidth` | `number` | Total width of all visible columns |
+| `contentHeight` | `number` | Total height of all rows |
+| `totalWidth` | `number` | `rowNumberWidth + contentWidth` |
+| `totalHeight` | `number` | `headerHeight + contentHeight` |
+
+**Methods:**
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setRowCount` | `(count: number): void` | Update row count; reallocates arrays if needed |
+| `getRowPositions` | `(): Float64Array` | Cumulative row positions (shared ref) |
+| `getRowHeightsArray` | `(): Float64Array` | Per-row heights array |
+| `getCellRect` | `(row: number, col: number): CellRect` | O(1) cell rectangle lookup |
+| `getColumnX` | `(col: number): number` | Column x-position |
+| `getColumnWidth` | `(col: number): number` | Column width |
+| `getRowY` | `(row: number): number` | Row y-position |
+| `getRowHeight` | `(row: number): number` | Height of a specific row |
+| `getRowAtY` | `(y: number): number` | O(log n) binary search for row at y pixel |
+| `getColAtX` | `(x: number): number` | O(log n) binary search for column at x pixel |
+| `setRowHeight` | `(row: number, height: number): void` | Update single row height; O(n) recompute |
+| `setRowHeightsBatch` | `(updates: Map<number, number>): void` | Batch-update row heights; single O(n) recompute |
+| `setColumnWidth` | `(col: number, width: number): void` | Update single column width |
+| `setColumnWidthsBatch` | `(updates: Map<number, number>): void` | Batch-update column widths |
+| `getFrozenRowsHeight` | `(count: number): number` | Pixel height of first `count` frozen rows |
+| `getFrozenColsWidth` | `(count: number): number` | Pixel width of first `count` frozen columns |
+
+### GridGeometry
+
+Pure cell position/rectangle computation. Delegates to `LayoutEngine` row positions when available, falls back to uniform row height.
+
+```typescript
+import { GridGeometry, GridGeometryConfig } from '@witqq/spreadsheet';
+
+interface GridGeometryConfig {
+  columns: ColumnDef[];
+  theme: SpreadsheetTheme;
+  showRowNumbers: boolean;
+  rowPositions?: Float64Array;
+  rowHeights?: Float64Array;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `getRowY` | `(row: number): number` | Row y-position relative to content |
+| `getRowHeight` | `(row: number): number` | Height of a specific row |
+| `setRowData` | `(rowPositions: Float64Array, rowHeights: Float64Array): void` | Update row data (shared refs from LayoutEngine) |
+| `getVisibleColumns` | `(): ColumnDef[]` | Non-hidden columns (cached) |
+| `getColumnWidth` | `(col: number): number` | Column width |
+| `setColumnWidth` | `(col: number, width: number): void` | Set column width override |
+| `computeColumnRects` | `(): CellRect[]` | Column header rectangles (cached) |
+| `computeCellRect` | `(row: number, col: number): CellRect` | Rectangle for a specific cell |
+| `computeAllCellRects` | `(rowCount: number): CellRect[][]` | 2D array of all cell rectangles |
+| `invalidateCache` | `(): void` | Clear cached rects and visible columns |
+| `setTheme` | `(theme: SpreadsheetTheme): void` | Update theme and invalidate |
+
+### ViewportManager
+
+Computes visible cell range from scroll position with configurable row/column buffer for pre-rendering.
+
+```typescript
+import { ViewportManager, ViewportRange, ViewportConfig, FrozenViewportRanges } from '@witqq/spreadsheet';
+
+interface ViewportRange {
+  readonly startRow: number;
+  readonly endRow: number;
+  readonly startCol: number;
+  readonly endCol: number;
+  readonly visibleRowCount: number;
+  readonly visibleColCount: number;
+}
+
+interface FrozenViewportRanges {
+  corner: ViewportRange;
+  frozenRow: ViewportRange;
+  frozenCol: ViewportRange;
+  main: ViewportRange;
+}
+
+interface ViewportConfig {
+  rowBuffer?: number; // default: 10
+  colBuffer?: number; // default: 5
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `computeVisibleRange` | `(scrollX, scrollY, viewportWidth, viewportHeight): ViewportRange` | Visible rows/columns with buffer |
+| `computeFrozenRanges` | `(scrollX, scrollY, viewportWidth, viewportHeight, frozenRows, frozenCols): FrozenViewportRanges` | 4 viewport ranges for frozen pane rendering |
+
+### RenderScheduler
+
+RAF-based render coalescing. Multiple `requestRender()` calls within one frame produce a single render.
+
+```typescript
+import { RenderScheduler } from '@witqq/spreadsheet';
+
+const scheduler = new RenderScheduler(() => { /* render callback */ });
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `requestRender` | `(): void` | Schedule render on next `requestAnimationFrame` |
+| `cancel` | `(): void` | Cancel pending render |
+| `isPending` | `(): boolean` | Whether a render is scheduled |
+
+### DirtyTracker
+
+Tracks which visual regions need redrawing. Subsystems mark regions dirty; the render loop flushes them.
+
+```typescript
+import { DirtyTracker, DirtyRegion, DirtyCell, DirtyRect } from '@witqq/spreadsheet';
+
+type DirtyRegion = 'full' | 'viewport-change' | 'cell-update';
+interface DirtyCell { row: number; col: number; }
+interface DirtyRect { x: number; y: number; width: number; height: number; }
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `markDirty` | `(region: DirtyRegion): void` | Mark entire region for redraw |
+| `markCellDirty` | `(row: number, col: number): void` | Mark specific cell dirty (cap: 50 cells) |
+| `isDirty` | `(): boolean` | Whether any region is dirty |
+| `isRegionDirty` | `(region: DirtyRegion): boolean` | Check specific region |
+| `flush` | `(): Set<DirtyRegion>` | Get dirty regions and clear |
+| `flushCells` | `(): DirtyCell[] | null` | Flush dirty cells; `null` if full redraw needed |
+| `clear` | `(): void` | Clear all dirty flags |
+
+### ScrollManager
+
+Native scrollbar behavior via hidden scrollable overlay div. Captures wheel events and forwards to callback.
+
+```typescript
+import { ScrollManager, ScrollManagerConfig } from '@witqq/spreadsheet';
+
+interface ScrollManagerConfig {
+  container: HTMLElement;
+  totalWidth: number;
+  totalHeight: number;
+  onScroll: (scrollX: number, scrollY: number) => void;
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `scrollX` | `number` (getter) | Current horizontal scroll offset |
+| `scrollY` | `number` (getter) | Current vertical scroll offset |
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `updateContentSize` | `(totalWidth: number, totalHeight: number): void` | Update scrollable area |
+| `scrollTo` | `(x: number, y: number): void` | Programmatic scroll |
+| `getElement` | `(): HTMLDivElement` | Get scroll container element |
+| `destroy` | `(): void` | Remove listeners and DOM |
+
+### RenderPipeline
+
+Orchestrates composable render layers on a single canvas. Supports frozen pane 4-region rendering with `ImageData` caching for static frozen areas.
+
+```typescript
+import { RenderPipeline, FrozenPaneConfig } from '@witqq/spreadsheet';
+
+interface FrozenPaneConfig {
+  frozenRows: number;
+  frozenColumns: number;
+  layoutEngine: LayoutEngine;
+  frozenRanges: FrozenViewportRanges;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `addLayer` | `(layer: RenderLayer): void` | Append layer to pipeline |
+| `insertLayerBefore` | `(layer: RenderLayer, beforeLayer: RenderLayer): void` | Insert layer before another |
+| `getLayer` | `<T extends RenderLayer>(layerClass: new (...) => T): T \| undefined` | Find layer by class type |
+| `removeLayer` | `(layer: RenderLayer): void` | Remove layer from pipeline |
+| `setMergeManager` | `(manager: MergeManager \| undefined): void` | Set merge manager for merge-aware rendering |
+| `setTheme` | `(theme: SpreadsheetTheme): void` | Update theme, invalidate frozen caches |
+| `invalidateFrozenCache` | `(): void` | Invalidate frozen pane caches |
+| `render` | `(ctx, viewport, canvasWidth, canvasHeight, scrollX, scrollY, renderMode?, frozenConfig?): void` | Full render of all layers |
+| `renderPartial` | `(ctx, viewport, canvasWidth, canvasHeight, scrollX, scrollY, dirtyRects, renderMode?, frozenConfig?): void` | Partial render of dirty rectangles only |
+
+### RenderLayer Interface
+
+Composable layer that draws one visual aspect of the grid.
+
+```typescript
+import { RenderLayer, RenderContext, RenderMode, PaneRegion } from '@witqq/spreadsheet';
+
+type RenderMode = 'full' | 'light' | 'placeholder';
+type PaneRegion = 'corner' | 'frozenRow' | 'frozenCol' | 'main' | 'full';
+
+interface RenderContext {
+  ctx: CanvasRenderingContext2D;
+  geometry: GridGeometry;
+  theme: SpreadsheetTheme;
+  canvasWidth: number;
+  canvasHeight: number;
+  viewport: ViewportRange;
+  scrollX: number;
+  scrollY: number;
+  renderMode: RenderMode;
+  paneRegion: PaneRegion;
+  mergeManager?: MergeManager;
+}
+
+interface RenderLayer {
+  render(rc: RenderContext): void;
+  measureHeights?(rc: RenderContext): Map<number, number>; // optional: row → desired height
+}
+```
+
+### GridRenderer
+
+Facade that creates the default layer stack: Background → CellText → CellStatus → EmptyState → GridLines → Header → RowNumber → SelectionOverlay.
+
+```typescript
+import { GridRenderer, GridRenderConfig } from '@witqq/spreadsheet';
+
+interface GridRenderConfig {
+  columns: ColumnDef[];
+  cellStore: CellStore;
+  dataView: DataView;
+  rowCount: number;
+  theme: SpreadsheetTheme;
+  showRowNumbers: boolean;
+  showGridLines: boolean;
+  selectionManager?: SelectionManager;
+  cellTypeRegistry?: CellTypeRegistry;
+  rowPositions?: Float64Array;
+  rowHeights?: Float64Array;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `computeColumnRects` | `(): CellRect[]` | Column header rectangles |
+| `computeCellRect` | `(row, col): CellRect` | Rectangle for a specific cell |
+| `computeAllCellRects` | `(): CellRect[][]` | All cell rectangles as 2D array |
+| `getGeometry` | `(): GridGeometry` | Access grid geometry |
+| `addLayer` | `(layer: RenderLayer): void` | Add layer (inserted before GridLines/Selection) |
+| `insertLayerBefore` | `(layer, beforeLayer): void` | Insert layer before another |
+| `getLayer` | `<T>(layerClass): T \| undefined` | Find layer by type |
+| `removeLayer` | `(layer): void` | Remove layer |
+| `setSortState` | `(state: HeaderSortState): void` | Sort indicators on headers |
+| `setFilterState` | `(state: HeaderFilterState): void` | Filter indicators on headers |
+| `setFrozenConfig` | `(config: FrozenPaneConfig \| undefined): void` | Set frozen pane config |
+| `invalidateFrozenCache` | `(): void` | Invalidate frozen pane caches |
+| `setMergeManager` | `(manager: MergeManager \| undefined): void` | Set merge manager |
+| `setTheme` | `(theme: SpreadsheetTheme): void` | Runtime theme change |
+| `setLocale` | `(locale: ResolvedLocale): void` | Runtime locale change |
+| `render` | `(ctx, viewport, w, h, scrollX, scrollY, renderMode?): void` | Full render |
+| `renderPartial` | `(ctx, viewport, w, h, scrollX, scrollY, dirtyRects, renderMode?): void` | Partial render |
+
+### TextMeasureCache
+
+LRU cache for `ctx.measureText()` results. Caches text width, word-wrap line splits, and em-height measurements.
+
+```typescript
+import { TextMeasureCache } from '@witqq/spreadsheet';
+
+const cache = new TextMeasureCache(10_000); // maxSize
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `measureText` | `(ctx, text: string, font: string): number` | Cached text width measurement |
+| `measureEmHeight` | `(ctx, font: string): number` | Font em-height (ascent+descent) |
+| `getWrappedLines` | `(ctx, text, font, maxWidth): string[]` | Word-wrap line splitting |
+| `countWrappedLines` | `(ctx, text, font, maxWidth): number` | Count of wrapped lines |
+| `measureWrappedHeight` | `(ctx, text, font, maxWidth, lineHeight?, padding?): number` | Total pixel height for wrapped text |
+| `truncateText` | `(ctx, text, font, maxWidth): string` | Truncate with ellipsis |
+| `clear` | `(): void` | Clear all caches |
+
+### Built-in Render Layers
+
+| Layer | Constructor | Description |
+|-------|-------------|-------------|
+| `CellTextLayer` | `(cellStore, dataView, measureCache, typeRegistry?)` | Cell text with truncation, alignment, word-wrap, merged cell support, custom cell type rendering |
+| `CellStatusLayer` | `(cellStore, dataView)` | Status indicators: error (red triangle), changed/saving (blue dot), saved (green dot) |
+| `EmptyStateLayer` | parameterless | "No data" text when all rows filtered out |
+| `FillHandleLayer` | `(autofillManager)` | Fill handle square + autofill preview overlay |
+| `RowGroupToggleLayer` | `(groupManager, dataView)` | Expand/collapse icons in row number gutter |
+
+`CellTextLayer` also implements `measureHeights(rc)` returning `Map<number, number>` of desired row heights for wrap-text columns.
+
+---
+
+## Events
+
+### EventBus
+
+Typed publish/subscribe for spreadsheet events. Supports both typed event names (via `SpreadsheetEvents` interface) and dynamic string names (for framework wrappers).
+
+```typescript
+import { EventBus } from '@witqq/spreadsheet';
+
+const bus = new EventBus();
+bus.on('cellClick', (event) => console.log(event.row, event.col));
+bus.off('cellClick', handler);
+bus.emit('cellClick', { row: 0, col: 0, value: 'test', column: colDef });
+bus.destroy(); // remove all handlers
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `on` | `<K extends keyof SpreadsheetEvents>(event: K, handler: SpreadsheetEvents[K]): void` | Register typed handler |
+| `on` | `(event: string, handler: EventHandler): void` | Register dynamic handler |
+| `off` | `<K extends keyof SpreadsheetEvents>(event: K, handler: SpreadsheetEvents[K]): void` | Remove typed handler |
+| `off` | `(event: string, handler: EventHandler): void` | Remove dynamic handler |
+| `emit` | `<K>(event: K, ...args: Parameters<SpreadsheetEvents[K]>): void` | Dispatch event |
+| `destroy` | `(): void` | Remove all handlers |
+
+### EventTranslator
+
+Translates DOM events (mouse, touch, keyboard) on the scroll container into typed spreadsheet events via hit-testing.
+
+```typescript
+import { EventTranslator, EventTranslatorConfig } from '@witqq/spreadsheet';
+
+interface EventTranslatorConfig {
+  scrollContainer: HTMLElement;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  eventBus: EventBus;
+  cellStore: CellStore;
+  dataView: DataView;
+  columns: ColumnDef[];
+  rowGroupManager?: RowGroupManager;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `attach` | `(): void` | Attach DOM listeners (mouse, touch, keyboard) |
+| `detach` | `(): void` | Remove all DOM listeners |
+| `setFrozenConfig` | `(frozenRows: number, frozenCols: number): void` | Update frozen pane config for hit-testing |
+| `hitTest` | `(offsetX: number, offsetY: number): HitTestResult` | Convert pixel coordinates to grid region + cell address |
+
+### Event Types
+
+```typescript
+import type {
+  SpreadsheetEvents,
+  CellEvent, CellChangeEvent,
+  SelectionChangeEvent, ScrollEvent,
+  CommandEvent, ClipboardDataEvent,
+  ColumnResizeEvent, RowResizeEvent,
+  CellStatusChangeEvent, CellValidationEvent,
+  GridMouseEvent, GridKeyboardEvent,
+  HitTestResult, HitRegion,
+  SortChangeEvent, SortRejectedEvent, FilterChangeEvent,
+  AutofillStartEvent, AutofillPreviewEvent, AutofillCompleteEvent,
+  RowGroupToggleEvent, RowGroupChangeEvent,
+} from '@witqq/spreadsheet';
+```
+
+**`HitRegion`** — `'cell' | 'header' | 'header-sort-icon' | 'header-filter-icon' | 'row-number' | 'row-group-toggle' | 'corner' | 'outside'`
+
+**`HitTestResult`** — `{ readonly region: HitRegion; readonly row: number; readonly col: number }`
+
+**`GridMouseEvent`** extends `HitTestResult` — `{ readonly originalEvent: MouseEvent; readonly shiftKey: boolean; readonly ctrlKey: boolean }`
+
+**`GridKeyboardEvent`** — `{ readonly originalEvent: KeyboardEvent; readonly key: string; readonly shiftKey: boolean; readonly ctrlKey: boolean }`
+
+**`CellEvent`** — `{ row: number; col: number; value: CellValue; column: ColumnDef }`
+
+**`CellChangeEvent`** extends `CellEvent` — `{ oldValue: CellValue; newValue: CellValue; source: string }`
+
+**`SelectionChangeEvent`** — `{ selection: Selection; previousSelection: Selection }`
+
+**`ScrollEvent`** — `{ scrollTop: number; scrollLeft: number }`
+
+**`CommandEvent`** — `{ description: string }`
+
+**`ClipboardDataEvent`** — `{ rowCount: number; colCount: number }`
+
+**`ColumnResizeEvent`** — `{ colIndex: number; oldWidth: number; newWidth: number }`
+
+**`RowResizeEvent`** — `{ rowIndex: number; oldHeight: number; newHeight: number }`
+
+**`CellStatusChangeEvent`** — `{ row: number; col: number; oldStatus: CellMetadata['status'] | undefined; newStatus: CellMetadata['status'] | undefined; errorMessage?: string }`
+
+**`CellValidationEvent`** — `{ row: number; col: number; result: ValidationResult }`
+
+**`AutofillStartEvent`** — `{ sourceRange: CellRange }`
+
+**`AutofillPreviewEvent`** — `{ sourceRange: CellRange; fillRange: CellRange | null; direction: FillDirection | null }`
+
+**`AutofillCompleteEvent`** — `{ sourceRange: CellRange; fillRange: CellRange; direction: FillDirection }`
+
+**`SortChangeEvent`** — `{ readonly sortColumns: readonly { col: number; direction: 'asc' | 'desc' }[] }`
+
+**`SortRejectedEvent`** — `{ readonly reason: 'merged-regions-exist' }`
+
+**`FilterChangeEvent`** — `{ readonly visibleRowCount: number; readonly totalRowCount: number }`
+
+**`RowGroupToggleEvent`** — `{ readonly headerRow: number; readonly expanded: boolean }`
+
+**`RowGroupChangeEvent`** — `{ readonly groupHeaders: readonly number[] }`
+
+### SpreadsheetEvents Map
+
+All events follow `(event: T) => void` signature. Registered via `engine.on('eventName', handler)`.
+
+| Category | Event | Payload |
+|----------|-------|---------|
+| Cell | `cellClick` | `CellEvent` |
+| Cell | `cellDoubleClick` | `CellEvent` |
+| Cell | `cellChange` | `CellChangeEvent` |
+| Selection | `selectionChange` | `SelectionChangeEvent` |
+| Scroll | `scroll` | `ScrollEvent` |
+| Lifecycle | `ready` | (none) |
+| Lifecycle | `destroy` | (none) |
+| Command | `commandExecute` | `CommandEvent` |
+| Command | `commandUndo` | `CommandEvent` |
+| Command | `commandRedo` | `CommandEvent` |
+| Clipboard | `clipboardCopy` | `ClipboardDataEvent` |
+| Clipboard | `clipboardCut` | `ClipboardDataEvent` |
+| Clipboard | `clipboardPaste` | `ClipboardDataEvent` |
+| Resize | `columnResize` | `ColumnResizeEvent` |
+| Resize | `columnResizeStart` | `{ colIndex: number }` |
+| Resize | `columnResizeEnd` | `ColumnResizeEvent` |
+| Resize | `rowResize` | `RowResizeEvent` |
+| Resize | `rowResizeStart` | `{ rowIndex: number }` |
+| Resize | `rowResizeEnd` | `RowResizeEvent` |
+| Status | `cellStatusChange` | `CellStatusChangeEvent` |
+| Status | `cellValidation` | `CellValidationEvent` |
+| Autofill | `autofillStart` | `AutofillStartEvent` |
+| Autofill | `autofillPreview` | `AutofillPreviewEvent` |
+| Autofill | `autofillComplete` | `AutofillCompleteEvent` |
+| Sort | `sortChange` | `SortChangeEvent` |
+| Sort | `sortRejected` | `SortRejectedEvent` |
+| Filter | `filterChange` | `FilterChangeEvent` |
+| Groups | `rowGroupToggle` | `RowGroupToggleEvent` |
+| Groups | `rowGroupChange` | `RowGroupChangeEvent` |
+| Theme | `themeChange` | `{ theme: SpreadsheetTheme }` |
+
+Internal grid events (`gridMouseDown`, `gridMouseMove`, `gridMouseUp`, `gridMouseHover`, `gridContextMenu`, `gridKeyDown`) are emitted by `EventTranslator` and consumed by internal subsystems.
+
+---
+
+## Commands
+
+### Command Interface
+
+Core interface for the undo/redo system. Every data-modifying operation implements `Command`.
+
+```typescript
+import type { Command } from '@witqq/spreadsheet';
+
+interface Command {
+  execute(): void;
+  undo(): void;
+  readonly description: string;
+}
+```
+
+### CommandManager
+
+Manages command execution with bounded undo/redo stacks.
+
+```typescript
+import { CommandManager, CommandManagerConfig, CommandCallback } from '@witqq/spreadsheet';
+
+type CommandCallback = (command: Command) => void;
+
+interface CommandManagerConfig {
+  historyLimit?: number; // default: 100
+  onAfterExecute?: CommandCallback;
+  onAfterUndo?: CommandCallback;
+  onAfterRedo?: CommandCallback;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `execute` | `(command: Command): void` | Execute command, push to undo stack, clear redo stack |
+| `undo` | `(): Command \| undefined` | Undo last command |
+| `redo` | `(): Command \| undefined` | Redo last undone command |
+| `canUndo` | `(): boolean` | Whether undo is available |
+| `canRedo` | `(): boolean` | Whether redo is available |
+| `clear` | `(): void` | Clear both stacks |
+
+**Getters:** `undoCount: number`, `redoCount: number`
+
+### Built-in Commands
+
+| Command | Constructor | Description |
+|---------|-------------|-------------|
+| `CellEditCommand` | `(cellStore, row, col, oldValue, newValue)` | Single-cell value edit |
+| `BatchCellEditCommand` | `(cellStore, edits: readonly CellEdit[])` | Multi-cell edit (paste, autofill, bulk ops) |
+| `ResizeColumnCommand` | `(layoutEngine, gridGeometry, colIndex, oldWidth, newWidth)` | Column width resize |
+| `ResizeRowCommand` | `(layoutEngine, rowIndex, oldHeight, newHeight)` | Row height resize |
+| `MergeCellsCommand` | `(mergeManager, cellStore, region, value?)` | Merge cell region (snapshots displaced cells) |
+| `UnmergeCellsCommand` | `(mergeManager, cellStore, region)` | Unmerge cell region |
+| `InsertRowCommand` | `(deps: RowCommandDeps, targetRow)` | Insert row, shift cells and merges down |
+| `DeleteRowCommand` | `(deps: RowCommandDeps, targetRow)` | Delete row, shift cells and merges up |
+
+```typescript
+import type { CellEdit, RowCommandDeps } from '@witqq/spreadsheet';
+
+interface CellEdit {
+  readonly row: number;
+  readonly col: number;
+  readonly oldValue: CellValue;
+  readonly newValue: CellValue;
+}
+
+interface RowCommandDeps {
+  cellStore: CellStore;
+  mergeManager: MergeManager | null;
+  setRowCount: (count: number) => void;
+  getRowCount: () => number;
+}
+```
+
+`CellEditCommand` and `BatchCellEditCommand` expose `get affectedCells()` returning `ReadonlyArray<{ row, col, oldValue, newValue }>`.
+
+---
+
+## Sort
+
+### SortEngine
+
+Multi-column sort with stable ordering. Supports toggle cycling (`none → asc → desc → none`).
+
+```typescript
+import { SortEngine, SortEngineConfig, SortColumn, SortDirection, compareCellValues } from '@witqq/spreadsheet';
+
+type SortDirection = 'asc' | 'desc';
+
+interface SortColumn {
+  readonly col: number;
+  readonly direction: SortDirection;
+}
+
+interface SortEngineConfig {
+  cellStore: CellStore;
+  totalRowCount: number;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `isClear` | `(): boolean` | No sort columns active |
+| `toggleColumn` | `(col: number, multiColumn?: boolean): SortColumn[]` | Cycle sort on column; `multiColumn` preserves other sorts |
+| `setSortColumns` | `(columns: SortColumn[]): void` | Programmatically set sort columns |
+| `clearSort` | `(): void` | Remove all sorts |
+| `setTotalRowCount` | `(count: number): void` | Update row count |
+| `computeSortedIndices` | `(physicalIndices?: number[]): number[] \| null` | Sorted row indices; `null` if no sort active |
+
+**Getter:** `sortColumns: readonly SortColumn[]`
+
+**`compareCellValues(a: CellValue, b: CellValue): number`** — Exported utility. `null` sorts last; type-aware comparison (numbers, strings via `localeCompare`, booleans, dates); cross-type order: `number < boolean < string`.
+
+---
+
+## Filter
+
+### FilterEngine
+
+Multi-column filtering with 14 operators. AND logic across conditions.
+
+```typescript
+import { FilterEngine, FilterEngineConfig, FilterCondition, FilterOperator, evaluateCondition } from '@witqq/spreadsheet';
+
+type FilterOperator =
+  | 'equals' | 'notEquals' | 'contains' | 'startsWith' | 'endsWith'
+  | 'greaterThan' | 'lessThan' | 'greaterThanOrEqual' | 'lessThanOrEqual'
+  | 'between' | 'in' | 'notIn' | 'isEmpty' | 'isNotEmpty';
+
+interface FilterCondition {
+  col: number;
+  operator: FilterOperator;
+  value?: CellValue;    // comparison value
+  valueTo?: CellValue;  // upper bound for 'between'
+  values?: CellValue[]; // for 'in' / 'notIn'
+}
+
+interface FilterEngineConfig {
+  cellStore: CellStore;
+  totalRowCount: number;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setColumnFilter` | `(col: number, conditions: FilterCondition[]): void` | Set filter for a column |
+| `removeColumnFilter` | `(col: number): void` | Remove filter from column |
+| `getColumnFilters` | `(col: number): FilterCondition[]` | Get conditions for column |
+| `getFilteredColumns` | `(): Set<number>` | Columns with active filters |
+| `setConditions` | `(conditions: FilterCondition[]): void` | Replace all conditions |
+| `clearAll` | `(): void` | Clear all filters |
+| `clearFilters` | `(): void` | Alias for `clearAll()` |
+| `getVisibleRowCount` | `(): number` | Count of rows passing filters |
+| `setTotalRowCount` | `(count: number): void` | Update row count |
+| `computeVisibleRows` | `(): number[] \| null` | Visible row indices; `null` if no filters |
+
+**Getters:** `conditions: readonly FilterCondition[]`, `totalRowCount: number`, `hasActiveFilters: boolean`
+
+**`evaluateCondition(value: CellValue | null, cond: FilterCondition): boolean`** — Exported utility. Evaluates a single condition. String comparisons are case-insensitive; numeric coercion for cross-type comparisons.
+
+### FilterPanel
+
+DOM-based filter UI panel positioned below column headers.
+
+```typescript
+import { FilterPanel, FilterPanelConfig } from '@witqq/spreadsheet';
+
+interface FilterPanelConfig {
+  container: HTMLElement;
+  scrollContainer: HTMLElement;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  theme: SpreadsheetTheme;
+  onApply: (col: number, operator: FilterOperator, value: string, valueTo?: string) => void;
+  onClear: (col: number) => void;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `open` | `(col: number, currentOperator?, currentValue?): void` | Open panel for column, optionally pre-fill |
+| `close` | `(): void` | Close panel and remove DOM |
+| `setTheme` | `(theme: SpreadsheetTheme): void` | Runtime theme switch |
+| `setLocale` | `(locale: ResolvedLocale): void` | Runtime locale switch |
+| `destroy` | `(): void` | Alias for `close()` |
+
+**Getters:** `isOpen: boolean`, `currentCol: number` (-1 if closed)
+
+---
+
+## Clipboard
+
+### ClipboardManagerConfig
+
+```ts
+import { ClipboardManagerConfig, ClipboardManager } from '@witqq/spreadsheet';
+
+interface ClipboardManagerConfig {
+  cellStore: CellStore;
+  dataView: DataView;
+  selectionManager: SelectionManager;
+  commandManager: CommandManager;
+  eventBus: EventBus;
+  isEditing: () => boolean;
+  onDataChange: () => void;
+}
+```
+
+### ClipboardManager
+
+Handles copy, cut, and paste operations through native clipboard events. Serializes data as both TSV and HTML for cross-application compatibility.
+
+```ts
+const clipboard = new ClipboardManager(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `attach` | `(scrollContainer: HTMLElement): void` | Attach copy/cut/paste keyboard listeners to the container |
+| `detach` | `(): void` | Remove all clipboard listeners |
+| `getSelectedData` | `(): CellValue[][]` | Read first selected range as a 2D array |
+
+All clipboard operations are no-ops while `isEditing()` returns `true`.
+
+**Copy** serializes the selection to TSV + HTML and emits `clipboardCopy`.
+**Cut** copies then clears source cells via `BatchCellEditCommand` (undoable) and emits `clipboardCut`.
+**Paste** parses HTML first (Excel/Sheets compatibility), falls back to TSV, writes starting at the active cell clipped to grid boundaries via `BatchCellEditCommand`, and emits `clipboardPaste`.
+
+### Clipboard Serialization Functions
+
+```ts
+import {
+  serializeToTSV,
+  serializeToHTML,
+  parseTSV,
+  parseHTML,
+} from '@witqq/spreadsheet';
+```
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `serializeToTSV` | `(data: CellValue[][]): string` | Rows joined by `\n`, cells by `\t` |
+| `serializeToHTML` | `(data: CellValue[][]): string` | Returns `<table>` HTML with escaped values |
+| `parseTSV` | `(text: string): CellValue[][]` | Splits on `\n`/`\t`; coerces values to number, boolean, or null |
+| `parseHTML` | `(html: string): CellValue[][] \| null` | Extracts `<td>`/`<th>` text via DOMParser; returns `null` if no `<table>` found |
+
+### ClipboardDataEvent
+
+```ts
+interface ClipboardDataEvent {
+  rowCount: number;
+  colCount: number;
+}
+```
+
+Payload for `clipboardCopy`, `clipboardCut`, and `clipboardPaste` events.
+
+---
+
+## Validation
+
+### Validation Rule Types
+
+```ts
+import {
+  ValidationRule,
+  ValidationResult,
+  SpreadsheetValidationRule,
+  RequiredRule,
+  RangeRule,
+  RegexRule,
+  CustomRule,
+  ValidationEngine,
+  ValidationEngineConfig,
+} from '@witqq/spreadsheet';
+```
+
+**Base types:**
+
+```ts
+interface ValidationRule {
+  readonly type: string;
+  readonly message?: string;
+  readonly severity?: 'error' | 'warning' | 'info';
+}
+
+interface ValidationResult {
+  readonly valid: boolean;
+  readonly message?: string;
+  readonly severity?: 'error' | 'warning' | 'info';
+}
+```
+
+**Built-in rule discriminated union:**
+
+```ts
+type SpreadsheetValidationRule = RequiredRule | RangeRule | RegexRule | CustomRule;
+```
+
+| Rule | `type` | Extra Fields | Behavior |
+|------|--------|-------------|----------|
+| `RequiredRule` | `'required'` | — | Fails if value is `null`, `undefined`, or `''` |
+| `RangeRule` | `'range'` | `min?: number`, `max?: number` | Skips empty; coerces to number; fails if `NaN`, `< min`, or `> max` |
+| `RegexRule` | `'regex'` | `pattern: string`, `flags?: string` | Skips empty; tests `String(value)` against `new RegExp(pattern, flags)` |
+| `CustomRule` | `'custom'` | `validate: (value: CellValue) => ValidationResult` | Delegates to user function |
+
+### ValidationEngineConfig
+
+```ts
+interface ValidationEngineConfig {
+  cellStore: CellStore;
+  eventBus: EventBus;
+}
+```
+
+### ValidationEngine
+
+```ts
+const validation = new ValidationEngine(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setColumnRules` | `(col: number, rules: SpreadsheetValidationRule[]): void` | Set rules for all cells in a column |
+| `getColumnRules` | `(col: number): SpreadsheetValidationRule[]` | Get column rules |
+| `setCellRules` | `(row: number, col: number, rules: SpreadsheetValidationRule[]): void` | Set rules for a specific cell |
+| `getCellRules` | `(row: number, col: number): SpreadsheetValidationRule[]` | Get cell rules |
+| `removeColumnRules` | `(col: number): void` | Remove column rules |
+| `removeCellRules` | `(row: number, col: number): void` | Remove cell rules |
+| `hasRules` | `(row: number, col: number): boolean` | True if column or cell rules exist for this position |
+| `hasAnyRules` | `(): boolean` | True if any rules registered |
+| `validate` | `(row: number, col: number, value: CellValue): ValidationResult` | Run all column + cell rules; returns first failure or `{ valid: true }` |
+| `validateCell` | `(row: number, col: number): ValidationResult` | Reads current value from CellStore, validates, emits `cellValidation` event |
+| `validateAll` | `(rowCount: number): void` | Validate all cells with registered rules |
+| `clearAllRules` | `(): void` | Remove all column and cell rules |
+
+`validateCell` sets cell metadata to `'error'` on failure and emits `cellStatusChange`.
+
+### CellValidationEvent
+
+```ts
+interface CellValidationEvent {
+  row: number;
+  col: number;
+  result: ValidationResult;
+}
+```
+
+Payload for the `cellValidation` event.
+
+---
+
+## Merge
+
+### MergedRegion
+
+```ts
+import { MergedRegion, MergeManager } from '@witqq/spreadsheet';
+
+interface MergedRegion {
+  readonly startRow: number;
+  readonly startCol: number;
+  readonly endRow: number;   // inclusive
+  readonly endCol: number;   // inclusive
+}
+```
+
+### MergeManager
+
+Manages merged cell regions with O(1) cell-to-region lookup via a spatial index.
+
+```ts
+const merges = new MergeManager();
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `merge` | `(region: MergedRegion): boolean` | Add a merge; returns `false` on overlap, inverted coords, or < 2 cells |
+| `unmerge` | `(startRow: number, startCol: number): boolean` | Remove by anchor position; returns `false` if not found |
+| `getMergedRegion` | `(row: number, col: number): MergedRegion \| null` | Region containing this cell, or `null` |
+| `isAnchorCell` | `(row: number, col: number): boolean` | True if cell is the top-left of a merged region |
+| `isHiddenCell` | `(row: number, col: number): boolean` | True if cell is a non-anchor cell within a merge |
+| `getAllRegions` | `(): ReadonlyArray<MergedRegion>` | All active merged regions |
+| `clearAll` | `(): void` | Remove all regions |
+| `hasAnyRegions` | `(): boolean` | True if any merges exist |
+| `validateMerge` | `(region: MergedRegion, frozenRows: number, frozenCols: number): string \| null` | Returns error string or `null` (checks size, overlap, frozen pane crossings) |
+
+---
+
+## Context Menu
+
+### Types
+
+```ts
+import {
+  ContextMenuManager,
+  ContextMenuItem,
+  ContextMenuManagerConfig,
+  MenuContext,
+  MenuActionContext,
+  createDefaultMenuItems,
+} from '@witqq/spreadsheet';
+
+type MenuContext = 'cell' | 'header' | 'row-number' | 'corner';
+
+interface MenuActionContext {
+  readonly row: number;
+  readonly col: number;
+  readonly region: string;
+  readonly engine: SpreadsheetEngine;
+}
+
+interface ContextMenuItem {
+  readonly id: string;
+  readonly label: string;
+  readonly icon?: string;
+  readonly shortcut?: string;
+  readonly separator?: boolean;
+  readonly contexts: ReadonlyArray<MenuContext>;
+  readonly submenu?: ReadonlyArray<ContextMenuItem>;
+  action?: (ctx: MenuActionContext) => void;
+  isDisabled?: (ctx: MenuActionContext) => boolean;
+  isVisible?: (ctx: MenuActionContext) => boolean;
+}
+```
+
+### ContextMenuManagerConfig
+
+```ts
+interface ContextMenuManagerConfig {
+  container: HTMLElement;
+  engine: SpreadsheetEngine;
+  eventBus: EventBus;
+  theme: SpreadsheetTheme;
+}
+```
+
+### ContextMenuManager
+
+Subscribes to `gridContextMenu` events on construction. Renders a DOM-based context menu.
+
+```ts
+const menu = new ContextMenuManager(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `registerItem` | `(item: ContextMenuItem): void` | Register a menu item by id |
+| `unregisterItem` | `(id: string): void` | Remove a menu item by id |
+| `getItems` | `(): ReadonlyMap<string, ContextMenuItem>` | All registered items |
+| `setTheme` | `(theme: SpreadsheetTheme): void` | Update theme at runtime |
+| `setLocale` | `(locale: ResolvedLocale): void` | Replace default items with localized strings |
+| `close` | `(): void` | Close menu if open |
+| `destroy` | `(): void` | Full cleanup; unsubscribes from eventBus |
+
+**Getter:** `isOpen: boolean`
+
+### createDefaultMenuItems
+
+```ts
+function createDefaultMenuItems(locale?: ResolvedLocale): ContextMenuItem[]
+```
+
+Returns 8 default menu items:
+
+| ID | Label | Contexts |
+|----|-------|----------|
+| `cut` | "Cut" | cell, header, row-number |
+| `copy` | "Copy" | cell, header, row-number |
+| `paste` | "Paste" | cell |
+| `sort-asc` | "Sort Ascending" | header |
+| `sort-desc` | "Sort Descending" | header |
+| `insert-row-above` | "Insert Row Above" | row-number |
+| `insert-row-below` | "Insert Row Below" | row-number |
+| `delete-row` | "Delete Row" | row-number |
+
+Labels are overridable via `locale.contextMenu` properties. The `paste` item is disabled when `navigator.clipboard.readText` is unavailable.
+
+---
+
+## Row Grouping
+
+### Types
+
+```ts
+import {
+  RowGroupManager,
+  RowGroupDef,
+  ColumnAggregate,
+  AggregateFunction,
+  AggregateResult,
+} from '@witqq/spreadsheet';
+
+type AggregateFunction = 'sum' | 'count' | 'average' | 'min' | 'max' | 'none';
+
+interface ColumnAggregate {
+  col: number;
+  fn: AggregateFunction;
+}
+
+interface RowGroupDef {
+  headerRow: number;
+  childRows: number[];
+  expanded?: boolean;  // default true
+}
+
+interface AggregateResult {
+  row: number;
+  col: number;
+  value: number | string;
+  label: string;  // e.g. "Sum: 42"
+}
+```
+
+### RowGroupManager
+
+```ts
+const groups = new RowGroupManager();
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setCellStore` | `(cellStore: CellStore): void` | Set CellStore reference for aggregate computation |
+| `setLocale` | `(locale: ResolvedLocale): void` | Set locale for aggregate labels |
+| `setAggregates` | `(aggregates: ColumnAggregate[]): void` | Configure per-column aggregate functions |
+| `getAggregates` | `(): readonly ColumnAggregate[]` | Current aggregate configuration |
+| `setGroups` | `(groups: RowGroupDef[]): void` | Replace all groups; throws if a child belongs to multiple groups |
+| `hasGroups` | `(): boolean` | Any groups defined |
+| `getGroup` | `(headerRow: number): { expanded: boolean; childRows: number[] } \| undefined` | Internal group state for a header row |
+| `isGroupHeader` | `(physicalRow: number): boolean` | Is this row a group header |
+| `isGroupChild` | `(physicalRow: number): boolean` | Is this row a child of any group |
+| `getParentHeader` | `(physicalRow: number): number \| undefined` | Parent header for a child row |
+| `getDepth` | `(headerRow: number): number` | Nesting depth (top-level = 0) |
+| `isExpanded` | `(headerRow: number): boolean` | Is group expanded |
+| `isHiddenByAncestor` | `(physicalRow: number): boolean` | Is row hidden by any collapsed ancestor |
+| `toggleGroup` | `(headerRow: number): boolean` | Toggle expand/collapse; returns new expanded state |
+| `expandGroup` | `(headerRow: number): void` | Expand a specific group |
+| `collapseGroup` | `(headerRow: number): void` | Collapse a specific group |
+| `expandAll` | `(): void` | Expand all groups |
+| `collapseAll` | `(): void` | Collapse all groups |
+| `getGroupHeaders` | `(): number[]` | All header row indices |
+| `getAllGroups` | `(): ReadonlyMap<number, { expanded: boolean; childRows: number[] }>` | All group states |
+| `getLeafDescendants` | `(headerRow: number): number[]` | All non-header descendants (recursive) |
+| `filterCollapsed` | `(physicalIndices: number[]): number[]` | Filter out rows hidden by collapsed groups |
+| `computeAggregates` | `(headerRow: number): AggregateResult[]` | Compute aggregates for a header using leaf descendants |
+| `clear` | `(): void` | Clear all groups |
+
+---
+
+## Pivot
+
+### Types
+
+```ts
+import {
+  PivotEngine,
+  PivotConfig,
+  PivotMeasure,
+  PivotAggregateFunction,
+  PivotResult,
+  PivotColumnDef,
+} from '@witqq/spreadsheet';
+
+type PivotAggregateFunction = 'sum' | 'count' | 'average' | 'min' | 'max';
+
+interface PivotMeasure {
+  field: string;
+  aggregate: PivotAggregateFunction;
+  label?: string;  // defaults to "aggregate(field)"
+}
+
+interface PivotConfig {
+  rowDimensions: string[];
+  columnDimensions: string[];
+  measures: PivotMeasure[];
+}
+
+interface PivotColumnDef {
+  readonly key: string;
+  readonly title: string;
+  readonly width: number;
+  readonly type?: CellType;
+  readonly frozen?: boolean;
+  readonly editable?: boolean;
+}
+
+interface PivotResult {
+  columns: PivotColumnDef[];
+  rows: Record<string, unknown>[];
+  frozenColumns: number;  // equals rowDimensions.length
+  sourceRowIndices: Map<string, number[]>;  // "outputRow:outputCol" → source indices
+}
+```
+
+### PivotEngine
+
+Transforms flat tabular data into a pivot table with row/column dimensions and aggregated measures.
+
+```ts
+const pivot = new PivotEngine();
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `compute` | `(sourceData: Record<string, unknown>[], config: PivotConfig): PivotResult` | Compute pivot table; throws if `measures` is empty |
+| `getDrillDownRows` | `(sourceData: Record<string, unknown>[], result: PivotResult, outputRow: number, outputCol: number): Record<string, unknown>[]` | Get source rows contributing to a specific output cell |
+
+**Drill-down** uses `sourceRowIndices` from the result to map any output cell back to the original data rows.
+
+---
+
+## Autofill
+
+### Types
+
+```ts
+import {
+  AutofillManager,
+  AutofillManagerConfig,
+  FillDirection,
+  detectPattern,
+  extendPattern,
+  DetectedPattern,
+  PatternType,
+} from '@witqq/spreadsheet';
+
+type FillDirection = 'down' | 'up' | 'right' | 'left';
+
+type PatternType = 'number-sequence' | 'number-increment' | 'date-sequence' | 'text-repeat';
+
+interface DetectedPattern {
+  readonly type: PatternType;
+  readonly step: number;
+  readonly sourceValues: readonly CellValue[];
+}
+```
+
+### AutofillManagerConfig
+
+```ts
+interface AutofillManagerConfig {
+  cellStore: CellStore;
+  dataView: DataView;
+  selectionManager: SelectionManager;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  commandManager: CommandManager;
+  eventBus: EventBus;
+  dirtyTracker: DirtyTracker;
+  renderScheduler: RenderScheduler;
+  container: HTMLElement;
+  rowCount: number;
+  colCount: number;
+  mergeManager?: MergeManager;
+}
+```
+
+### AutofillManager
+
+Handles cell fill-handle drag to extend selection values using detected patterns.
+
+```ts
+const autofill = new AutofillManager(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `attach` | `(scrollContainer: HTMLElement): void` | Bind mousedown/mousemove to container |
+| `detach` | `(): void` | Remove listeners, clean up drag state |
+| `getFillRange` | `(): CellRange \| null` | Current fill preview range |
+| `getFillDirection` | `(): FillDirection \| null` | Current fill direction |
+| `getHandlePosition` | `(): { x: number; y: number } \| null` | Pixel position of fill handle; `null` if no selection |
+| `isOnHandle` | `(offsetX: number, offsetY: number): boolean` | Hit-test within fill handle zone |
+
+**Getter:** `isDragging: boolean`
+
+Fill operations create a `BatchCellEditCommand` (undoable). Emits `autofillStart`, `autofillPreview`, and `autofillComplete` events.
+
+### Pattern Detection Functions
+
+```ts
+function detectPattern(values: readonly CellValue[]): DetectedPattern
+```
+
+Detection priority: number sequence → date sequence → text repeat (fallback).
+
+```ts
+function extendPattern(pattern: DetectedPattern, count: number): CellValue[]
+```
+
+Produces `count` new values continuing the pattern. Number sequences add `step × i`, date sequences add `interval × i`, text repeat cycles through source values.
+
+### Autofill Events
+
+```ts
+interface AutofillStartEvent {
+  sourceRange: CellRange;
+}
+
+interface AutofillPreviewEvent {
+  sourceRange: CellRange;
+  fillRange: CellRange | null;
+  direction: FillDirection | null;
+}
+
+interface AutofillCompleteEvent {
+  sourceRange: CellRange;
+  fillRange: CellRange;
+  direction: FillDirection;
+}
+```
+
+**Internal constant:** `HANDLE_SIZE = 7` (pixel size of fill handle square, not exported from package entry point)
+
+---
+
+## Resize
+
+### ColumnResizeManagerConfig
+
+```ts
+import {
+  ColumnResizeManager,
+  ColumnResizeManagerConfig,
+  ColumnStretchManager,
+  ColumnStretchConfig,
+  StretchMode,
+  RowResizeManager,
+  RowResizeManagerConfig,
+} from '@witqq/spreadsheet';
+
+interface ColumnResizeManagerConfig {
+  layoutEngine: LayoutEngine;
+  gridGeometry: GridGeometry;
+  scrollManager: ScrollManager;
+  commandManager: CommandManager;
+  eventBus: EventBus;
+  columns: ColumnDef[];
+  container: HTMLElement;
+  onResize: () => void;
+}
+```
+
+### ColumnResizeManager
+
+Handles column width resizing by dragging the right border of header cells.
+
+```ts
+const colResize = new ColumnResizeManager(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `attach` | `(scrollContainer: HTMLElement): void` | Attach mousedown/mousemove listeners |
+| `detach` | `(): void` | Remove listeners, clean up |
+| `getResizeColumnAt` | `(offsetX: number, offsetY: number): number` | Column index at mouse position, or `-1` |
+
+**Getter:** `isDragging: boolean`
+
+Creates `ResizeColumnCommand` on drag end. Emits `columnResizeStart`, `columnResize`, `columnResizeEnd`. Respects `minWidth`/`maxWidth` from `ColumnDef`.
+
+### ColumnStretchManager
+
+Distributes remaining container width across columns.
+
+```ts
+import { ColumnStretchManager, ColumnStretchConfig, StretchMode } from '@witqq/spreadsheet';
+
+type StretchMode = 'all' | 'last';
+
+interface ColumnStretchConfig {
+  mode: StretchMode;
+}
+```
+
+```ts
+const stretch = new ColumnStretchManager(config, applyWidths);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `markManualResize` | `(visibleColIndex: number): void` | Exclude column from stretch |
+| `clearManualResizes` | `(): void` | Reset manual resize marks |
+| `calculate` | `(columns: ColumnDef[], containerWidth: number, frozenColumns: number, currentWidths: (colIndex: number) => number): Map<number, number> \| null` | Returns width map or `null` |
+| `recalculate` | `(columns: ColumnDef[], containerWidth: number, frozenColumns: number, currentWidths: (colIndex: number) => number): void` | Calculate then apply |
+| `destroy` | `(): void` | Clear state |
+
+**Getter:** `isDestroyed: boolean`
+
+Mode `'all'` distributes extra space evenly (excluding frozen and manually resized columns). Mode `'last'` gives all remaining space to the last column.
+
+### RowResizeManagerConfig
+
+```ts
+interface RowResizeManagerConfig {
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  commandManager: CommandManager;
+  eventBus: EventBus;
+  container: HTMLElement;
+  onResize: () => void;
+}
+```
+
+### RowResizeManager
+
+Handles row height resizing by dragging the bottom border of row-number cells.
+
+```ts
+const rowResize = new RowResizeManager(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `attach` | `(scrollContainer: HTMLElement): void` | Attach mousedown/mousemove listeners |
+| `detach` | `(): void` | Remove listeners, clean up |
+| `getResizeRowAt` | `(offsetX: number, offsetY: number): number` | Row index at mouse position, or `-1` |
+
+**Getter:** `isDragging: boolean`
+
+Creates `ResizeRowCommand` on drag end. Emits `rowResizeStart`, `rowResize`, `rowResizeEnd`. Clamps height to `[12, 400]`.
+
+### Resize Events
+
+```ts
+interface ColumnResizeEvent {
+  colIndex: number;
+  oldWidth: number;
+  newWidth: number;
+}
+
+interface RowResizeEvent {
+  rowIndex: number;
+  oldHeight: number;
+  newHeight: number;
+}
+```
+
+---
+
+## Tooltip
+
+### TooltipManagerConfig
+
+```ts
+import { TooltipManager, TooltipManagerConfig } from '@witqq/spreadsheet';
+
+interface TooltipManagerConfig {
+  container: HTMLElement;
+  eventBus: EventBus;
+  cellStore: CellStore;
+  dataView: DataView;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  theme: SpreadsheetTheme;
+}
+```
+
+### TooltipManager
+
+Shows error-message tooltips on hover over cells with `metadata.status === 'error'`. Listens for `gridMouseHover` events.
+
+```ts
+const tooltip = new TooltipManager(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setTheme` | `(theme: SpreadsheetTheme): void` | Update theme at runtime |
+| `destroy` | `(): void` | Unsubscribe from events, remove DOM element |
+
+---
+
+## Themes
+
+### SpreadsheetTheme
+
+```ts
+import { SpreadsheetTheme, lightTheme, darkTheme } from '@witqq/spreadsheet';
+
+interface SpreadsheetTheme {
+  name: string;
+  colors: {
+    gridLine: string;
+    background: string;
+    headerBackground: string;
+    headerText: string;
+    headerBorder: string;
+    selectionFill: string;
+    selectionBorder: string;
+    activeCellBorder: string;
+    fillHandle: string;
+    cellText: string;
+    cellBorder: string;
+    cellEditBackground: string;
+    alternateRowBackground: string;
+    hoverRowBackground: string;
+    frozenSeparator: string;
+    scrollbarTrack: string;
+    scrollbarThumb: string;
+    scrollbarThumbHover: string;
+    errorBackground: string;
+    warningBackground: string;
+    changedIndicator: string;
+    savedIndicator: string;
+    cellPlaceholder: string;
+  };
+  fonts: {
+    cell: string;
+    header: string;
+    cellSize: number;
+    headerSize: number;
+  };
+  dimensions: {
+    rowHeight: number;
+    headerHeight: number;
+    minColumnWidth: number;
+    scrollbarWidth: number;
+    cellPadding: number;
+    borderWidth: number;
+    rowNumberWidth: number;
+  };
+  borders: {
+    gridLineWidth: number;
+    selectionWidth: number;
+    activeCellWidth: number;
+    frozenPaneWidth: number;
+  };
+}
+```
+
+### Built-in Themes
+
+```ts
+const lightTheme: SpreadsheetTheme  // name: 'light'
+const darkTheme: SpreadsheetTheme   // name: 'dark'
+```
+
+Both share identical `fonts`, `dimensions`, and `borders`:
+- **fonts:** `cell`/`header` = `'Arial, sans-serif'`, `cellSize`/`headerSize` = `13`
+- **dimensions:** `rowHeight` 28, `headerHeight` 32, `minColumnWidth` 40, `scrollbarWidth` 14, `cellPadding` 4, `borderWidth` 1, `rowNumberWidth` 50
+- **borders:** `gridLineWidth` 1, `selectionWidth` 2, `activeCellWidth` 2, `frozenPaneWidth` 2
+
+---
+
+## Locale
+
+### SpreadsheetLocale
+
+```ts
+import {
+  SpreadsheetLocale,
+  ResolvedLocale,
+  resolveLocale,
+  enLocale,
+  ruLocale,
+} from '@witqq/spreadsheet';
+```
+
+All fields are optional — missing values fall back to English defaults.
+
+```ts
+interface SpreadsheetLocale {
+  formatLocale?: string;  // BCP 47 tag, e.g. 'en-US'
+  contextMenu?: {
+    cut?: string; copy?: string; paste?: string;
+    sortAscending?: string; sortDescending?: string;
+    insertRowAbove?: string; insertRowBelow?: string; deleteRow?: string;
+  };
+  datePicker?: {
+    weekLabels?: [string, string, string, string, string, string, string];
+    monthNames?: [string, string, string, string, string, string,
+                  string, string, string, string, string, string];
+    today?: string; ariaLabel?: string;
+  };
+  dateTimePicker?: {
+    hour?: string; minute?: string; now?: string; ariaLabel?: string;
+  };
+  filter?: {
+    equals?: string; notEquals?: string; contains?: string;
+    startsWith?: string; endsWith?: string;
+    greaterThan?: string; lessThan?: string;
+    greaterOrEqual?: string; lessOrEqual?: string;
+    between?: string; isEmpty?: string; isNotEmpty?: string;
+    valuePlaceholder?: string; toValuePlaceholder?: string;
+    apply?: string; clear?: string;
+  };
+  grouping?: {
+    sum?: string; count?: string; avg?: string; min?: string; max?: string;
+  };
+  emptyState?: { noData?: string };
+  print?: { showingRows?: string };      // template: "{shown} of {total}"
+  aria?: {
+    cellAnnouncement?: string;           // template: "{column}, Row {row}: {value}"
+    cellEmpty?: string;
+    sortCleared?: string; sortAscending?: string; sortDescending?: string;
+    sortedBy?: string;                   // template: "{columns}"
+    filterCleared?: string;
+    filterActive?: string;               // template: "{visible} of {total}"
+  };
+}
+```
+
+### ResolvedLocale
+
+```ts
+type ResolvedLocale = Required<SpreadsheetLocale>;
+```
+
+All optional fields become required — guaranteed no `undefined` values at runtime.
+
+### resolveLocale
+
+```ts
+function resolveLocale(locale?: SpreadsheetLocale): ResolvedLocale
+```
+
+Deep-merges a partial locale over `enLocale` defaults.
+
+### Built-in Locales
+
+```ts
+const enLocale: Required<SpreadsheetLocale>  // formatLocale: 'en-US'
+const ruLocale: Required<SpreadsheetLocale>  // formatLocale: 'ru-RU'
+```
+
+---
+
+## Streaming
+
+### StreamingAdapterOptions
+
+```ts
+import { StreamingAdapter, StreamingAdapterOptions } from '@witqq/spreadsheet';
+
+interface StreamingAdapterOptions {
+  throttleMs?: number;    // batch window in ms (default: 100)
+  columnKeys: string[];   // column keys matching engine column indices
+}
+```
+
+### StreamingAdapter
+
+Bridges external data sources to the spreadsheet engine with throttled batch updates.
+
+```ts
+const stream = new StreamingAdapter(engine, options);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `pushRows` | `(rows: Record<string, unknown>[]): void` | Append rows to end of grid |
+| `updateRow` | `(index: number, data: Record<string, unknown>): void` | Update existing row at logical index |
+| `deleteRow` | `(index: number): void` | Delete row at logical index |
+| `flush` | `(): void` | Immediately flush pending updates |
+| `dispose` | `(): void` | Flush and prevent further scheduling |
+
+**Getter:** `disposed: boolean`
+
+---
+
+## Print
+
+### PrintManagerConfig
+
+```ts
+import { PrintManager, PrintManagerConfig } from '@witqq/spreadsheet';
+
+interface PrintManagerConfig {
+  container: HTMLElement;
+  cellStore: CellStore;
+  dataView: DataView;
+  columns: ColumnDef[];
+  rowStore: RowStore;
+  theme: SpreadsheetTheme;
+  maxPrintRows?: number;  // default: 10000
+}
+```
+
+### PrintManager
+
+Generates a DOM table from visible data and triggers browser print dialog.
+
+```ts
+const print = new PrintManager(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setLocale` | `(locale: ResolvedLocale): void` | Set locale for print labels |
+| `attach` | `(): void` | Inject `@media print` CSS |
+| `detach` | `(): void` | Remove print CSS |
+| `print` | `(): void` | Generate print table, hide canvas, call `window.print()` |
+
+---
+
+## Benchmark
+
+### Types
+
+```ts
+import {
+  BenchmarkRunner,
+  BenchmarkResult,
+  BenchmarkMetric,
+  BenchmarkSuiteResult,
+  FPSCounter,
+  FPSResult,
+  TimingResult,
+  RunStats,
+  measureInitTime,
+  measureMultiRun,
+  measureThroughput,
+  computeStats,
+} from '@witqq/spreadsheet';
+
+interface BenchmarkResult {
+  initTimeMs: number;
+  memoryMB?: number;
+  rowCount: number;
+  columnCount: number;
+}
+
+interface TimingResult {
+  timeMs: number;
+}
+
+interface FPSResult {
+  avgFPS: number;
+  minFPS: number;
+  maxFPS: number;
+  frameCount: number;
+  durationMs: number;
+}
+
+interface RunStats {
+  medianMs: number;
+  meanMs: number;
+  minMs: number;
+  maxMs: number;
+  cv: number;        // coefficient of variation (stddev/mean)
+  runs: number[];
+}
+
+interface BenchmarkMetric {
+  name: string;
+  dataset: string;   // e.g. "1K", "10K"
+  stats: RunStats;
+  unit: string;
+}
+
+interface BenchmarkSuiteResult {
+  timestamp: string;
+  metrics: BenchmarkMetric[];
+}
+```
+
+### Utility Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `measureInitTime` | `(factory: () => void): TimingResult` | Time a synchronous function |
+| `measureMultiRun` | `(fn: () => void, runs?: number): RunStats` | Run N times (+ 1 warmup), return stats |
+| `computeStats` | `(times: number[]): RunStats` | Compute statistical summary from timing array |
+| `measureThroughput` | `(fn: () => void, iterations: number): { opsPerSec: number; totalMs: number }` | Operations per second measurement |
+
+### FPSCounter
+
+```ts
+const fps = new FPSCounter();
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `start` | `(): void` | Reset and begin counting |
+| `tick` | `(): void` | Call on each requestAnimationFrame |
+| `stop` | `(): FPSResult` | Stop and return FPS statistics |
+
+### BenchmarkRunner
+
+```ts
+const runner = new BenchmarkRunner();
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `record` | `(name: string, dataset: string, stats: RunStats, unit?: string): void` | Record a metric |
+| `toJSON` | `(): BenchmarkSuiteResult` | Get all metrics as structured result |
+| `reset` | `(): void` | Clear all collected metrics |
+
+---
+
+## ARIA Accessibility
+
+### AriaManagerConfig
+
+```ts
+import { AriaManager, AriaManagerConfig } from '@witqq/spreadsheet';
+
+interface AriaManagerConfig {
+  container: HTMLElement;
+  scrollContainer: HTMLElement;
+  eventBus: EventBus;
+  cellStore: CellStore;
+  dataView: DataView;
+  columns: ColumnDef[];
+  rowCount: number;
+}
+```
+
+### AriaManager
+
+Provides screen reader support via ARIA attributes and a hidden live region for announcements.
+
+```ts
+const aria = new AriaManager(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setLocale` | `(locale: ResolvedLocale): void` | Set locale for announcements |
+| `attach` | `(): void` | Set ARIA attributes on container, create live region, subscribe to events |
+| `detach` | `(): void` | Remove ARIA attributes, remove live region, unsubscribe |
+| `announce` | `(message: string): void` | Announce message to screen readers |
+| `getLiveRegionText` | `(): string` | Current live region text (for testing) |
+
+Subscribes to `selectionChange`, `sortChange`, `filterChange`, and `cellValidation` events. Announces cell content on selection change using the locale template `"{column}, Row {row}: {value}"`.
+
+---
+
+## Change Tracking
+
+### ChangeTrackerConfig
+
+```ts
+import { ChangeTracker, ChangeTrackerConfig } from '@witqq/spreadsheet';
+
+interface ChangeTrackerConfig {
+  cellStore: CellStore;
+  eventBus: EventBus;
+}
+```
+
+### ChangeTracker
+
+Tracks cell changes relative to a captured baseline, enabling "changed" / "saved" visual indicators.
+
+```ts
+const tracker = new ChangeTracker(config);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `captureBaseline` | `(): void` | Snapshot current cell values as the baseline |
+| `handleCommandExecute` | `(command: Command): void` | Track changes from command execution |
+| `handleCommandUndo` | `(command: Command): void` | Track changes from undo |
+| `handleCommandRedo` | `(command: Command): void` | Track changes from redo |
+| `setCellStatus` | `(row: number, col: number, status: CellMetadata['status'], errorMessage?: string): void` | Set cell metadata status and emit `cellStatusChange` |
+| `getCellStatus` | `(row: number, col: number): CellMetadata['status'] \| undefined` | Get cell status |
+| `getChangedCells` | `(): Array<{ row: number; col: number }>` | All cells changed since baseline |
+| `clearChanges` | `(): void` | Clear all tracked changes |
+
+---
+
+## Auto Row Size
+
+### Types
+
+```ts
+import {
+  AutoRowSizeManager,
+  AutoRowSizeConfig,
+  ApplyHeightsCallback,
+} from '@witqq/spreadsheet';
+
+interface AutoRowSizeConfig {
+  batchSize?: number;      // batch size for async measurement (default: 100)
+  minRowHeight?: number;   // minimum row height (default: 28)
+  cellPadding?: number;    // vertical padding per row (default: 8)
+}
+
+type ApplyHeightsCallback = (updates: Map<number, number>) => void;
+```
+
+### AutoRowSizeManager
+
+Measures cell content height and auto-sizes rows. Supports both synchronous viewport measurement and asynchronous progressive measurement using `requestIdleCallback`.
+
+```ts
+const autoSize = new AutoRowSizeManager(config, applyHeights);
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setLayers` | `(layers: RenderLayer[]): void` | Set render layers for height measurement |
+| `markDirtyRows` | `(rows: Iterable<number>): void` | Mark specific rows for re-measurement |
+| `markAllDirty` | `(): void` | Mark all rows for re-measurement |
+| `clearDirty` | `(): void` | Clear dirty state |
+| `isRowDirty` | `(row: number): boolean` | Check if a specific row needs measurement |
+| `measureViewport` | `(rc: RenderContext, rowStore: RowStore): number` | Measure visible rows synchronously; returns count |
+| `startAsyncMeasurement` | `(totalRows: number, buildRenderContext: (startRow: number, endRow: number) => RenderContext \| null, rowStore: RowStore): void` | Start progressive background measurement |
+| `startDirtyMeasurement` | `(buildRenderContext: (startRow: number, endRow: number) => RenderContext \| null, rowStore: RowStore): void` | Start async measurement for dirty rows only (more efficient than full sweep) |
+| `cancelAsyncMeasurement` | `(): void` | Cancel ongoing async measurement |
+| `destroy` | `(): void` | Cancel measurement, clear state |
+
+**Getters:** `hasDirtyRows: boolean`, `dirtyRowCount: number`, `isAllDirty: boolean`, `isMeasuring: boolean`, `progress: number` (0–1)
+
+---
 
 ## License
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,9 @@ export type {
   IconSetName,
   ComparisonOperator,
   CellChange,
+  CellStyleRef,
+  SelectionType,
+  BorderStyle,
 } from './types/interfaces';
 
 // Events

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -1,100 +1,641 @@
 # @witqq/spreadsheet-plugins
 
-> Official plugins for the witqq Canvas spreadsheet engine.
-
-[![npm version](https://img.shields.io/npm/v/@witqq/spreadsheet-plugins.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-plugins)
-[![license](https://img.shields.io/npm/l/@witqq/spreadsheet-plugins.svg)](https://github.com/witqq/spreadsheet/blob/master/LICENSE)
-
-## Installation
+Plugins for `@witqq/spreadsheet`. Peer dependency on `@witqq/spreadsheet`.
 
 ```bash
 npm install @witqq/spreadsheet-plugins @witqq/spreadsheet
 ```
 
-## Available Plugins
+## Exports
 
-| Plugin | Description |
-|--------|-------------|
-| **Context Menu** | Right-click menu with keyboard navigation and extensible items |
-| **Formula Engine** | Spreadsheet formulas with tokenizer, parser, evaluator, and dependency graph |
-| **Conditional Formatting** | Color gradients, data bars, and icon sets |
-| **Excel I/O** | Import/export Excel files via SheetJS (lazy-loaded) |
-| **Collaboration** | Real-time editing with OT engine and remote cursors |
+### Value Exports (25)
 
-## Usage
+| Export | Kind | Plugin |
+|--------|------|--------|
+| `createContextMenuPlugin` | function | Context Menu |
+| `registerMenuItem` | function | Context Menu |
+| `unregisterMenuItem` | function | Context Menu |
+| `CONTEXT_MENU_PLUGIN_NAME` | `"context-menu"` | Context Menu |
+| `FormulaPlugin` | class | Formula |
+| `FORMULA_PLUGIN_NAME` | `"formula"` | Formula |
+| `evaluateFormula` | function | Formula |
+| `ConditionalFormattingPlugin` | class | Conditional Format |
+| `ConditionalFormatLayer` | class | Conditional Format |
+| `CONDITIONAL_FORMAT_PLUGIN_NAME` | `"conditional-format"` | Conditional Format |
+| `ICON_SETS` | const object | Conditional Format |
+| `toNumber` | function | Conditional Format |
+| `evaluateComparison` | function | Conditional Format |
+| `interpolateColor` | function | Conditional Format |
+| `ExcelPlugin` | class | Excel |
+| `EXCEL_PLUGIN_NAME` | `"excel"` | Excel |
+| `CollaborationPlugin` | class | Collaboration |
+| `otTransform` | function | Collaboration |
+| `transformAgainstAll` | function | Collaboration |
+| `MockTransport` | class | Collaboration |
+| `WebSocketTransport` | class | Collaboration |
+| `RemoteCursorLayer` | class | Collaboration |
+| `ProgressiveLoaderPlugin` | class | Progressive Loader |
+| `ProgressOverlay` | class | Progressive Loader |
+| `PROGRESSIVE_LOADER_PLUGIN_NAME` | `"progressive-loader"` | Progressive Loader |
 
-### Context Menu
+### Type Exports (15)
+
+| Type | Plugin |
+|------|--------|
+| `ContextMenuPluginState` | Context Menu |
+| `ExcelImportResult` | Excel |
+| `ExcelExportOptions` | Excel |
+| `CollaborationPluginConfig` | Collaboration |
+| `TransformResult` | Collaboration |
+| `OTOperation` | Collaboration |
+| `SetCellValueOp` | Collaboration |
+| `InsertRowOp` | Collaboration |
+| `DeleteRowOp` | Collaboration |
+| `VersionedOperation` | Collaboration |
+| `OTTransport` | Collaboration |
+| `WebSocketTransportConfig` | Collaboration |
+| `CursorInfo` | Collaboration |
+| `RemoteCursor` | Collaboration |
+| `ProgressiveLoaderConfig` | Progressive Loader |
+
+---
+
+## Context Menu Plugin
+
+Wraps the built-in `ContextMenuManager` as a `SpreadsheetPlugin`. Provides registration API for other plugins to add custom menu items.
+
+### Registration
 
 ```typescript
 import { createContextMenuPlugin } from '@witqq/spreadsheet-plugins';
+import type { ContextMenuItem } from '@witqq/spreadsheet';
 
-const engine = new WitEngine({ container, columns, data });
-engine.installPlugin(createContextMenuPlugin());
+// Pass initial items at creation (optional)
+const items: ContextMenuItem[] = [
+  { id: 'copy-cell', label: 'Copy', action: (ctx) => { /* ... */ } },
+];
+const plugin = createContextMenuPlugin(items);
+engine.installPlugin(plugin);
 ```
 
-### Formula Engine
+### `createContextMenuPlugin(items?: ContextMenuItem[]): SpreadsheetPlugin`
+
+Factory function. Returns a `SpreadsheetPlugin` with `name: "context-menu"`.
+
+- `items` — optional initial `ContextMenuItem[]` to register on install.
+- On install: registers all initial items via `engine.registerContextMenuItem()`.
+- On destroy: unregisters all tracked items via `engine.unregisterContextMenuItem()`.
+
+### `registerMenuItem(api: PluginAPI, item: ContextMenuItem): void`
+
+Register an additional menu item after plugin installation. Throws `"Context menu plugin is not installed"` if plugin is not installed.
+
+### `unregisterMenuItem(api: PluginAPI, itemId: string): void`
+
+Unregister a menu item by ID. Throws `"Context menu plugin is not installed"` if plugin is not installed.
+
+### `ContextMenuPluginState`
+
+```typescript
+interface ContextMenuPluginState {
+  registeredItems: string[];  // IDs of all registered items
+}
+```
+
+Stored via `api.setPluginState<ContextMenuPluginState>('state', state)`.
+
+---
+
+## Formula Plugin
+
+Spreadsheet formula engine with tokenizer, parser, evaluator, and dependency graph. Supports synchronous evaluation (default) and Web Worker offloading.
+
+### Registration
 
 ```typescript
 import { FormulaPlugin } from '@witqq/spreadsheet-plugins';
 
-const engine = new WitEngine({ container, columns, data });
-engine.installPlugin(new FormulaPlugin());
+// Sync mode (default)
+const plugin = new FormulaPlugin();
+engine.installPlugin(plugin);
 
-// Set a formula
+// Worker mode
+const worker = new Worker(new URL('./formula-worker.js', import.meta.url));
+const plugin = new FormulaPlugin({ worker });
+engine.installPlugin(plugin);
+
+// Set formula — plugin evaluates automatically
 engine.setCellValue(0, 2, '=SUM(A1:B1)');
 ```
 
-### Conditional Formatting
+### `new FormulaPlugin(options?: FormulaPluginOptions)`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `worker` | `Worker` | — | Pre-created Worker for off-main-thread evaluation |
+| `syncOnly` | `boolean` | `false` | Force synchronous mode even if Worker provided |
+
+### Instance Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `isUsingWorker` | `(): boolean` | Whether currently using Web Worker for evaluation |
+| `getDependencyGraph` | `(): DependencyGraph` | Get the dependency graph (sync mode only) |
+
+### Behavior
+
+- Listens to `cellChange`, `commandUndo`, `commandRedo` events on the engine EventBus.
+- When a cell value starts with `=`: tokenizes, parses, extracts dependencies, evaluates, stores result.
+- Circular references detected via `DependencyGraph.setDependencies()` — returns `#REF!`.
+- After evaluation, cascades to all dependent cells in topological order.
+- On undo/redo: full recalculation of all formula cells.
+- Worker mode: falls back to sync on Worker error.
+
+### `evaluateFormula(formula: string, resolver: CellValueResolver): FormulaResult`
+
+Standalone evaluation function. Strips leading `=`, tokenizes, parses, evaluates.
+
+```typescript
+import { evaluateFormula } from '@witqq/spreadsheet-plugins';
+
+const resolver = {
+  getCellValue(row: number, col: number): unknown {
+    return data[row]?.[col] ?? null;
+  },
+};
+const result = evaluateFormula('=SUM(A1:A10)', resolver);
+```
+
+**Return type:** `FormulaResult = number | string | boolean | FormulaError`
+
+### Supported Functions (19)
+
+| Category | Functions |
+|----------|-----------|
+| Math | `SUM`, `AVERAGE`, `COUNT`, `COUNTA`, `MIN`, `MAX`, `ABS`, `ROUND` |
+| Logic | `IF`, `AND`, `OR`, `NOT` |
+| Text | `CONCATENATE`, `LEN`, `UPPER`, `LOWER`, `LEFT`, `RIGHT` |
+| Date | `TODAY` |
+
+**Operators:** `+`, `-`, `*`, `/`, `^`, `&` (concatenation), `=`, `<>`, `<`, `>`, `<=`, `>=`, `%` (percent)
+
+**Cell references:** `A1`, `$A$1` (absolute), `A1:B10` (range)
+
+### Formula Types
+
+```typescript
+interface CellValueResolver {
+  getCellValue(row: number, col: number): unknown;
+}
+
+type FormulaResult = number | string | boolean | FormulaError;
+
+enum FormulaErrorType {
+  REF   = '#REF!',
+  VALUE = '#VALUE!',
+  DIV0  = '#DIV/0!',
+  NAME  = '#NAME?',
+  NUM   = '#NUM!',
+  NULL  = '#NULL!',
+}
+```
+
+> `FormulaError`, `FormulaErrorType`, and other formula internals (`tokenize`, `parse`, `evaluate`, `DependencyGraph`, AST node types) are exported from the formula sub-package but **not** from the top-level barrel. They are available if you import directly from the build output.
+
+---
+
+## Conditional Formatting Plugin
+
+Renders cell backgrounds, data bars, and icon sets based on rules. Uses a custom `RenderLayer` with source-over compositing.
+
+### Registration
 
 ```typescript
 import { ConditionalFormattingPlugin } from '@witqq/spreadsheet-plugins';
 
 const plugin = new ConditionalFormattingPlugin();
 engine.installPlugin(plugin);
-
-plugin.addRule({
-  range: { startRow: 0, startCol: 1, endRow: 99, endCol: 1 },
-  condition: { type: 'gradient', stops: [
-    { value: 0, color: '#ff0000' },
-    { value: 100, color: '#00ff00' },
-  ]},
-});
 ```
 
-### Excel I/O
+### Instance Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `addRule` | `(rule: ConditionalFormatRule): void` | Add a formatting rule |
+| `removeRule` | `(ruleId: string): void` | Remove rule by ID |
+| `clearRules` | `(): void` | Remove all rules |
+| `getRules` | `(): readonly ConditionalFormatRule[]` | Get current rules |
+| `getLayer` | `(): ConditionalFormatLayer \| null` | Get the render layer |
+
+### Static Factory Methods
+
+Four convenience methods that create `ConditionalFormatRule` objects:
+
+#### `ConditionalFormattingPlugin.createValueRule(range, operator, value, bgColor, options?)`
+
+```typescript
+const rule = ConditionalFormattingPlugin.createValueRule(
+  { startRow: 0, startCol: 1, endRow: 99, endCol: 1 },
+  'greaterThan',
+  50,
+  '#c6efce',
+  { textColor: '#006100', priority: 1, stopIfTrue: true, value2: 100 },
+);
+plugin.addRule(rule);
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `range` | `CellRange` | `{ startRow, startCol, endRow, endCol }` |
+| `operator` | `ComparisonOperator` | See operators below |
+| `value` | `number` | Threshold value |
+| `bgColor` | `string` | Background color (hex) |
+| `options.value2` | `number` | Second value for `between`/`notBetween` |
+| `options.priority` | `number` | Rule priority (lower = first) |
+| `options.textColor` | `string` | Text color (hex) |
+| `options.stopIfTrue` | `boolean` | Stop processing subsequent rules |
+
+**`ComparisonOperator`:** `'greaterThan'` | `'lessThan'` | `'greaterThanOrEqual'` | `'lessThanOrEqual'` | `'equal'` | `'notEqual'` | `'between'` | `'notBetween'`
+
+#### `ConditionalFormattingPlugin.createGradientScale(range, stops, options?)`
+
+```typescript
+const rule = ConditionalFormattingPlugin.createGradientScale(
+  { startRow: 0, startCol: 2, endRow: 99, endCol: 2 },
+  [
+    { value: 0, color: '#ff0000' },
+    { value: 50, color: '#ffff00' },
+    { value: 100, color: '#00ff00' },
+  ],
+);
+plugin.addRule(rule);
+```
+
+Renders cells with interpolated background color at 50% opacity.
+
+#### `ConditionalFormattingPlugin.createDataBar(range, color, options?)`
+
+```typescript
+const rule = ConditionalFormattingPlugin.createDataBar(
+  { startRow: 0, startCol: 3, endRow: 99, endCol: 3 },
+  '#3b82f6',
+  { minValue: 0, maxValue: 100, showValue: true },
+);
+plugin.addRule(rule);
+```
+
+Renders horizontal bar at 30% opacity proportional to cell value.
+
+#### `ConditionalFormattingPlugin.createIconSet(range, iconSet, options?)`
+
+```typescript
+const rule = ConditionalFormattingPlugin.createIconSet(
+  { startRow: 0, startCol: 4, endRow: 99, endCol: 4 },
+  'arrows',
+  { showValue: false },
+);
+plugin.addRule(rule);
+```
+
+### `ICON_SETS`
+
+Built-in icon set definitions:
+
+| Set | Icons | Thresholds |
+|-----|-------|------------|
+| `arrows` | `▲` `▶` `▼` | 67, 33, 0 |
+| `circles` | `🟢` `🟡` `🔴` | 67, 33, 0 |
+| `flags` | `🟩` `🟨` `🟥` | 67, 33, 0 |
+| `stars` | `★★★` `★★☆` `★☆☆` `☆☆☆` | 80, 60, 40, 0 |
+
+### Helper Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `toNumber` | `(value: CellValue): number \| null` | Convert cell value to number |
+| `evaluateComparison` | `(cellValue: CellValue, operator: ComparisonOperator, threshold: number, threshold2?: number): boolean` | Evaluate comparison |
+| `interpolateColor` | `(value: number, stops: readonly { value: number; color: string }[]): string` | Interpolate color between stops |
+
+---
+
+## Excel Plugin
+
+Import/export `.xlsx` files via SheetJS (lazy-loaded from CDN on first use).
+
+### Registration
 
 ```typescript
 import { ExcelPlugin } from '@witqq/spreadsheet-plugins';
 
 const plugin = new ExcelPlugin();
 engine.installPlugin(plugin);
-
-// Export
-const blob = await plugin.exportToExcel({ filename: 'data.xlsx' });
-
-// Import
-const result = await plugin.importFromExcel(file);
 ```
 
-### Collaboration
+### `plugin.importExcel(buffer: ArrayBuffer, sheetIndex?: number): Promise<ExcelImportResult>`
+
+Parse `.xlsx` buffer, populate `CellStore`, derive columns from header row.
 
 ```typescript
-import { CollaborationPlugin, WebSocketTransport } from '@witqq/spreadsheet-plugins';
+const file = await fetch('/data.xlsx').then(r => r.arrayBuffer());
+const result = await plugin.importExcel(file);
+// result: { columns: ColumnDef[], rowCount: number, sheetName: string }
+```
 
-const transport = new WebSocketTransport({ url: 'wss://your-server/ws' });
-const plugin = new CollaborationPlugin({ transport });
+- First row treated as header → column titles.
+- Column types inferred from first 10 data rows (`number`, `date`, `boolean`, `string`).
+- Column widths read from `!cols` metadata (clamped to 50–300px).
+- Merged regions preserved via `engine.mergeCells()`.
+- Clears existing `CellStore` data and merges before import.
+
+### `plugin.exportExcel(options?: ExcelExportOptions): Promise<ArrayBuffer>`
+
+Build workbook from `CellStore`, return `.xlsx` ArrayBuffer.
+
+```typescript
+const buffer = await plugin.exportExcel({ sheetName: 'Data', includeHeaders: true });
+const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+```
+
+### `ExcelExportOptions`
+
+```typescript
+interface ExcelExportOptions {
+  sheetName?: string;        // Default: 'Sheet1'
+  includeHeaders?: boolean;  // Default: true
+  maxRows?: number;          // Default: all (browser memory limits apply)
+}
+```
+
+### `ExcelImportResult`
+
+```typescript
+interface ExcelImportResult {
+  columns: ColumnDef[];
+  rowCount: number;
+  sheetName: string;
+}
+```
+
+> **Note:** SheetJS is lazy-loaded from CDN (`https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js`). If `globalThis.XLSX` is already present (e.g., from a `<script>` tag), that instance is reused.
+
+---
+
+## Collaboration Plugin
+
+Real-time collaborative editing via Operational Transformation (OT). Captures local cell edits, transforms against concurrent remote operations, and applies remote changes to `CellStore`.
+
+### Registration
+
+```typescript
+import {
+  CollaborationPlugin,
+  WebSocketTransport,
+  RemoteCursorLayer,
+} from '@witqq/spreadsheet-plugins';
+
+const cursorLayer = new RemoteCursorLayer();
+
+const transport = new WebSocketTransport({
+  url: 'wss://your-server/ws',
+  onInit: ({ clientId, color, revision, cursors }) => { /* ... */ },
+  onCursor: (info) => cursorLayer.setCursor(info.clientId, {
+    clientId: info.clientId,
+    color: info.color,
+    name: info.name,
+    row: info.cursor?.row ?? 0,
+    col: info.cursor?.col ?? 0,
+  }),
+  onLeave: ({ clientId }) => cursorLayer.removeCursor(clientId),
+});
+
+await transport.connect();
+
+const plugin = new CollaborationPlugin({
+  clientId: 'user-123',
+  transport,
+  cursorLayer,
+  sendCursor: (cursor) => transport.sendCursor(cursor),
+});
+
 engine.installPlugin(plugin);
 ```
 
-## Documentation
+### `CollaborationPluginConfig`
 
-Full documentation and live demos: [spreadsheet.witqq.dev](https://spreadsheet.witqq.dev)
+```typescript
+interface CollaborationPluginConfig {
+  clientId: string;
+  transport: OTTransport;
+  cursorLayer?: RemoteCursorLayer;
+  sendCursor?: (cursor: { row: number; col: number } | null) => void;
+}
+```
+
+### `CollaborationPlugin` Instance Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `getPendingCount` | `(): number` | Count of unacknowledged local operations |
+| `getRevision` | `(): number` | Current server revision number |
+
+### OT Operation Types
+
+```typescript
+type OTOperation = SetCellValueOp | InsertRowOp | DeleteRowOp;
+
+interface SetCellValueOp {
+  type: 'setCellValue';
+  row: number;
+  col: number;
+  value: unknown;
+  oldValue?: unknown;
+}
+
+interface InsertRowOp {
+  type: 'insertRow';
+  row: number;
+  count: number;
+}
+
+interface DeleteRowOp {
+  type: 'deleteRow';
+  row: number;
+  count: number;
+}
+
+interface VersionedOperation {
+  clientId: string;
+  revision: number;
+  op: OTOperation;
+}
+```
+
+### OT Transform Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `otTransform` | `(opA: OTOperation, opB: OTOperation): TransformResult` | Transform opA against opB. Returns `[opA', opB']` |
+| `transformAgainstAll` | `(localOp: OTOperation, serverOps: OTOperation[]): OTOperation \| null` | Transform local op against list of server ops |
+
+`TransformResult = [OTOperation | null, OTOperation | null]` — `null` means the operation became a no-op.
+
+Invariant: `apply(apply(state, opA), opB') === apply(apply(state, opB), opA')`
+
+### `OTTransport` Interface
+
+```typescript
+interface OTTransport {
+  send(op: VersionedOperation): void;
+  onReceive(handler: (op: VersionedOperation) => void): void;
+  onAck(handler: (revision: number) => void): void;
+  disconnect(): void;
+}
+```
+
+### `WebSocketTransport`
+
+```typescript
+interface WebSocketTransportConfig {
+  url: string;
+  onInit?: (data: { clientId: string; color: string; revision: number; cursors: CursorInfo[] }) => void;
+  onCursor?: (info: CursorInfo) => void;
+  onJoin?: (info: { clientId: string; color: string; name: string }) => void;
+  onLeave?: (info: { clientId: string }) => void;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `connect` | `(): Promise<void>` | Open WebSocket connection |
+| `send` | `(op: VersionedOperation): void` | Send operation |
+| `sendCursor` | `(cursor: { row: number; col: number } \| null): void` | Send cursor position |
+| `disconnect` | `(): void` | Close connection |
+| `getClientId` | `(): string` | Get assigned client ID |
+
+Server message types: `init`, `op`, `ack`, `cursor`, `join`, `leave`.
+
+### `MockTransport`
+
+For testing. Connects two clients directly without a server.
+
+```typescript
+const [transportA, transportB] = MockTransport.createPair();
+```
+
+### `RemoteCursorLayer`
+
+Render layer that draws colored cell overlays with name labels for remote users.
+
+```typescript
+interface RemoteCursor {
+  clientId: string;
+  color: string;
+  name: string;
+  row: number;
+  col: number;
+}
+```
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setCursor` | `(clientId: string, cursor: RemoteCursor \| null): void` | Set or clear a remote cursor |
+| `removeCursor` | `(clientId: string): void` | Remove a remote cursor |
+| `getCursors` | `(): RemoteCursor[]` | Get all active remote cursors |
+
+### `CursorInfo`
+
+```typescript
+interface CursorInfo {
+  clientId: string;
+  color: string;
+  name: string;
+  cursor: { row: number; col: number } | null;
+}
+```
+
+---
+
+## Progressive Loader Plugin
+
+Non-blocking data loader for large datasets. Loads rows in async chunks using `scheduler.yield()` (Chrome 129+) or `MessageChannel` fallback. CSS progress overlay stays smooth regardless of data size.
+
+### Registration
+
+```typescript
+import { ProgressiveLoaderPlugin } from '@witqq/spreadsheet-plugins';
+
+const plugin = new ProgressiveLoaderPlugin({
+  totalRows: 1_000_000,
+  columnKeys: columns.map(c => c.key),
+  generateRow: (index) => ({
+    id: index,
+    name: `Row ${index}`,
+    value: Math.random() * 1000,
+  }),
+  onProgress: (loaded, total) => console.log(`${loaded}/${total}`),
+  onComplete: (ms) => console.log(`Loaded in ${ms}ms`),
+  chunkBudgetMs: 50,
+});
+
+engine.installPlugin(plugin);
+plugin.start();
+```
+
+### `ProgressiveLoaderConfig`
+
+```typescript
+interface ProgressiveLoaderConfig {
+  totalRows: number;
+  columnKeys: string[];
+  generateRow: (index: number) => Record<string, unknown>;
+  onProgress?: (loaded: number, total: number) => void;
+  onComplete?: (loadTimeMs: number) => void;
+  chunkBudgetMs?: number;  // Default: 50
+}
+```
+
+### Instance Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `start` | `(): void` | Begin progressive loading |
+| `cancel` | `(): void` | Cancel ongoing loading |
+| `getProgress` | `(): number` | Fraction loaded (0–1) |
+| `isLoading` | `(): boolean` | Whether loading is in progress |
+| `getLoadedRows` | `(): number` | Count of rows loaded so far |
+
+### `ProgressOverlay`
+
+DOM-based progress overlay showing percentage, progress bar with shimmer animation, and row count. Mounts into the engine container.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `mount` | `(container: HTMLElement): void` | Mount overlay into container |
+| `setProgress` | `(loaded: number, total: number): void` | Update progress display |
+| `setPhase` | `(phase: 'loading' \| 'processing' \| 'done'): void` | Set display phase |
+| `destroy` | `(): void` | Remove overlay from DOM |
+
+Phases: `loading` (determinate bar + shimmer) → `processing` (indeterminate animation) → `done` (fade out, auto-destroy after 600ms).
+
+Supports light/dark themes via `data-theme="light"` on `<html>`.
+
+---
+
+## Plugin Registration Pattern
+
+All plugins implement `SpreadsheetPlugin`:
+
+```typescript
+interface SpreadsheetPlugin {
+  name: string;
+  version: string;
+  install(api: PluginAPI): void;
+  destroy(): void;
+}
+```
+
+Install via `engine.installPlugin(plugin)`, remove via `engine.removePlugin(pluginName)`.
 
 ## License
 
-Licensed under the [Business Source License 1.1](https://github.com/witqq/spreadsheet/blob/master/LICENSE).
-
-**Free** for non-commercial use (personal, educational, academic, non-commercial open source).
-**Commercial use** requires a paid license — see [spreadsheet.witqq.dev/pricing](https://spreadsheet.witqq.dev/pricing).
-
-Change Date: 2030-03-01 → Apache License 2.0.
+[Business Source License 1.1](https://github.com/witqq/spreadsheet/blob/master/LICENSE). Free for non-commercial use. Commercial use requires a paid license. Change Date: 2030-03-01 → Apache License 2.0.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -11,12 +11,47 @@
 npm install @witqq/spreadsheet-react @witqq/spreadsheet
 ```
 
-**Peer dependencies:** React 18+ or 19+.
+**Peer dependencies:** `react` and `react-dom` — version 18+ or 19+.
+
+## Exports
+
+```ts
+import { Spreadsheet } from '@witqq/spreadsheet-react';
+import type {
+  SpreadsheetProps,
+  SpreadsheetRef,
+  SpreadsheetCallbacks,
+} from '@witqq/spreadsheet-react';
+
+// Re-exported core types (convenience — also available from @witqq/spreadsheet)
+import type {
+  CellData,
+  CellValue,
+  CellStyle,
+  CellType,
+  ColumnDef,
+  Selection,
+  SpreadsheetEvents,
+  SpreadsheetPlugin,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet-react';
+
+// Re-exported event types (convenience — also available from @witqq/spreadsheet)
+import type {
+  CellChangeEvent,
+  SelectionChangeEvent,
+  SortChangeEvent,
+  FilterChangeEvent,
+  ScrollEvent,
+} from '@witqq/spreadsheet-react';
+```
+
+---
 
 ## Quick Start
 
 ```tsx
-import { WitTable } from '@witqq/spreadsheet-react';
+import { Spreadsheet } from '@witqq/spreadsheet-react';
 import type { ColumnDef } from '@witqq/spreadsheet-react';
 
 interface Person {
@@ -38,7 +73,7 @@ const data: Person[] = [
 
 function App() {
   return (
-    <WitTable<Person>
+    <Spreadsheet<Person>
       columns={columns}
       data={data}
       onCellChange={(e) => console.log('Changed:', e)}
@@ -47,57 +82,259 @@ function App() {
 }
 ```
 
-## Props
+---
 
-`WitTableProps<TRow>` extends all `WitEngineConfig` options plus:
+## Spreadsheet Component
+
+The `Spreadsheet` component is a generic `forwardRef` component accepting a row type parameter `TRow`.
+
+```tsx
+<Spreadsheet<TRow> {...props} ref={ref} />
+```
+
+`TRow` defaults to `Record<string, unknown>`. Providing a concrete type enables type-safe data binding.
+
+---
+
+## SpreadsheetProps\<TRow\>
+
+`SpreadsheetProps<TRow>` extends `Omit<SpreadsheetEngineConfig, 'data'>` and `SpreadsheetCallbacks`.
+
+```ts
+interface SpreadsheetProps<TRow extends Record<string, unknown> = Record<string, unknown>>
+  extends Omit<SpreadsheetEngineConfig, 'data'>, SpreadsheetCallbacks {
+  data?: TRow[];
+  className?: string;
+  style?: React.CSSProperties;
+}
+```
+
+### Component-specific props
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `data` | `TRow[]` | Row data array |
-| `columns` | `ColumnDef[]` | Column definitions |
-| `className` | `string` | CSS class for container |
-| `style` | `CSSProperties` | Inline styles for container |
-| `onCellChange` | `(e: CellChangeEvent) => void` | Cell value changed |
-| `onSelectionChange` | `(e: SelectionChangeEvent) => void` | Selection changed |
-| `onSortChange` | `(e: SortChangeEvent) => void` | Sort changed |
-| `onFilterChange` | `(e: FilterChangeEvent) => void` | Filter changed |
+| `data` | `TRow[]` | Row data array (generic over row type) |
+| `className` | `string` | CSS class for the container `<div>` |
+| `style` | `React.CSSProperties` | Inline styles for the container `<div>` |
 
-## Ref API
+### Engine config props (from SpreadsheetEngineConfig)
 
-Use `useRef<WitTableRef>` for imperative access:
+All fields from `SpreadsheetEngineConfig` (except `data`, which is replaced by the generic `TRow[]` version above) are accepted as props. See the core package README for full details. Key props:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `columns` | `ColumnDef[]` | *(required)* | Column definitions |
+| `rowCount` | `number` | `data.length` | Total row count |
+| `width` | `number \| string` | — | Container width |
+| `height` | `number \| string` | — | Container height |
+| `editable` | `boolean` | `false` | Enable inline cell editing |
+| `sortable` | `boolean` | `false` | Enable column header click-to-sort |
+| `frozenRows` | `number` | — | Rows frozen at top |
+| `frozenColumns` | `number` | — | Columns frozen at left |
+| `rowHeight` | `number` | — | Default row height (pixels) |
+| `headerHeight` | `number` | — | Header row height (pixels) |
+| `showGridLines` | `boolean` | `true` | Show grid lines between cells |
+| `showRowNumbers` | `boolean` | `true` | Show row number column |
+| `theme` | `SpreadsheetTheme` | `lightTheme` | Visual theme |
+| `autoRowHeight` | `boolean \| AutoRowSizeConfig` | `false` | Auto-size rows to content |
+| `stretchColumns` | `'all' \| 'last'` | — | Stretch columns to fill container width |
+| `locale` | `SpreadsheetLocale` | English | Locale for UI strings |
+
+### Prop reactivity
+
+| Prop | Reactive | Behavior |
+|------|----------|----------|
+| `theme` | Yes | Calls `engine.setTheme()` on change |
+| `data` | Yes | Clears cell store, bulk-loads new data, updates row count, re-renders |
+| Other engine props | No | Read once at mount; changing them requires remount |
+
+---
+
+## SpreadsheetCallbacks
+
+```ts
+interface SpreadsheetCallbacks {
+  onCellChange?: (event: CellChangeEvent) => void;
+  onSelectionChange?: (event: SelectionChangeEvent) => void;
+  onSortChange?: (event: SortChangeEvent) => void;
+  onFilterChange?: (event: FilterChangeEvent) => void;
+  onScroll?: (event: ScrollEvent) => void;
+  onReady?: () => void;
+}
+```
+
+| Callback | Event Type | Fires when |
+|----------|-----------|------------|
+| `onCellChange` | `CellChangeEvent` | Cell value changes |
+| `onSelectionChange` | `SelectionChangeEvent` | Selection changes |
+| `onSortChange` | `SortChangeEvent` | Sort state changes |
+| `onFilterChange` | `FilterChangeEvent` | Filter state changes |
+| `onScroll` | `ScrollEvent` | Viewport scrolls |
+| `onReady` | *(none)* | Engine initialization completes |
+
+Callbacks are stored in refs internally, so they do not cause re-subscription when the function identity changes.
+
+---
+
+## SpreadsheetRef (Ref API)
+
+Use `useRef<SpreadsheetRef>` for imperative access to the underlying engine.
 
 ```tsx
 import { useRef } from 'react';
-import { WitTable } from '@witqq/spreadsheet-react';
-import type { WitTableRef } from '@witqq/spreadsheet-react';
+import { Spreadsheet } from '@witqq/spreadsheet-react';
+import type { SpreadsheetRef } from '@witqq/spreadsheet-react';
 
 function App() {
-  const tableRef = useRef<WitTableRef>(null);
+  const ref = useRef<SpreadsheetRef>(null);
 
-  const handleClick = () => {
-    const engine = tableRef.current?.getInstance();
-    tableRef.current?.selectCell(0, 0);
+  const handleExport = () => {
+    const engine = ref.current?.getInstance();
+    // use engine API directly
   };
 
-  return <WitTable ref={tableRef} columns={columns} data={data} />;
+  return <Spreadsheet ref={ref} columns={columns} data={data} />;
 }
 ```
 
 ### Ref Methods
 
-| Method | Description |
-|--------|-------------|
-| `getInstance()` | Get underlying `WitEngine` |
-| `focus()` | Focus the table container |
-| `getSelection()` | Get current selection state |
-| `selectCell(row, col)` | Select a cell |
-| `getCell(row, col)` | Get cell data |
-| `setCell(row, col, value)` | Set cell value |
-| `undo()` / `redo()` | Undo/redo commands |
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `getInstance` | `(): SpreadsheetEngine` | Get the underlying `SpreadsheetEngine` instance |
+| `focus` | `(): void` | Focus the container element |
+| `getSelection` | `(): Selection` | Get current selection state |
+| `selectCell` | `(row: number, col: number): void` | Select a cell by row and column index |
+| `getCell` | `(row: number, col: number): CellData \| undefined` | Get cell data at position |
+| `setCell` | `(row: number, col: number, value: CellValue): void` | Set cell value at position |
+| `undo` | `(): void` | Undo the last command |
+| `redo` | `(): void` | Redo the last undone command |
+| `scrollTo` | `(x: number, y: number): void` | Scroll to position |
+| `requestRender` | `(): void` | Force a re-render |
+| `installPlugin` | `(plugin: SpreadsheetPlugin): void` | Install a plugin |
+| `removePlugin` | `(name: string): void` | Remove a plugin by name |
+| `print` | `(): void` | Trigger print dialog |
 
-## Documentation
+Methods throw `Error('Spreadsheet not mounted')` if called before the component mounts (`getInstance`, `getSelection`). Other methods silently no-op via optional chaining.
 
-Full documentation and live demos: [spreadsheet.witqq.dev](https://spreadsheet.witqq.dev)
+---
+
+## TypeScript Generic Row Type
+
+The component accepts a type parameter `TRow` that constrains the `data` prop:
+
+```tsx
+interface Order {
+  id: number;
+  product: string;
+  quantity: number;
+  price: number;
+}
+
+// data prop is typed as Order[]
+<Spreadsheet<Order>
+  columns={orderColumns}
+  data={orders}
+  onCellChange={(e) => {
+    // e is CellChangeEvent
+  }}
+/>
+```
+
+`TRow` must extend `Record<string, unknown>`. If omitted, defaults to `Record<string, unknown>`.
+
+---
+
+## Controlled Data Pattern
+
+When the `data` prop changes (by reference), the component:
+
+1. Clears the internal `CellStore`
+2. Bulk-loads the new data using column keys
+3. Updates the row count
+4. Triggers a re-render
+
+```tsx
+function App() {
+  const [data, setData] = useState<Person[]>(initialData);
+
+  const handleAdd = () => {
+    setData([...data, newRow]);
+  };
+
+  return <Spreadsheet<Person> columns={columns} data={data} />;
+}
+```
+
+---
+
+## Plugin Installation
+
+Plugins can be installed via the ref API or through the engine instance:
+
+```tsx
+import { useRef, useEffect } from 'react';
+import { Spreadsheet } from '@witqq/spreadsheet-react';
+import type { SpreadsheetRef, SpreadsheetPlugin } from '@witqq/spreadsheet-react';
+
+function App() {
+  const ref = useRef<SpreadsheetRef>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.installPlugin(myPlugin);
+    }
+  }, []);
+
+  return <Spreadsheet ref={ref} columns={columns} data={data} />;
+}
+```
+
+---
+
+## Theme Switching
+
+The `theme` prop is reactive. Changing it updates the engine theme without remounting:
+
+```tsx
+import { useState } from 'react';
+import { Spreadsheet } from '@witqq/spreadsheet-react';
+import { lightTheme, darkTheme } from '@witqq/spreadsheet';
+
+function App() {
+  const [theme, setTheme] = useState(lightTheme);
+
+  return (
+    <>
+      <button onClick={() => setTheme(darkTheme)}>Dark</button>
+      <Spreadsheet columns={columns} data={data} theme={theme} />
+    </>
+  );
+}
+```
+
+---
+
+## Re-exported Core Types
+
+The following types are re-exported from `@witqq/spreadsheet` for convenience. They are identical to importing directly from the core package.
+
+**Data types:** `CellData`, `CellValue`, `CellStyle`, `CellType`, `ColumnDef`, `Selection`
+
+**System types:** `SpreadsheetEvents`, `SpreadsheetPlugin`, `SpreadsheetTheme`
+
+**Event types:** `CellChangeEvent`, `SelectionChangeEvent`, `SortChangeEvent`, `FilterChangeEvent`, `ScrollEvent`
+
+---
+
+## Component Lifecycle
+
+1. **Mount:** Engine created with props (excluding callbacks and `className`/`style`). Mounted to container `<div>`. EventBus handlers wired for all callbacks.
+2. **Update `data`:** Cell store cleared, new data bulk-loaded, row count updated, re-render triggered.
+3. **Update `theme`:** `engine.setTheme()` called if theme reference changed.
+4. **Unmount:** All EventBus handlers unsubscribed. Engine destroyed. Ref cleared.
+
+---
 
 ## License
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,128 @@
+# @witqq/spreadsheet-server
+
+WebSocket relay server for real-time OT (Operational Transformation) collaboration. Receives operations from clients, applies server-side transformation, assigns revision numbers, and broadcasts to all connected clients. Also relays cursor position updates.
+
+> **Private package** — not published to npm. Used internally alongside `@witqq/spreadsheet-plugins` `CollaborationPlugin`.
+
+## Quick Start
+
+```bash
+# Start with default port 3151
+npx tsx packages/server/src/index.ts
+
+# Or with custom port
+WIT_COLLAB_PORT=8080 npx tsx packages/server/src/index.ts
+```
+
+The CLI entry auto-detects when run directly (checks `process.argv[1]`) and starts the server.
+
+## Exports
+
+### Value Exports (1)
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `createCollabServer` | function | Create a WebSocket collaboration server |
+
+### Type Exports (2)
+
+| Type | Description |
+|------|-------------|
+| `ClientInfo` | Connected client metadata |
+| `ServerMessage` | Server-to-client message envelope |
+
+## `createCollabServer(port): { wss, close }`
+
+Create and start a WebSocket collaboration server on the given port.
+
+```typescript
+import { createCollabServer } from '@witqq/spreadsheet-server';
+
+const { wss, close } = createCollabServer(3151);
+
+// Later: shut down
+close(); // Disconnects all clients and closes the server
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `port` | `number` | WebSocket server port |
+
+Returns:
+
+```typescript
+{
+  wss: WebSocketServer;  // Underlying ws server instance
+  close: () => void;     // Disconnect all clients and close server
+}
+```
+
+## `ClientInfo`
+
+```typescript
+interface ClientInfo {
+  id: string;                                  // Auto-generated: "client-{timestamp}-{random}"
+  ws: WebSocket;                               // WebSocket connection
+  color: string;                               // Assigned cursor color (from 8-color palette)
+  name: string;                                // Display name: "User {n}"
+  cursor: { row: number; col: number } | null; // Current cursor position
+}
+```
+
+## `ServerMessage`
+
+```typescript
+interface ServerMessage {
+  type: 'op' | 'ack' | 'cursor' | 'join' | 'leave' | 'init';
+  [key: string]: unknown;
+}
+```
+
+### Message Types
+
+| Type | Direction | Description |
+|------|-----------|-------------|
+| `init` | server → client | Sent on connect: `{ clientId, color, revision, cursors }` |
+| `join` | server → others | New client connected: `{ clientId, color, name }` |
+| `leave` | server → others | Client disconnected: `{ clientId }` |
+| `op` | client → server | Submit operation: `{ op: OTOperation, revision: number }` |
+| `op` | server → others | Broadcast transformed operation: `{ clientId, revision, op }` |
+| `ack` | server → client | Acknowledge operation: `{ revision }` |
+| `cursor` | client → server | Update cursor position: `{ cursor: { row, col } \| null }` |
+| `cursor` | server → others | Broadcast cursor update: `{ clientId, color, name, cursor }` |
+
+## Server Behavior
+
+- **OT transformation**: Incoming operations are transformed against all operations since the client's revision using `transform()` from the OT engine.
+- **Revision tracking**: Each accepted operation gets an incremented revision number.
+- **Color assignment**: Clients receive colors from an 8-color palette (cycles on overflow).
+- **Auto-reset**: When the last client disconnects, operation history and revision counter reset.
+- **No-op handling**: If transformation reduces an operation to null, the server sends an ack without broadcasting.
+
+## Integration with CollaborationPlugin
+
+```typescript
+import { SpreadsheetEngine } from '@witqq/spreadsheet';
+import { CollaborationPlugin, WebSocketTransport } from '@witqq/spreadsheet-plugins';
+
+const transport = new WebSocketTransport({ url: 'ws://localhost:3151' });
+const collab = new CollaborationPlugin({ transport });
+
+const engine = new SpreadsheetEngine({
+  columns: [{ key: 'name', title: 'Name', width: 200 }],
+  data: [],
+  plugins: [collab],
+});
+```
+
+See `@witqq/spreadsheet-plugins` README for full `CollaborationPlugin` documentation.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WIT_COLLAB_PORT` | `3151` | Server port (CLI mode only) |
+
+## License
+
+[Business Source License 1.1](https://github.com/witqq/spreadsheet/blob/master/LICENSE). Free for non-commercial use. Change Date: 2030-03-01 → Apache License 2.0.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,6 +1,6 @@
 # @witqq/spreadsheet-vue
 
-Vue 3 wrapper for the witqq Canvas spreadsheet engine.
+> Vue 3 wrapper for the witqq Canvas spreadsheet engine.
 
 ## Installation
 
@@ -8,43 +8,248 @@ Vue 3 wrapper for the witqq Canvas spreadsheet engine.
 npm install @witqq/spreadsheet-vue @witqq/spreadsheet
 ```
 
-## Usage
+**Peer dependency:** `vue` version 3.3+.
+
+## Exports
+
+```ts
+import { Spreadsheet, SpreadsheetEngine, lightTheme, darkTheme } from '@witqq/spreadsheet-vue';
+import type { SpreadsheetExposed } from '@witqq/spreadsheet-vue';
+
+// Re-exported event types (convenience — also available from @witqq/spreadsheet)
+import type {
+  CellChangeEvent,
+  SelectionChangeEvent,
+  SortChangeEvent,
+  FilterChangeEvent,
+  ScrollEvent,
+} from '@witqq/spreadsheet-vue';
+
+// Re-exported core types (convenience — also available from @witqq/spreadsheet)
+import type {
+  CellData,
+  CellValue,
+  CellStyle,
+  CellType,
+  ColumnDef,
+  Selection,
+  SpreadsheetEvents,
+  SpreadsheetPlugin,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet-vue';
+```
+
+---
+
+## Quick Start
 
 ```vue
 <script setup lang="ts">
-import { WitTable } from '@witqq/spreadsheet-vue';
-import type { ColumnDef } from '@witqq/spreadsheet';
+import { Spreadsheet } from '@witqq/spreadsheet-vue';
+import type { ColumnDef } from '@witqq/spreadsheet-vue';
 
 const columns: ColumnDef[] = [
-  { key: 'name', title: 'Name', width: 150 },
-  { key: 'value', title: 'Value', width: 100 },
+  { key: 'name', header: 'Name', width: 150 },
+  { key: 'age', header: 'Age', width: 80, type: 'number' },
+  { key: 'email', header: 'Email', width: 200 },
 ];
 
-const rows = [
-  { name: 'Item 1', value: 100 },
-  { name: 'Item 2', value: 200 },
+const data = [
+  { name: 'Alice', age: 30, email: 'alice@example.com' },
+  { name: 'Bob', age: 25, email: 'bob@example.com' },
 ];
 </script>
 
 <template>
-  <WitTable :columns="columns" :rows="rows" :height="400" />
+  <Spreadsheet
+    :columns="columns"
+    :data="data"
+    :editable="true"
+    @cellChange="(e) => console.log('Changed:', e)"
+  />
 </template>
 ```
 
+---
+
 ## Props
 
-| Prop | Type | Description |
-|------|------|-------------|
-| `columns` | `ColumnDef[]` | Column definitions |
-| `rows` | `TRow[]` | Data rows |
-| `height` | `number` | Container height in pixels |
-| `theme` | `WitTheme` | Theme configuration |
-| `options` | `WitEngineOptions` | Engine options |
+The component accepts engine configuration props via `v-bind`:
 
-## Documentation
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `columns` | `ColumnDef[]` | Yes | — | Column definitions |
+| `data` | `Record<string, unknown>[]` | No | — | Row data array |
+| `rowCount` | `number` | No | `data.length` | Total row count |
+| `theme` | `SpreadsheetTheme` | No | `lightTheme` | Visual theme |
+| `frozenRows` | `number` | No | — | Rows frozen at top |
+| `frozenColumns` | `number` | No | — | Columns frozen at left |
+| `editable` | `boolean` | No | `false` | Enable inline cell editing |
+| `sortable` | `boolean` | No | `false` | Enable column header click-to-sort |
+| `showGridLines` | `boolean` | No | `true` | Show grid lines between cells |
+| `showRowNumbers` | `boolean` | No | `true` | Show row number column |
+| `rowHeight` | `number` | No | — | Default row height (pixels) |
+| `headerHeight` | `number` | No | — | Header row height (pixels) |
+| `width` | `number \| string` | No | — | Container width |
+| `height` | `number \| string` | No | — | Container height |
 
-Full documentation: https://spreadsheet.witqq.dev/frameworks/vue
+### Prop reactivity
+
+| Prop | Reactive | Behavior |
+|------|----------|----------|
+| `theme` | Yes | Calls `engine.setTheme()` on change |
+| `data` | Yes | Clears cell store, bulk-loads new data, updates row count, re-renders |
+| Other props | No | Read once at mount |
+
+---
+
+## Events
+
+Events are emitted via Vue's `emit` and can be listened to with `@eventName` or `v-on:eventName`:
+
+| Event | Payload Type | Description |
+|-------|-------------|-------------|
+| `cellChange` | `CellChangeEvent` | Cell value changes |
+| `selectionChange` | `SelectionChangeEvent` | Selection changes |
+| `sortChange` | `SortChangeEvent` | Sort state changes |
+| `filterChange` | `FilterChangeEvent` | Filter state changes |
+| `scroll` | `ScrollEvent` | Viewport scrolls |
+| `ready` | *(none)* | Engine initialization completes |
+
+```vue
+<template>
+  <Spreadsheet
+    :columns="columns"
+    :data="data"
+    @cellChange="onCellChange"
+    @selectionChange="onSelectionChange"
+    @ready="onReady"
+  />
+</template>
+```
+
+---
+
+## SpreadsheetExposed (Template Ref API)
+
+Access the underlying engine via template refs:
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Spreadsheet } from '@witqq/spreadsheet-vue';
+import type { SpreadsheetExposed } from '@witqq/spreadsheet-vue';
+
+const spreadsheetRef = ref<InstanceType<typeof Spreadsheet> & SpreadsheetExposed>();
+
+function handleExport() {
+  const engine = spreadsheetRef.value?.getInstance();
+  // use engine API directly
+}
+</script>
+
+<template>
+  <Spreadsheet ref="spreadsheetRef" :columns="columns" :data="data" />
+</template>
+```
+
+### Exposed Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `getInstance` | `(): SpreadsheetEngine` | Get the underlying engine instance |
+| `focus` | `(): void` | Focus the container element |
+| `getSelection` | `(): Selection` | Get current selection state |
+| `selectCell` | `(row: number, col: number): void` | Select a cell |
+| `getCell` | `(row: number, col: number): CellData \| undefined` | Get cell data at position |
+| `setCell` | `(row: number, col: number, value: CellValue): void` | Set cell value at position |
+| `undo` | `(): void` | Undo the last command |
+| `redo` | `(): void` | Redo the last undone command |
+| `scrollTo` | `(x: number, y: number): void` | Scroll to position |
+| `requestRender` | `(): void` | Force a re-render |
+| `installPlugin` | `(plugin: SpreadsheetPlugin): void` | Install a plugin |
+| `removePlugin` | `(name: string): void` | Remove a plugin by name |
+| `print` | `(): void` | Trigger print dialog |
+
+`getInstance` and `getSelection` throw `Error('Spreadsheet not mounted')` if called before mount. Other methods silently no-op.
+
+---
+
+## Theme Switching
+
+The `theme` prop is reactive. Changing it updates the engine theme without remounting:
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Spreadsheet, lightTheme, darkTheme } from '@witqq/spreadsheet-vue';
+
+const currentTheme = ref(lightTheme);
+</script>
+
+<template>
+  <button @click="currentTheme = darkTheme">Dark</button>
+  <Spreadsheet :columns="columns" :data="data" :theme="currentTheme" />
+</template>
+```
+
+---
+
+## Controlled Data Pattern
+
+When the `data` prop changes, the component:
+
+1. Clears the internal `CellStore`
+2. Bulk-loads the new data using column keys
+3. Updates the row count
+4. Triggers a re-render
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Spreadsheet } from '@witqq/spreadsheet-vue';
+
+const data = ref([{ name: 'Alice', age: 30 }]);
+
+function addRow() {
+  data.value = [...data.value, { name: 'Bob', age: 25 }];
+}
+</script>
+
+<template>
+  <button @click="addRow">Add</button>
+  <Spreadsheet :columns="columns" :data="data" />
+</template>
+```
+
+---
+
+## Re-exported Values and Types
+
+**Values:** `SpreadsheetEngine`, `lightTheme`, `darkTheme` — re-exported from `@witqq/spreadsheet` for convenience.
+
+**Data types:** `CellData`, `CellValue`, `CellStyle`, `CellType`, `ColumnDef`, `Selection`
+
+**System types:** `SpreadsheetEvents`, `SpreadsheetPlugin`, `SpreadsheetTheme`
+
+**Event types:** `CellChangeEvent`, `SelectionChangeEvent`, `SortChangeEvent`, `FilterChangeEvent`, `ScrollEvent`
+
+---
+
+## Component Lifecycle
+
+1. **Mount (`onMounted`):** Engine created with props, mounted to container `<div>`. EventBus handlers wired for all emits.
+2. **Watch `data`:** Cell store cleared, new data bulk-loaded, row count updated, re-render triggered.
+3. **Watch `theme`:** `engine.setTheme()` called if theme reference changed.
+4. **Unmount (`onUnmounted`):** All EventBus handlers unsubscribed. Engine destroyed.
+
+---
 
 ## License
 
-BSL 1.1 — see [LICENSE](./LICENSE)
+Licensed under the [Business Source License 1.1](https://github.com/witqq/spreadsheet/blob/master/LICENSE).
+
+**Free** for non-commercial use (personal, educational, academic, non-commercial open source).
+**Commercial use** requires a paid license — see [spreadsheet.witqq.dev/pricing](https://spreadsheet.witqq.dev/pricing).
+
+Change Date: 2030-03-01 → Apache License 2.0.

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -1,46 +1,130 @@
 # @witqq/spreadsheet-widget
 
-Embeddable spreadsheet widget — single IIFE/UMD bundle with zero framework dependencies.
-
-## Installation
+Embeddable spreadsheet widget — single IIFE/UMD bundle with zero framework dependencies. No build step required.
 
 ```bash
 npm install @witqq/spreadsheet-widget
 ```
 
-Or use from CDN:
+Or load via script tag:
 
 ```html
 <script src="https://unpkg.com/@witqq/spreadsheet-widget"></script>
 ```
 
-## Usage
+The UMD build exposes a global `Spreadsheet` object (configured in vite as `name: 'Spreadsheet'`).
+
+## Exports
+
+### Value Exports (5)
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `create` | function | Create and mount a spreadsheet in a container |
+| `embed` | function | Create a spreadsheet with a destroy handle |
+| `SpreadsheetEngine` | class | Re-exported from `@witqq/spreadsheet` |
+| `lightTheme` | object | Re-exported from `@witqq/spreadsheet` |
+| `darkTheme` | object | Re-exported from `@witqq/spreadsheet` |
+
+### Type Exports (7)
+
+| Type | Source |
+|------|--------|
+| `WidgetConfig` | Local — extends `SpreadsheetEngineConfig` |
+| `SpreadsheetEngineConfig` | Re-exported from `@witqq/spreadsheet` |
+| `ColumnDef` | Re-exported from `@witqq/spreadsheet` |
+| `CellData` | Re-exported from `@witqq/spreadsheet` |
+| `CellValue` | Re-exported from `@witqq/spreadsheet` |
+| `Selection` | Re-exported from `@witqq/spreadsheet` |
+| `CellAddress` | Re-exported from `@witqq/spreadsheet` |
+
+## `create(container, config): SpreadsheetEngine`
+
+Create a spreadsheet inside the given container. Returns the `SpreadsheetEngine` instance.
+
+```typescript
+import { create } from '@witqq/spreadsheet-widget';
+
+const engine = create('#spreadsheet', {
+  columns: [
+    { key: 'name', title: 'Name', width: 150 },
+    { key: 'value', title: 'Value', width: 100 },
+  ],
+  data: [
+    { name: 'Item 1', value: 100 },
+    { name: 'Item 2', value: 200 },
+  ],
+  height: 400,
+});
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `container` | `HTMLElement \| string` | DOM element or CSS selector |
+| `config` | `WidgetConfig` | Engine configuration |
+
+Throws `"Spreadsheet.create: container not found"` if the container element cannot be resolved.
+
+## `embed(container, config): { engine, destroy }`
+
+Convenience wrapper around `create()` that returns a handle with `destroy()`.
+
+```typescript
+import { embed } from '@witqq/spreadsheet-widget';
+
+const { engine, destroy } = embed('#spreadsheet', {
+  columns: [{ key: 'id', title: 'ID', width: 80 }],
+  data: [],
+});
+
+// Later: clean up
+destroy();
+```
+
+Returns `{ engine: SpreadsheetEngine, destroy: () => void }`.
+
+## `WidgetConfig`
+
+```typescript
+interface WidgetConfig extends SpreadsheetEngineConfig {
+  autoMount?: boolean;  // Default: true
+}
+```
+
+When `autoMount` is `true` (default), the engine mounts into the container immediately. Set to `false` to defer mounting.
+
+## Script Tag Usage
 
 ```html
-<div id="spreadsheet"></div>
+<div id="grid" style="width: 800px; height: 400px"></div>
+<script src="https://unpkg.com/@witqq/spreadsheet-widget"></script>
 <script>
-  WitTable.create(document.getElementById('spreadsheet'), {
+  const engine = Spreadsheet.create(document.getElementById('grid'), {
     columns: [
-      { key: 'name', title: 'Name', width: 150 },
-      { key: 'value', title: 'Value', width: 100 },
+      { key: 'name', title: 'Name', width: 200 },
+      { key: 'age', title: 'Age', width: 100, type: 'number' },
     ],
-    rows: [
-      { name: 'Item 1', value: 100 },
-      { name: 'Item 2', value: 200 },
+    data: [
+      { name: 'Alice', age: 30 },
+      { name: 'Bob', age: 25 },
     ],
-    height: 400,
+    theme: Spreadsheet.lightTheme,
   });
 </script>
 ```
 
-## Bundle Size
+Global `Spreadsheet` exposes: `create`, `embed`, `SpreadsheetEngine`, `lightTheme`, `darkTheme`.
 
-< 36KB gzipped, includes `@witqq/spreadsheet`.
+## Build Output
 
-## Documentation
+| File | Format | Description |
+|------|--------|-------------|
+| `dist/witqq-spreadsheet-widget.js` | ES module | For bundlers and `type="module"` scripts |
+| `dist/witqq-spreadsheet-widget.umd.cjs` | UMD/IIFE | For `<script>` tags, exposes `Spreadsheet` global |
+| `dist/index.d.ts` | TypeScript | Rolled-up type declarations |
 
-Full documentation: https://spreadsheet.witqq.dev/frameworks/widget
+The bundle includes `@witqq/spreadsheet` — no external dependencies required.
 
 ## License
 
-BSL 1.1 — see [LICENSE](./LICENSE)
+[Business Source License 1.1](https://github.com/witqq/spreadsheet/blob/master/LICENSE). Free for non-commercial use. Change Date: 2030-03-01 → Apache License 2.0.


### PR DESCRIPTION
## Summary

Add self-contained API reference READMEs to all 7 packages for LLM/agent consumption directly from node_modules without internet access.

## Changes

### Package Documentation (325/325 exports documented)

| Package | Lines | Exports |
|---------|-------|---------|
| core | 2,866 | 220/220 |
| react | 346 | 18/18 |
| vue | 255 | 19/19 |
| angular | 231 | 13/13 |
| plugins | 641 | 40/40 |
| widget | 130 | 12/12 |
| server | 128 | 3/3 |
| root | 119 | navigation hub |
| **Total** | **4,716** | **325/325** |

### What each README includes
- Installation instructions
- Complete exports table with all value and type exports
- TypeScript signatures with parameter descriptions and return types
- Usage examples (383 code blocks total)
- Configuration options
- Integration patterns

### Source code changes
- Added 3 missing type re-exports to core: CellStyleRef, SelectionType, BorderStyle

### Root README
- Rewritten as LLM navigation hub with package decision tree and API overview table

### Project docs
- Updated CHANGELOG and CHECKLIST for package README maintenance