### PR TITLE
docs: audit and document all 224 public API exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ function App() {
 
 | Package | Path | npm | Description |
 |---------|------|-----|-------------|
-| [`@witqq/spreadsheet`](packages/core/README.md) | `packages/core/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet.svg)](https://www.npmjs.com/package/@witqq/spreadsheet) | Canvas engine — rendering, editing, selection, data model, commands, theming, localization. 220 exports. |
+| [`@witqq/spreadsheet`](packages/core/README.md) | `packages/core/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet.svg)](https://www.npmjs.com/package/@witqq/spreadsheet) | Canvas engine — rendering, editing, selection, data model, commands, theming, localization. 224 exports. |
 | [`@witqq/spreadsheet-react`](packages/react/README.md) | `packages/react/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet-react.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-react) | React wrapper component. 18 exports. |
 | [`@witqq/spreadsheet-vue`](packages/vue/README.md) | `packages/vue/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet-vue.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-vue) | Vue 3 wrapper component. 19 exports. |
 | [`@witqq/spreadsheet-angular`](packages/angular/README.md) | `packages/angular/` | [![npm](https://img.shields.io/npm/v/@witqq/spreadsheet-angular.svg)](https://www.npmjs.com/package/@witqq/spreadsheet-angular) | Angular wrapper component. 13 exports. |
@@ -63,7 +63,7 @@ All framework wrappers re-export core types (`ColumnDef`, `CellData`, `Spreadshe
 
 ## Core API Overview
 
-The core package (`@witqq/spreadsheet`) provides `SpreadsheetEngine` — the main class that manages the entire spreadsheet lifecycle. See [packages/core/README.md](packages/core/README.md) for the full 220-export API reference.
+The core package (`@witqq/spreadsheet`) provides `SpreadsheetEngine` — the main class that manages the entire spreadsheet lifecycle. See [packages/core/README.md](packages/core/README.md) for the full 224-export API reference.
 
 Key areas:
 

--- a/docs/DOCUMENTATION-STYLE-GUIDE.md
+++ b/docs/DOCUMENTATION-STYLE-GUIDE.md
@@ -24,28 +24,58 @@
 | Code examples | TypeScript internals     | React/Vue/Angular integration |
 | Format        | Markdown + TypeDoc       | MDX with interactive demos    |
 
-## Mandatory: Keep Site Docs in Sync with Code
+## Mandatory: Keep All Documentation in Sync with Code
 
-When adding, changing, or removing **public API functions, interfaces, config options, or user-visible behavior**:
+When adding, changing, or removing **public API functions, interfaces, config options, or user-visible behavior**, update **both** the site docs and the relevant npm package README:
+
+### Site Docs
 
 1. Update the relevant guide in `packages/site/src/content/docs/guides/`
 2. Update `packages/site/src/content/docs/api/` if types or engine API changed
 3. Add or update interactive demo components in `packages/site/src/components/demos/` if the feature is visual
 
-### What Triggers a Site Docs Update
+### npm Package READMEs
 
-| Code Change | Required Site Update |
-|---|---|
-| New `SpreadsheetEngineConfig` option | `api/wit-engine.mdx` + relevant guide |
-| New column type or `CellType` | `api/cell-types.mdx` |
-| New public interface/type | `api/types.mdx` |
-| New editing behavior | `guides/editing.mdx` |
-| New context menu feature | `guides/context-menu.mdx` |
-| New plugin capability | `plugins/` section |
-| Changed keyboard shortcuts | Relevant guide |
-| New framework wrapper API | `frameworks/` section |
+4. Update `packages/core/README.md` if core API changed — every exported class, function, interface, and type must have a README entry
+5. Update the relevant wrapper README (`packages/react/README.md`, `packages/vue/README.md`, etc.) if wrapper API changed
+6. Update `packages/plugins/README.md` if plugin API changed
 
-### What Does NOT Require Site Update
+### Code-Change-to-Documentation Mapping
+
+| Code Change | Site Docs Update | README Update |
+|---|---|---|
+| New `SpreadsheetEngineConfig` option | `api/wit-engine.mdx` + relevant guide | `packages/core/README.md` Configuration section |
+| New column type or `CellType` | `api/cell-types.mdx` | `packages/core/README.md` Cell Types section |
+| New public interface/type | `api/types.mdx` | `packages/core/README.md` Types section |
+| New editing behavior | `guides/editing.mdx` | `packages/core/README.md` if public API |
+| New context menu feature | `guides/context-menu.mdx` | `packages/core/README.md` if public API |
+| New plugin capability | `plugins/` section | `packages/plugins/README.md` |
+| Changed keyboard shortcuts | Relevant guide | — |
+| New framework wrapper API | `frameworks/` section | Wrapper package README |
+| New style property or type | `api/types.mdx` + `guides/styling.mdx` (create if missing) | `packages/core/README.md` Styling section |
+| New decorator API method | `api/cell-types.mdx` + `guides/decorators.mdx` (create if missing) | `packages/core/README.md` Decorators section |
+
+### Examples Requirement
+
+Every documented API (site docs and READMEs) must include at least one working code example demonstrating typical usage. Examples must:
+
+- Use real API names from current source code
+- Be self-contained (reader can copy-paste and run)
+- Show the import path when relevant
+
+### Sync Checklist
+
+Before merging any PR that touches public API:
+
+- [ ] Every new export in `packages/core/src/index.ts` has a corresponding site docs entry
+- [ ] Every new export has a corresponding core README entry
+- [ ] Every new export has TSDoc comments in source
+- [ ] Code examples in docs match current API signatures
+- [ ] Wrapper/plugin READMEs updated if their API changed
+- [ ] Demo components updated if the feature is visual
+- [ ] Site builds clean (`npm run build` in `packages/site/`)
+
+### What Does NOT Require Documentation Update
 
 - Internal refactoring with no API change
 - Test additions
@@ -62,10 +92,12 @@ All public interfaces, types, and functions exported from `packages/core/src/ind
  * When enabled, row heights adjust to fit wrapped text content.
  */
 export interface AutoRowSizeConfig {
-  /** Number of rows to measure per idle callback batch. Default: 50 */
+  /** Batch size for off-screen async measurement. Default: 100. */
   batchSize?: number;
-  /** Minimum row height in pixels. Default: 24 */
+  /** Minimum row height (prevents rows from collapsing). Default: the grid's default row height. */
   minRowHeight?: number;
+  /** Vertical padding to add to measured height per row. Default: 8. */
+  cellPadding?: number;
 }
 ```
 
@@ -97,9 +129,12 @@ Complex algorithms require inline comments explaining "why", not "what":
 
 ```
 docs/
-  api/                  # TypeDoc generated API reference
-  CHECKLIST.md          # Quality checklist for PRs
+  api/                          # TypeDoc generated API reference
+  ARCHITECTURE.md               # System architecture overview
+  CHECKLIST.md                  # Quality checklist for PRs
   DOCUMENTATION-STYLE-GUIDE.md  # This file
+  SCREENSHOT-VALIDATION-GUIDE.md # Visual regression testing guide
+  TESTING-GUIDE.md              # Testing practices and patterns
 
 packages/site/src/content/docs/
   api/                  # Public API reference (MDX)

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -210,6 +210,10 @@ export class AppComponent {
 
 **System types:** `SpreadsheetEvents`, `SpreadsheetPlugin`, `SpreadsheetTheme`
 
+Event payload types are not re-exported. Import them from `@witqq/spreadsheet`.
+
+For per-cell styling (`CellStyleRef`, `BorderStyle`, `StylePool`) and cell decorators (`CellDecorator`, `CellDecoratorRegistration`), import directly from `@witqq/spreadsheet` and use via the engine instance from `@ViewChild` `getInstance()`.
+
 ---
 
 ## Component Lifecycle

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -622,7 +622,13 @@ Maps `CellType` identifiers to render and format functions. Built-in types: `str
 
 ```typescript
 import { CellTypeRegistry } from '@witqq/spreadsheet';
-import type { CellTypeRenderer, CellAlignment } from '@witqq/spreadsheet';
+import type {
+  CellTypeRenderer,
+  CellAlignment,
+  CellDecorator,
+  CellDecoratorPosition,
+  CellDecoratorRegistration,
+} from '@witqq/spreadsheet';
 
 interface CellTypeRenderer {
   format(value: CellValue): string;            // Format value for text display
@@ -645,6 +651,24 @@ interface CellTypeRenderer {
     width: number, height: number,
     theme?: SpreadsheetTheme,
   ) => HitZone[];
+}
+
+// Decorator position relative to cell content
+type CellDecoratorPosition = 'left' | 'right' | 'overlay' | 'underlay';
+
+// Composable rendering addon for cells
+interface CellDecorator {
+  readonly id: string;
+  readonly position: CellDecoratorPosition;
+  getWidth?(cellData: CellData, cellHeight: number, ctx?: CanvasRenderingContext2D, theme?: SpreadsheetTheme): number;
+  render(ctx: CanvasRenderingContext2D, cellData: CellData, x: number, y: number, width: number, height: number, theme: SpreadsheetTheme): void;
+  getHitZones?(width: number, height: number, cellData: CellData): HitZone[];
+}
+
+// Registration binding a decorator to specific cells
+interface CellDecoratorRegistration {
+  decorator: CellDecorator;
+  appliesTo: (row: number, col: number, cellData: CellData) => boolean;
 }
 ```
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -212,6 +212,7 @@ Renders cell backgrounds, data bars, and icon sets based on rules. Uses a custom
 
 ```typescript
 import { ConditionalFormattingPlugin } from '@witqq/spreadsheet-plugins';
+import type { ConditionalFormatRule } from '@witqq/spreadsheet';
 
 const plugin = new ConditionalFormattingPlugin();
 engine.installPlugin(plugin);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -325,6 +325,8 @@ The following types are re-exported from `@witqq/spreadsheet` for convenience. T
 
 **Event types:** `CellChangeEvent`, `SelectionChangeEvent`, `SortChangeEvent`, `FilterChangeEvent`, `ScrollEvent`
 
+For per-cell styling (`CellStyleRef`, `BorderStyle`, `StylePool`) and cell decorators (`CellDecorator`, `CellDecoratorRegistration`), import directly from `@witqq/spreadsheet` and use via the engine instance from `ref.current?.getInstance()`.
+
 ---
 
 ## Component Lifecycle

--- a/packages/site/astro.config.mjs
+++ b/packages/site/astro.config.mjs
@@ -55,6 +55,8 @@ export default defineConfig({
             { label: 'Column & Row Resize', slug: 'guides/resize' },
             { label: 'Auto Row Height', slug: 'guides/auto-row-height' },
             { label: 'Text Wrapping', slug: 'guides/text-wrapping' },
+            { label: 'Per-Cell Styling', slug: 'guides/styling' },
+            { label: 'Cell Decorators', slug: 'guides/decorators' },
             { label: 'Column Stretch', slug: 'guides/column-stretch' },
             { label: 'Autofill', slug: 'guides/autofill' },
             { label: 'Change Tracking', slug: 'guides/change-tracking' },

--- a/packages/site/src/content/docs/api/types.mdx
+++ b/packages/site/src/content/docs/api/types.mdx
@@ -946,3 +946,426 @@ interface CustomRule {
 ```
 
 Validation rule with a user-supplied validation function.
+
+## Editor Types
+
+### CellEditorClose
+
+```typescript
+type CellEditorClose = (reason: EditorCloseReason) => void;
+```
+
+Callback to close an active cell editor with a specified reason.
+
+### CellEditorMatcher
+
+```typescript
+type CellEditorMatcher = (column: ColumnDef, value: CellValue) => boolean;
+```
+
+Predicate that determines whether a custom cell editor applies to a given column and value.
+
+### CellEditorRegistration
+
+```typescript
+interface CellEditorRegistration {
+  editor: CellEditor;
+  matcher: CellEditorMatcher;
+  priority: number;
+}
+```
+
+Links a `CellEditor` to a matcher predicate. Higher `priority` values take precedence when multiple editors match.
+
+### DatePickerConfig
+
+```typescript
+interface DatePickerConfig {
+  container: HTMLElement;
+  scrollContainer: HTMLElement;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  theme: SpreadsheetTheme;
+  onCommit: (row: number, col: number, oldValue: CellValue, newValue: CellValue) => void;
+  onClose: (reason: EditorCloseReason) => void;
+  frozenRows?: number;
+  frozenColumns?: number;
+}
+```
+
+Configuration for `DatePickerOverlay`. Requires DOM containers, layout references, and commit/close callbacks.
+
+## Conditional Format Types
+
+### ConditionalFormatCondition
+
+```typescript
+type ConditionalFormatCondition =
+  | ValueCondition
+  | GradientScaleCondition
+  | DataBarCondition
+  | IconSetCondition;
+```
+
+Union of all supported conditional format condition types.
+
+### ConditionalFormatRule
+
+```typescript
+interface ConditionalFormatRule {
+  readonly id: string;
+  readonly priority: number;
+  readonly range: CellRange;
+  readonly condition: ConditionalFormatCondition;
+  readonly style?: Partial<CellStyle>;
+  readonly stopIfTrue?: boolean;
+}
+```
+
+A conditional formatting rule applied to a cell range. Rules are evaluated in `priority` order. When `stopIfTrue` is set, lower-priority rules are skipped if this rule matches.
+
+## Sort & Stretch Types
+
+### SortDirection
+
+```typescript
+type SortDirection = 'asc' | 'desc';
+```
+
+Sort order for column sorting.
+
+### StretchMode
+
+```typescript
+type StretchMode = 'all' | 'last';
+```
+
+Column stretch strategy: `all` distributes extra width across all columns; `last` assigns it to the last column.
+
+## Additional Config Types
+
+### ChangeTrackerConfig
+
+```typescript
+interface ChangeTrackerConfig {
+  cellStore: CellStore;
+  eventBus: EventBus;
+}
+```
+
+Configuration for `ChangeTracker`. Requires access to cell store and event bus.
+
+### CellChange
+
+```typescript
+interface CellChange {
+  readonly row: number;
+  readonly col: number;
+  readonly oldValue: CellValue;
+  readonly newValue: CellValue;
+  readonly timestamp: number;
+  readonly userId?: string;
+  readonly source: string;
+}
+```
+
+Record of a single cell value change. Used by `ChangeTracker` for audit trails and collaboration conflict resolution.
+
+### ColumnStretchConfig
+
+```typescript
+interface ColumnStretchConfig {
+  mode: StretchMode;
+}
+```
+
+Configuration for column stretch behavior.
+
+### FilterPanelConfig
+
+```typescript
+interface FilterPanelConfig {
+  container: HTMLElement;
+  scrollContainer: HTMLElement;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  theme: SpreadsheetTheme;
+  onApply: (col: number, operator: FilterOperator, value: string, valueTo?: string) => void;
+  onClear: (col: number) => void;
+}
+```
+
+Configuration for the filter panel overlay.
+
+### FrozenPaneConfig
+
+```typescript
+interface FrozenPaneConfig {
+  frozenRows: number;
+  frozenColumns: number;
+  layoutEngine: LayoutEngine;
+  frozenRanges: FrozenViewportRanges;
+}
+```
+
+Configuration for frozen pane rendering regions.
+
+### TooltipManagerConfig
+
+```typescript
+interface TooltipManagerConfig {
+  container: HTMLElement;
+  eventBus: EventBus;
+  cellStore: CellStore;
+  dataView: DataView;
+  layoutEngine: LayoutEngine;
+  scrollManager: ScrollManager;
+  theme: SpreadsheetTheme;
+}
+```
+
+Configuration for the tooltip manager.
+
+## Rendering & Layer Classes
+
+### AutoRowSizeManager
+
+```typescript
+class AutoRowSizeManager {
+  constructor(config: AutoRowSizeConfig, applyHeights: ApplyHeightsCallback);
+  setLayers(layers: RenderLayer[]): void;
+  markDirtyRows(rows: Iterable<number>): void;
+  markAllDirty(): void;
+  clearDirty(): void;
+}
+```
+
+Measures cell content height and applies automatic row sizing. Operates on dirty rows and delegates height updates through `ApplyHeightsCallback`.
+
+### ApplyHeightsCallback
+
+```typescript
+type ApplyHeightsCallback = (updates: Map<number, number>) => void;
+```
+
+Callback receiving a map of row index → computed height for automatic row sizing.
+
+### FillHandleLayer
+
+```typescript
+class FillHandleLayer implements RenderLayer {
+  render(rc: RenderContext): void;
+}
+```
+
+Render layer that draws the autofill drag handle at the bottom-right corner of the selection.
+
+### RowGroupToggleLayer
+
+```typescript
+class RowGroupToggleLayer implements RenderLayer {
+  render(rc: RenderContext): void;
+}
+```
+
+Render layer that draws expand/collapse toggle icons in the row number area for grouped rows.
+
+### DatePickerOverlay
+
+```typescript
+class DatePickerOverlay {
+  constructor(config: DatePickerConfig);
+  get isOpen(): boolean;
+  get editingRow(): number;
+  get editingCol(): number;
+}
+```
+
+Calendar overlay for date cell editing. Positioned over the active cell and commits values through the configured callback.
+
+### LINE_HEIGHT_MULTIPLIER
+
+```typescript
+const LINE_HEIGHT_MULTIPLIER = 1.2;
+```
+
+Default multiplier applied to font size when computing line height for text rendering.
+
+## Events
+
+### SpreadsheetEvents
+
+```typescript
+interface SpreadsheetEvents {
+  cellClick: (event: CellEvent) => void;
+  cellDoubleClick: (event: CellEvent) => void;
+  cellHover: (event: CellEvent) => void;
+  cellChange: (event: CellChangeEvent) => void;
+  selectionChange: (event: SelectionChangeEvent) => void;
+  scroll: (event: ScrollEvent) => void;
+  ready: () => void;
+  destroy: () => void;
+  commandExecute: (event: CommandEvent) => void;
+  commandUndo: (event: CommandEvent) => void;
+  commandRedo: (event: CommandEvent) => void;
+  clipboardCopy: (event: ClipboardDataEvent) => void;
+  clipboardCut: (event: ClipboardDataEvent) => void;
+  clipboardPaste: (event: ClipboardDataEvent) => void;
+  columnResize: (event: ColumnResizeEvent) => void;
+  columnResizeStart: (event: { colIndex: number }) => void;
+  columnResizeEnd: (event: ColumnResizeEvent) => void;
+  rowResize: (event: RowResizeEvent) => void;
+  rowResizeStart: (event: { rowIndex: number }) => void;
+  rowResizeEnd: (event: RowResizeEvent) => void;
+  cellStatusChange: (event: CellStatusChangeEvent) => void;
+  cellValidation: (event: CellValidationEvent) => void;
+  autofillStart: (event: AutofillStartEvent) => void;
+  autofillPreview: (event: AutofillPreviewEvent) => void;
+  autofillComplete: (event: AutofillCompleteEvent) => void;
+  sortChange: (event: SortChangeEvent) => void;
+  sortRejected: (event: SortRejectedEvent) => void;
+  filterChange: (event: FilterChangeEvent) => void;
+  rowGroupToggle: (event: RowGroupToggleEvent) => void;
+  rowGroupChange: (event: RowGroupChangeEvent) => void;
+  themeChange: (event: { theme: SpreadsheetTheme }) => void;
+}
+```
+
+Map of all public events emitted by `SpreadsheetEngine`. Use `engine.on(eventName, handler)` to subscribe.
+
+## Benchmark Types
+
+### BenchmarkRunner
+
+```typescript
+class BenchmarkRunner {
+  record(name: string, dataset: string, stats: RunStats, unit?: string): void;
+  toJSON(): BenchmarkSuiteResult;
+  reset(): void;
+}
+```
+
+Collects benchmark metrics and serializes results.
+
+### BenchmarkMetric
+
+```typescript
+interface BenchmarkMetric {
+  name: string;
+  dataset: string;
+  stats: RunStats;
+  unit: string;
+}
+```
+
+A single benchmark measurement with statistical summary.
+
+### BenchmarkResult
+
+```typescript
+interface BenchmarkResult {
+  initTimeMs: number;
+  memoryMB?: number;
+  rowCount: number;
+  columnCount: number;
+}
+```
+
+Initialization benchmark result capturing startup time and optional memory usage.
+
+### BenchmarkSuiteResult
+
+```typescript
+interface BenchmarkSuiteResult {
+  timestamp: string;
+  metrics: BenchmarkMetric[];
+}
+```
+
+Complete benchmark suite output with timestamp and all collected metrics.
+
+### RunStats
+
+```typescript
+interface RunStats {
+  medianMs: number;
+  meanMs: number;
+  minMs: number;
+  maxMs: number;
+  cv: number;
+  runs: number[];
+}
+```
+
+Statistical summary of multiple benchmark runs. `cv` is the coefficient of variation.
+
+### TimingResult
+
+```typescript
+interface TimingResult {
+  timeMs: number;
+}
+```
+
+Single timing measurement result.
+
+### computeStats
+
+```typescript
+function computeStats(times: number[]): RunStats;
+```
+
+Computes statistical summary from an array of timing measurements.
+
+### measureMultiRun
+
+```typescript
+function measureMultiRun(fn: () => void, runs?: number): RunStats;
+```
+
+Executes a function multiple times and returns aggregated statistics. Defaults to 3 runs.
+
+### measureThroughput
+
+```typescript
+function measureThroughput(
+  fn: () => void,
+  iterations: number,
+): { opsPerSec: number; totalMs: number };
+```
+
+Measures operations per second by running a function for the specified number of iterations.
+
+### measureInitTime
+
+```typescript
+function measureInitTime(factory: () => void): TimingResult;
+```
+
+Measures the time to execute a factory function once and returns a `TimingResult`.
+
+### FPSCounter
+
+```typescript
+class FPSCounter {
+  start(): void;
+  tick(): void;
+  stop(): FPSResult;
+}
+```
+
+Measures rendering frame rate. Call `start()` before the loop, `tick()` on each frame, and `stop()` to get the result.
+
+### FPSResult
+
+```typescript
+interface FPSResult {
+  avgFPS: number;
+  minFPS: number;
+  maxFPS: number;
+  frameCount: number;
+  durationMs: number;
+}
+```
+
+Frame rate measurement result from `FPSCounter.stop()`.

--- a/packages/site/src/content/docs/api/wit-engine.mdx
+++ b/packages/site/src/content/docs/api/wit-engine.mdx
@@ -37,6 +37,33 @@ engine.mount(document.getElementById('grid')!);
 | `setCell` | `(row, col, value) => void` | Set cell value at logical row/col |
 | `getCellStore` | `() => CellStore` | Access the underlying CellStore |
 
+## Cell Styling
+
+Cell styles are applied through the `CellStore` and a standalone `StylePool` instance:
+
+```ts
+import { StylePool } from '@witqq/spreadsheet';
+
+const cellStore = engine.getCellStore();
+const stylePool = new StylePool();
+
+const ref = stylePool.intern({
+  fontWeight: 'bold',
+  bgColor: '#fef3cd',
+  borderBottom: { width: 1, color: '#856404', style: 'solid' },
+});
+const style = stylePool.resolve(ref)!;
+
+cellStore.set(row, col, {
+  value: 'Warning',
+  style: { ref, style },
+});
+```
+
+`StylePool` is not part of `SpreadsheetEngine` — create and manage it alongside the engine. The `CellData.style` field holds a `CellStyleRef` with the dedup key and resolved style.
+
+See [Per-Cell Styling](/guides/styling/) for `CellStyle` properties, borders, alignment, and number formatting.
+
 ## Cell Status (Change Tracking)
 
 | Method | Signature | Description |

--- a/packages/site/src/content/docs/concepts/data-model.mdx
+++ b/packages/site/src/content/docs/concepts/data-model.mdx
@@ -138,13 +138,49 @@ The `getRowAtY` and `getColAtX` methods are used by `EventTranslator` for hit-te
 
 ## StylePool
 
-The `StylePool` deduplicates cell styles. When multiple cells share the same style (font, color, alignment, etc.), they reference the same style object in memory instead of each holding a copy.
+The `StylePool` deduplicates cell styles using content-based hashing. When multiple cells share the same style (font, color, alignment, borders, etc.), they reference the same frozen style object in memory instead of each holding a copy.
 
 ```ts
-// Two cells with identical styles share one object
-const styleId = stylePool.intern({ fontWeight: 'bold', textColor: '#333' });
-cellA.style = stylePool.resolve(styleId);
-cellB.style = stylePool.resolve(styleId); // Same reference as cellA.style
+const stylePool = new StylePool();
+
+// Intern returns a ref key — identical styles produce the same key
+const ref = stylePool.intern({
+  fontWeight: 'bold',
+  textColor: '#333',
+  borderBottom: { width: 1, color: '#ccc', style: 'solid' },
+});
+
+// Resolve the ref to get the frozen CellStyle object
+const style = stylePool.resolve(ref)!;
+
+// Attach to cell data as a CellStyleRef
+cellStore.set(0, 0, {
+  value: 'Styled cell',
+  style: { ref, style },
+});
 ```
 
-This reduces memory usage significantly in tables where many cells share common formatting.
+### API
+
+| Method | Signature | Description |
+|---|---|---|
+| `intern` | `(style: CellStyle) => string` | Deduplicate and store a style, returns ref key |
+| `resolve` | `(ref: string) => CellStyle \| undefined` | Look up a style by its ref key |
+| `has` | `(ref: string) => boolean` | Check if a ref exists in the pool |
+| `clear` | `() => void` | Remove all styles from the pool |
+| `size` | `number` (getter) | Number of unique styles stored |
+
+### CellStyleRef
+
+The `CellData.style` field holds a `CellStyleRef` which carries both the dedup key and the resolved style:
+
+```ts
+interface CellStyleRef {
+  readonly ref: string;       // StylePool dedup key
+  readonly style: CellStyle;  // Resolved style object
+}
+```
+
+The renderer reads `style.style` directly — it never calls `StylePool.resolve()` at render time.
+
+See [Per-Cell Styling](/guides/styling/) for usage patterns including borders, alignment, and number formatting.

--- a/packages/site/src/content/docs/guides/decorators.mdx
+++ b/packages/site/src/content/docs/guides/decorators.mdx
@@ -1,0 +1,157 @@
+---
+title: "Cell Decorators"
+description: "Register, render, and interact with cell decorators — composable rendering addons for cells."
+---
+
+Cell decorators augment the default text rendering pipeline without replacing it.
+A decorator occupies one of four positions relative to cell content:
+
+| Position | Behavior |
+|---|---|
+| `left` | Reserves horizontal space to the left of text |
+| `right` | Reserves horizontal space to the right of text |
+| `overlay` | Renders on top of text |
+| `underlay` | Renders behind text |
+
+Render order: underlay → left → right → text/custom → overlay.
+
+## Interfaces
+
+```ts
+type CellDecoratorPosition = 'left' | 'right' | 'overlay' | 'underlay';
+
+interface CellDecorator {
+  readonly id: string;
+  readonly position: CellDecoratorPosition;
+  getWidth?(
+    cellData: CellData,
+    cellHeight: number,
+    ctx?: CanvasRenderingContext2D,
+    theme?: SpreadsheetTheme,
+  ): number;
+  render(
+    ctx: CanvasRenderingContext2D,
+    cellData: CellData,
+    x: number, y: number, width: number, height: number,
+    theme: SpreadsheetTheme,
+  ): void;
+  getHitZones?(width: number, height: number, cellData: CellData): HitZone[];
+}
+
+interface CellDecoratorRegistration {
+  decorator: CellDecorator;
+  appliesTo: (row: number, col: number, cellData: CellData) => boolean;
+}
+```
+
+- `getWidth` returns the reserved width in pixels for `left`/`right` decorators. Ignored for `overlay`/`underlay`. The `ctx` parameter is optional — during hit testing no canvas context is available; decorators with fixed widths can ignore it.
+- `render` draws into the allocated area. Coordinates `(x, y, width, height)` reflect the decorator's region after layout.
+- `getHitZones` returns interactive sub-cell zones. Coordinates are relative to the decorator's allocated area.
+
+## Registration
+
+Decorators are managed through `CellTypeRegistry`:
+
+```ts
+const registry = engine.getCellTypeRegistry();
+
+registry.addDecorator({
+  decorator: {
+    id: 'status-icon',
+    position: 'left',
+    getWidth: () => 24,
+    render(ctx, cellData, x, y, width, height, theme) {
+      const icon = cellData.value === 'done' ? '✓' : '○';
+      ctx.fillStyle = cellData.value === 'done' ? '#16a34a' : '#94a3b8';
+      ctx.font = `${height * 0.6}px sans-serif`;
+      ctx.textBaseline = 'middle';
+      ctx.fillText(icon, x + 4, y + height / 2);
+    },
+  },
+  appliesTo: (row, col) => col === 0,
+});
+```
+
+`addDecorator` replaces an existing decorator with the same `id` (dedup by `decorator.id`).
+
+## Removal
+
+```ts
+registry.removeDecorator('status-icon');
+```
+
+No-op if the decorator is not registered.
+
+## Hit Zones
+
+Decorators can define interactive areas via `getHitZones`. Each zone has a unique `id`, pixel coordinates relative to the decorator area, and an optional CSS `cursor`.
+
+```ts
+interface HitZone {
+  readonly id: string;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly cursor?: string;
+}
+```
+
+Example — a clickable delete button on the right side of a cell:
+
+```ts
+registry.addDecorator({
+  decorator: {
+    id: 'delete-btn',
+    position: 'right',
+    getWidth: () => 28,
+    render(ctx, cellData, x, y, width, height) {
+      ctx.fillStyle = '#ef4444';
+      ctx.font = `${height * 0.5}px sans-serif`;
+      ctx.textBaseline = 'middle';
+      ctx.textAlign = 'center';
+      ctx.fillText('×', x + width / 2, y + height / 2);
+    },
+    getHitZones(width, height) {
+      return [{ id: 'delete', x: 0, y: 0, width, height, cursor: 'pointer' }];
+    },
+  },
+  appliesTo: () => true,
+});
+```
+
+## Responding to Hit Zone Clicks
+
+The `cellClick` event carries the `hitZone` property when a decorator zone is clicked:
+
+```ts
+engine.on('cellClick', (e) => {
+  if (e.hitZone === 'delete') {
+    engine.setCell(e.row, e.col, { value: '' });
+  }
+});
+```
+
+The `cellHover` event also carries `hitZone` for hover effects. The cursor is set
+automatically from `HitZone.cursor`.
+
+## Hit Test Resolution Order
+
+When the engine resolves a click or hover within a cell, sub-cell zones are tested in this order:
+
+1. Cell type renderer zones (`CellTypeRenderer.getHitZones`)
+2. Left decorator zones (left to right)
+3. Right decorator zones (right to left)
+4. Overlay and underlay decorator zones
+
+The first matching zone wins.
+
+## Multiple Decorators
+
+A cell can have multiple decorators. `getDecorators(row, col, cellData)` returns all
+decorators whose `appliesTo` predicate returns `true`, in registration order.
+
+Left decorators stack from left to right; right decorators stack from right to left. Each shifts the text content area inward by its `getWidth()` value.
+
+See [API Types](/api/types/) for `CellDecorator`, `CellDecoratorRegistration`, `HitZone`, and `HitTestResult` definitions.
+See [SpreadsheetEngine API](/api/wit-engine/) for `addDecorator` and `removeDecorator` method signatures.

--- a/packages/site/src/content/docs/guides/styling.mdx
+++ b/packages/site/src/content/docs/guides/styling.mdx
@@ -1,0 +1,149 @@
+---
+title: "Per-Cell Styling"
+description: "Apply font, color, alignment, borders, and number formatting to individual cells using CellStyle and StylePool."
+---
+
+# Per-Cell Styling
+
+Cells can carry individual styles for font, color, alignment, borders, number formatting, text wrapping, and indentation. Styles are set through `CellData.style` and deduplicated by the `StylePool`.
+
+## CellStyle Properties
+
+```ts
+interface CellStyle {
+  readonly bgColor?: string;            // Background color (CSS color string)
+  readonly textColor?: string;          // Text color (CSS color string)
+  readonly fontFamily?: string;         // Font family name
+  readonly fontSize?: number;           // Font size in pixels
+  readonly fontWeight?: 'normal' | 'bold';
+  readonly fontStyle?: 'normal' | 'italic';
+  readonly textAlign?: 'left' | 'center' | 'right';
+  readonly verticalAlign?: 'top' | 'middle' | 'bottom';
+  readonly borderTop?: BorderStyle;
+  readonly borderRight?: BorderStyle;
+  readonly borderBottom?: BorderStyle;
+  readonly borderLeft?: BorderStyle;
+  readonly numberFormat?: string;       // e.g. "#,##0.00"
+  readonly textWrap?: boolean;          // Enable text wrapping within cell
+  readonly indent?: number;             // Text indentation level
+}
+```
+
+All properties are optional. Unset properties inherit from the theme or column defaults.
+
+## Setting Cell Styles
+
+Styles flow through the `StylePool` for deduplication, then attach to cell data via `CellStyleRef`:
+
+```ts
+import { StylePool, CellStore } from '@witqq/spreadsheet';
+
+const stylePool = new StylePool();
+const cellStore = new CellStore();
+
+// 1. Intern the style (returns a dedup key)
+const ref = stylePool.intern({
+  fontWeight: 'bold',
+  textColor: '#1a73e8',
+  bgColor: '#e8f0fe',
+});
+const style = stylePool.resolve(ref)!;
+
+// 2. Set cell data with the style reference
+cellStore.set(0, 0, {
+  value: 'Header',
+  style: { ref, style },
+});
+```
+
+Multiple cells with identical styles share the same pooled object:
+
+```ts
+const ref = stylePool.intern({ fontWeight: 'bold' });
+const style = stylePool.resolve(ref)!;
+
+// Both cells reference the same style — no duplication
+cellStore.set(0, 0, { value: 'A', style: { ref, style } });
+cellStore.set(0, 1, { value: 'B', style: { ref, style } });
+```
+
+## Borders
+
+Each cell edge has an independent `BorderStyle`:
+
+```ts
+interface BorderStyle {
+  readonly width: number;         // Border width in pixels
+  readonly color: string;         // CSS color string
+  readonly style: 'solid' | 'dashed' | 'dotted';
+}
+```
+
+Apply borders to individual cells:
+
+```ts
+const ref = stylePool.intern({
+  borderBottom: { width: 2, color: '#333', style: 'solid' },
+  borderRight: { width: 1, color: '#ccc', style: 'dashed' },
+});
+const style = stylePool.resolve(ref)!;
+
+cellStore.set(0, 0, {
+  value: 'Bordered',
+  style: { ref, style },
+});
+```
+
+For a visible border between two cells, set `borderRight` on the left cell or `borderLeft` on the right cell — the renderer draws whichever is defined.
+
+## Alignment and Indentation
+
+Horizontal alignment (`textAlign`) and vertical alignment (`verticalAlign`) control text positioning within the cell. `indent` shifts the text inward by the specified indentation level:
+
+```ts
+const ref = stylePool.intern({
+  textAlign: 'right',
+  verticalAlign: 'bottom',
+  indent: 2,
+});
+```
+
+## Number Formatting
+
+The `numberFormat` property controls how numeric values are displayed. The format string follows spreadsheet convention:
+
+```ts
+const ref = stylePool.intern({
+  numberFormat: '#,##0.00',
+});
+```
+
+The `displayValue` field on `CellData` stores the formatted output. Number formatting is applied by the cell type renderer, not by `StylePool`.
+
+## Text Wrapping
+
+Per-cell text wrapping is controlled by `CellStyle.textWrap`. This takes priority over `ColumnDef.wrapText`:
+
+```ts
+const ref = stylePool.intern({ textWrap: true });
+```
+
+Resolution order: `CellStyle.textWrap` → `ColumnDef.wrapText` → `false`.
+
+See [Text Wrapping](/guides/text-wrapping/) for wrapping behavior, auto row height integration, and performance details.
+
+## StylePool API
+
+| Method | Signature | Description |
+|---|---|---|
+| `intern` | `(style: CellStyle) => string` | Deduplicate and store a style, returns ref key |
+| `resolve` | `(ref: string) => CellStyle \| undefined` | Look up a style by its ref key |
+| `has` | `(ref: string) => boolean` | Check if a ref exists in the pool |
+| `clear` | `() => void` | Remove all styles from the pool |
+| `size` | `number` (getter) | Number of unique styles stored |
+
+## See Also
+
+- [Data Model](/concepts/data-model/) — `CellData`, `CellStore`, and `StylePool` internals
+- [Text Wrapping](/guides/text-wrapping/) — wrapping behavior and auto row height
+- [Types Reference](/api/types/) — `CellStyle`, `BorderStyle`, `CellStyleRef` definitions

--- a/packages/site/src/content/docs/guides/text-wrapping.mdx
+++ b/packages/site/src/content/docs/guides/text-wrapping.mdx
@@ -19,8 +19,8 @@ const columns: ColumnDef[] = [
 ];
 ```
 
-:::note
-`CellStyle.textWrap` is defined in the interface but is not currently read by the renderer. Use `ColumnDef.wrapText` for wrapping control.
+:::tip
+Per-cell text wrapping is also available via `CellStyle.textWrap`. Cell-level style takes priority over `ColumnDef.wrapText`. See [Per-Cell Styling](/guides/styling/) for details.
 :::
 
 ## Wrapping Behavior

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -234,6 +234,8 @@ function addRow() {
 
 **Event types:** `CellChangeEvent`, `SelectionChangeEvent`, `SortChangeEvent`, `FilterChangeEvent`, `ScrollEvent`
 
+For per-cell styling (`CellStyleRef`, `BorderStyle`, `StylePool`) and cell decorators (`CellDecorator`, `CellDecoratorRegistration`), import directly from `@witqq/spreadsheet` and use via the engine instance from template ref `getInstance()`.
+
 ---
 
 ## Component Lifecycle


### PR DESCRIPTION
## Summary

Complete documentation audit ensuring all 224 public API exports from `packages/core/src/index.ts` are documented in both the site docs and package READMEs.

## Changes

**Documentation style guide** — expanded with npm README sync mandate, code-change-to-docs mapping table, examples requirement, sync checklist.

**Site docs:**
- New `guides/styling.mdx`: CellStyle, BorderStyle, StylePool workflow, borders, alignment
- New `guides/decorators.mdx`: CellDecorator lifecycle, registration, hit zones, events
- `types.mdx`: 30 missing export entries (editor types, conditional format, rendering layers, SpreadsheetEvents with 31 events, benchmark APIs, CellChange)
- `wit-engine.mdx`: Cell Styling section
- `data-model.mdx`: StylePool section
- `text-wrapping.mdx`: corrected priority chain
- `astro.config.mjs`: sidebar entries for styling and decorators

**Package READMEs:**
- Core: CellDecorator, CellDecoratorPosition, CellDecoratorRegistration type definitions (224/224 coverage)
- Plugins: ConditionalFormatRule import in registration example
- React/Vue/Angular: per-cell styling and decorator import notes
- Root: export count updated 220→224

## Verification

- 224/224 exports verified via automated Python audit script
- All gate reviews passed (6 steps)
- `npm run build` passes