### PR TITLE
feat: Planeta Analytics universal enhancements — 20 Handsontable migration issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- `DecoratorsPlugin`: built-in plugin bundling six reusable cell decorators — TreeExpander, SortIcon, ProgressBar, Link, Image, and Spinner. Configurable via `DecoratorsPluginConfig` (enable/disable individual decorators)
+- `TreeExpanderDecorator` (position: left): renders expand/collapse triangle with tree-level indentation. Hit zone emits `treeToggle` event
+- `SortIconDecorator` (position: right): renders sort direction arrow (asc/desc). Hit zone emits `sortRequest` event
+- `ProgressBarDecorator` (position: underlay): renders colored progress bar behind cell text. Supports 0–1 fraction and 0–100 percentage ranges. Configurable color, height, border radius, vertical position
+- `LinkDecorator` (position: overlay): renders external link icon for cells with `metadata.link`. Hit zone emits `linkClick` event
+- `ImageDecorator` (position: left): renders thumbnail using `ImageManager` with placeholder while loading. Configurable size, URL field, border radius
+- `SpinnerDecorator` (position: overlay, animated): renders spinning loading indicator using timestamp-based animation from `RenderScheduler`
+- `CellMetadata` now supports decorator fields: `treeLevel`, `treeExpanded`, `sortDirection`, `progress`, `imageUrl`, `loading`, plus index signature for plugin-defined fields
+- `EventBus.emit()` now supports dynamic string event names (overload for plugin-defined custom events)
+- `ImageManager`: async `HTMLImageElement` loading with LRU cache (configurable `maxSize`, default 100). Synchronous `getImage()` returns cached image or `null` (triggers background load). `preload()` for batch warming. Triggers `requestRender()` on load. Accessed via `SpreadsheetEngine.getImageManager()`
+- `ImageManagerOptions` interface: `{ maxSize?: number, onLoad?: () => void }` for configuring the ImageManager
+- Animated decorator support: `CellDecoratorRegistration.animated` flag. When any animated decorator is registered, `RenderScheduler` maintains a continuous rAF loop passing `DOMHighResTimeStamp` to every frame. Loop stops automatically when all animated decorators are removed
+- `CellDecorator.render()` now accepts an optional `timestamp?: number` parameter (10th argument) — the `DOMHighResTimeStamp` from `requestAnimationFrame`, available during animation frames
+- `RenderContext.timestamp` field: optional `DOMHighResTimeStamp` passed to all render layers during animation frames
+- `RenderScheduler.setAnimationLoop(enabled)`: activates/deactivates continuous animation rendering
+- `RenderScheduler.isAnimating()`: returns whether the animation loop is active
+- `CellTypeRegistry.hasAnimatedDecorators()`: returns whether any registered decorator has `animated: true`
+- `CellTypeRegistry.setAnimatedChangeCallback()`: registers a callback for when animated decorator presence changes
+
+- `BaseOverlayEditor`: abstract base class for building overlay cell editors with shared lifecycle (positioning, scroll-close, click-outside detection), calendar grid rendering, and keyboard navigation. `DatePickerEditor` and `DateTimeEditor` now extend it
+- `BaseCalendarOverlayEditor`: intermediate class between `BaseOverlayEditor` and date editors, encapsulating calendar state (view year/month, selected date, focused day), calendar grid rendering, and month navigation. `DatePickerEditor` and `DateTimeEditor` now extend this instead of `BaseOverlayEditor` directly
+- `SelectEditor`: built-in cell editor for `'select'` column type. Renders a dropdown overlay with search input, keyboard navigation (ArrowUp/Down with wrapping, Enter/Tab to commit, Escape to close), mouse hover highlight, and ARIA roles. Automatically registered for `type: 'select'` columns
+- `SelectOption` interface: `{ value: string, label?: string }` for defining select dropdown options
+- `ColumnDef.selectOptions` field: array of `SelectOption` for select-type columns
+- Locale support for select editor: `select.ariaLabel`, `select.searchPlaceholder`, `select.noResults` in EN/RU locale packs
+- `calendar-utils` module: shared calendar constants (`DAYS_IN_WEEK`, `WEEK_LABELS`, `MONTH_NAMES`) and utility functions (`daysInMonth`, `firstDayOfMonth`, `isSameDay`, `pad2`, `clamp`) extracted from editor duplications
 - npm packages now include structured `docs/` directory with clean markdown documentation converted from site MDX sources
 - Per-package documentation filtering: core gets all docs, framework wrappers get getting-started + framework-specific docs, plugins get getting-started + plugin docs
 - Compact navigator README generated for each package with badges, install instructions, peer dependencies, and table of contents
 - `npm run docs:npm` script for generating package documentation
+- Editable Priority Guide: documents the global → column → cell editability chain with truth table and `isCellEditable` API
+- Context Menu Migration Guide: Handsontable-to-witqq context menu migration with side-by-side API comparison
+- Custom Cell Types Guide: hit zones, `measureHeight` for auto row sizing, complete custom type walkthrough (badge renderer)
+- Per-Cell Editor Resolution Guide: priority-based override patterns, `BaseOverlayEditor` custom editor creation guide
+- Migration Notes: already-solved issues documentation for `CellData.custom`, clipboard normalization, `bulkLoadCellData`, `StylePool`, and `getScrollContainer`
 - `CellData.custom` field: extensible `Record<string, unknown>` for user-defined data, preserved through `setValue()` and `setMetadata()`
+- `CellData.readOnly` field: per-cell editing override. When `true`, blocks all editing (inline, paste, cut, autofill). Priority: `CellData.readOnly` > `ColumnDef.editable` > `config.editable`
+- `SpreadsheetEngine.isCellEditable(row, col)`: public method returning whether a cell can be edited, respecting the full editability priority chain
+- `SpreadsheetEngine.setData(data, columnKeys?)`: atomic full data replacement — clears all cells, loads new data, updates row count, and schedules a single render
+- `SpreadsheetEngine.setDataCellData(data, startRow?)`: atomic full data replacement using `CellData[][]` arrays, preserving styles, metadata, and readOnly flags
+- `SpreadsheetEngine.appendRows(data, columnKeys?)`: appends rows after existing data without clearing
+- `SpreadsheetEngine.replaceRows(startRow, data, columnKeys?)`: replaces a range of rows at a specific offset, clearing stale cells in the target range
+- `SpreadsheetEngineConfig.showColumnHeaders`: boolean option (default: `true`). When `false`, hides the column header row, starts data from y=0, and disables header interactions (sort, filter, column resize)
+- `SpreadsheetEngineConfig.clipGridLinesToData`: boolean option (default: `false`). When `true`, grid lines stop at the last data column/row boundary instead of extending to canvas edges, and phantom grid lines in empty rows are suppressed
+- Transparent background support: set `theme.colors.background` to `'transparent'` and `BackgroundLayer` uses `clearRect` instead of `fillRect`, allowing underlying page elements to show through
+- `HitZone.padding`: optional padding that expands hit-test area beyond visual bounds. Accepts uniform `number` or per-side `{ top, right, bottom, left }`. Rendering unaffected — only click/hover detection grows
+- `HitZonePadding` type: exported type alias for padding specification
+- `ClipboardPasteEvent`: extended paste event with `startRow` and `startCol` coordinates (row/col of active cell at paste time). The `clipboardPaste` event now uses this type instead of `ClipboardDataEvent`
+- `SpreadsheetEngine.getScrollContainer()`: convenience method that returns the scroll container DOM element directly, equivalent to `getScrollManager()?.getElement() ?? null`
+- `MergeManager.setRegions(regions, frozenRows?, frozenCols?)`: atomically replace all merge regions. Clears existing regions, validates each new region (size, overlap, frozen pane boundaries), returns `SetRegionsResult` with accepted and rejected arrays
+- `SetRegionsResult` and `MergeValidationError` types: result types for `setRegions()` batch operation
+- `ContextMenuManager.setItems(items)`: atomically replace all user-registered (custom) menu items. Default items (cut, copy, paste, sort, row operations) are preserved. Enables declarative state management for reactive frameworks
+- `DEFAULT_MENU_ITEM_IDS`: exported `Set<string>` containing the 8 built-in default menu item IDs
+- `ColumnDef.dateFormat`: optional date format pattern (e.g., `'DD.MM.YYYY'`, `'MM/DD/YYYY'`). When set on date-type columns, overrides locale-based formatting for cell display and editor commit values. Supported tokens: `YYYY`, `MM`, `DD`
+- `formatDate(date, pattern)`: format a Date into a pattern string. Zero-dependency utility exported from core
+- `parseDateString(value, pattern)`: parse a date string according to a pattern. Returns `null` if invalid
+- `toDate(value, pattern?)`: parse any CellValue into a Date, trying custom pattern first, then ISO, then native parsing
+- `CellTypeRenderer.format()`: optional 5th parameter `columnDef?: ColumnDef` for column-aware formatting
 - `CellDecorator` methods now receive optional `row` and `col` parameters: `render()`, `getWidth()`, `getHitZones()`
 - `CellStore.bulkLoadCellData()`: bulk load complete `CellData` objects from a 2D array, storing value, type, style, metadata, and custom fields in one pass
 - `SpreadsheetEngine.bulkLoadCellData()`: public API for bulk loading complete cell data with dirty tracking and render scheduling
@@ -21,6 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@witqq/spreadsheet`: exports `AutofillStartEvent`, `AutofillPreviewEvent`, `AutofillCompleteEvent` from package index
 
 ### Changed
+
+- `@witqq/spreadsheet-react`: peerDependencies now include `react: ^17.0.0` and `react-dom: ^17.0.0`. The wrapper uses only React ≤16-era hooks (`useEffect`, `useRef`, `useImperativeHandle`, `forwardRef`) and the automatic JSX transform (`react-jsx`) available since React 17.0.0
+- `DatePickerEditor`: refactored from thin adapter (delegating to `DatePickerOverlay`) to direct `BaseOverlayEditor` subclass. Public API unchanged
+- `DateTimeEditor`: refactored from monolithic 821-line class to ~300-line `BaseOverlayEditor` subclass. Public API unchanged
+- `DatePickerOverlay`: internal utility functions replaced with imports from `calendar-utils` module. Public API unchanged
 - **BREAKING:** `CellTypeRenderer.render()` second parameter changed from `CellValue` to `CellData` (full cell data object); optional `row` and `col` trailing parameters added
 - **BREAKING:** `CellTypeRenderer.measureHeight()` second parameter changed from `CellValue` to `CellData`; optional `row` and `col` trailing parameters added
 - **BREAKING:** `CellTypeRenderer.getHitZones()` first parameter changed from `CellValue` to `CellData`; optional `row` and `col` trailing parameters added
@@ -29,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] — 2026-03-11
 
 ### Added
+
 - Cell Decorator API: `CellDecorator`, `CellDecoratorPosition`, `CellDecoratorRegistration` interfaces for composable rendering addons
 - `CellTypeRegistry.addDecorator()` and `removeDecorator()` for managing cell decorators with `appliesTo` predicates
 - `CellTypeRegistry.getDecorators()` returns applicable decorators for a given cell

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,13 +37,23 @@
 
 *Source: `render-scheduler.ts`*
 
-Classic RAF coalescing with a boolean dirty flag. When `requestRender()` is called:
+Supports two modes:
+
+**Pull-based (default):** Classic RAF coalescing with a boolean dirty flag. When `requestRender()` is called:
 
 1. If `dirty` is already `true`, return immediately (coalescing — any number of calls per frame collapse to one)
 2. Set `dirty = true`, schedule a single `requestAnimationFrame`
-3. Inside the RAF callback: reset `dirty = false`, invoke `renderCallback()`
+3. Inside the RAF callback: reset `dirty = false`, invoke `renderCallback(timestamp)`
 
 The coalescing is O(1) — the first `requestRender()` in a frame wins the RAF slot, all subsequent calls are no-ops. No queue, no debounce timer, no priority system.
+
+**Continuous animation mode:** Activated via `setAnimationLoop(true)` when animated decorators are present. Maintains a persistent rAF loop, calling `renderCallback(timestamp)` every frame. `requestRender()` is a no-op during animation. `setAnimationLoop(false)` reverts to pull-based mode.
+
+### ImageManager
+
+*Source: `image-manager.ts`*
+
+Async `HTMLImageElement` loader with LRU cache. `getImage(url)` returns the cached image synchronously (or `null` and triggers a background load). When an image finishes loading, calls `onLoad` (wired to `requestRender()`) so the grid refreshes. `preload(urls)` warms the cache in batch. Configurable `maxSize` (default 100). Accessed via `SpreadsheetEngine.getImageManager()`.
 
 ### RenderPipeline
 
@@ -97,7 +107,7 @@ Cache invalidation occurs on theme change, data change, or structural change (co
 6. Applies per-cell `verticalAlign` (`top`/`middle`/`bottom`) by computing text Y position within the cell
 7. Applies per-cell `textWrap` from `CellStyle` with bidirectional override: `cellStyle?.textWrap ?? col.wrapText ?? false` — per-cell can enable or disable wrapping regardless of column setting
 8. Applies per-cell `indent` — shifts text position and reduces available width by `indent * padding` pixels
-9. Collects applicable `CellDecorator` instances from `CellTypeRegistry.getDecorators()` and renders in order: underlay → left → right → text/custom → overlay. Left/right decorators reserve horizontal space, shifting text inward.
+9. Collects applicable `CellDecorator` instances from `CellTypeRegistry.getDecorators()` and renders in order: underlay → left → right → text/custom → overlay. Left/right decorators reserve horizontal space, shifting text inward. Animated decorators (with `animated: true` on their registration) receive a `DOMHighResTimeStamp` via the `timestamp` parameter for frame-based animation.
 10. Custom renderer path: delegates to `renderer.render()` if the cell type provides one
 11. Wrap text path: uses `TextMeasureCache.getWrappedLines()` for word breaking, draws each line with proper alignment and vertical alignment
 12. Single-line path: uses `TextMeasureCache.truncateText()` with ellipsis, draws via `ctx.fillText()`
@@ -308,11 +318,17 @@ Maps cell types to editor factories. Entries are sorted by priority (highest fir
 
 ### Overlay Editors
 
-**DatePickerOverlay** (`editing/date-picker-overlay.ts`) — calendar popup positioned below the cell (or above if no room below) at `z-index: 50`. Pure DOM calendar grid with month navigation, keyboard support (arrows, Enter, Escape), and a "Today" footer button.
+**BaseOverlayEditor** (`editing/base-overlay-editor.ts`) — abstract base class implementing `CellEditor`. Provides shared overlay lifecycle (open/close), positioning relative to the cell (below or above if no room), scroll-close for non-frozen cells, click-outside detection, keyboard delegation, and theme/locale propagation. Subclasses implement 6 abstract methods: `overlayWidth`, `overlayHeight`, `getAriaLabel`, `initializeFromValue`, `renderContent`, `onKeyDown`.
 
-**DatePickerEditor** (`editing/date-picker-editor.ts`) — adapter implementing `CellEditor` that wraps DatePickerOverlay. Registered for column type `'date'`.
+**BaseCalendarOverlayEditor** (`editing/base-calendar-overlay-editor.ts`) — intermediate class extending `BaseOverlayEditor` for calendar-based editors. Adds calendar state (view year/month, selected date, focused day), calendar grid rendering, month navigation, and day focus movement. Subclasses implement `parseValue` and `initializeState` for date parsing.
 
-**DateTimeEditor** (`editing/date-time-editor.ts`) — directly implements `CellEditor`. Adds hour/minute spin controls below the calendar. Has a `FocusSection` state machine (`'calendar' | 'hour' | 'minute'`) for Tab cycling between sections. Commits ISO datetime strings. Registered for column type `'datetime'`.
+**DatePickerOverlay** (`editing/date-picker-overlay.ts`) — legacy calendar popup class. Kept for backward compatibility as a public API export. Uses shared utilities from `calendar-utils.ts`.
+
+**DatePickerEditor** (`editing/date-picker-editor.ts`) — extends `BaseCalendarOverlayEditor`. Renders a calendar grid with "Today" footer button. Commits `YYYY-MM-DD` on day click or Enter. Registered for column type `'date'`.
+
+**DateTimeEditor** (`editing/date-time-editor.ts`) — extends `BaseCalendarOverlayEditor`. Adds hour/minute spin controls below the calendar. Has a `FocusSection` state machine (`'calendar' | 'hour' | 'minute'`) for Tab cycling between sections. Commits ISO datetime strings via "OK" button. Registered for column type `'datetime'`.
+
+**SelectEditor** (`editing/select-editor.ts`) — extends `BaseOverlayEditor`. Renders a dropdown overlay with search input and filterable options list from `ColumnDef.selectOptions`. Supports keyboard navigation (ArrowUp/Down with wrapping, Enter/Tab to commit, Escape to close), type-ahead filtering, mouse hover highlight, and ARIA roles (listbox/option). Registered for column type `'select'`.
 
 ### Command Integration
 
@@ -460,6 +476,10 @@ Each plugin receives a `PluginAPI` instance with:
 - `install()`: register menu items via `engine.registerContextMenuItem()`, store IDs in plugin state
 - `destroy()`: iterate stored IDs and unregister each
 
+**Decorator plugin** (e.g. DecoratorsPlugin):
+- `install()`: register `CellDecoratorRegistration` objects via `registry.addDecorator()`, subscribe to `cellClick` for hit zone events, emit custom events (`treeToggle`, `sortRequest`, `linkClick`) via EventBus
+- `destroy()`: call `registry.removeDecorator()` for each ID, unsubscribe click handler
+
 ## Features
 
 | Feature | Module | Description |
@@ -497,6 +517,7 @@ Each plugin receives a `PluginAPI` instance with:
 | ExcelPlugin | .xlsx import/export |
 | ProgressiveLoaderPlugin | Lazy data loading |
 | CollaborationPlugin | Real-time collaboration via OT |
+| DecoratorsPlugin | Built-in cell decorators (tree expander, sort icon, progress bar, link, image thumbnail, spinner) |
 
 ## Cell Type System
 
@@ -598,7 +619,7 @@ The package exports runtime classes/functions and type-only definitions, grouped
 - Types: `RenderLayer`, `RenderContext`, `PaneRegion`, `RenderMode`, `ViewportRange`, `FrozenViewportRanges`, dirty tracking types
 
 ### Editing
-- **`InlineEditor`**, **`DatePickerOverlay`**, **`DatePickerEditor`**, **`DateTimeEditor`**, **`CellEditorRegistry`**
+- **`InlineEditor`**, **`BaseOverlayEditor`**, **`DatePickerOverlay`**, **`DatePickerEditor`**, **`DateTimeEditor`**, **`CellEditorRegistry`**
 - Types: `CellEditor`, `CellEditorContext`, `CellEditorCommit`, `CellEditorClose`, `CellEditorMatcher`
 
 ### Commands

--- a/docs/SCREENSHOT-VALIDATION-GUIDE.md
+++ b/docs/SCREENSHOT-VALIDATION-GUIDE.md
@@ -2,6 +2,86 @@
 
 Screenshot validation captures UI state via Playwright scripts during development workflow steps. An HTML report embeds captured screenshots so the user can approve or reject changes without visiting a running instance.
 
+## When Screenshots Are Mandatory
+
+**Rule: If `has_ui_changes = "yes"`, at least one screenshot MUST be captured. Reporting `screenshots_captured: 0` with `has_ui_changes: "yes"` is a validation failure.**
+
+A step has UI changes if it introduces or modifies any of:
+- Canvas rendering (new layers, cell types, formatters)
+- Overlay editors (dropdowns, date pickers, popups)
+- Context menus, toolbars, or other DOM overlays
+- Theme or styling changes visible to the user
+- Layout changes (column/row sizing, frozen panes)
+
+### Decision Tree
+
+```
+has_ui_changes = "yes"?
+  ├─ YES → Demo page exists for this feature?
+  │   ├─ YES → Write capture script → Capture screenshots → Report
+  │   └─ NO  → Create demo scenario FIRST → Then capture
+  └─ NO  → Skip screenshot validation (screenshots_captured: 0 is OK)
+```
+
+### Creating Demo Scenarios for New Features
+
+When a new UI feature has no demo page, the agent MUST create one before reporting `screenshots_captured: 0`. Options:
+
+1. **Widget bundle standalone page** — use `setupGrid()` from this guide with config that exercises the feature. Fastest option, no Docker needed.
+2. **Add scenario to demo app** — add column/data config to `packages/demo/` that uses the new feature. Requires `npm run dev`.
+3. **Add visual regression scenario** — create a scenario in `packages/demo/src/visual-tests/scenarios/` for permanent coverage.
+
+### Bad vs Good Examples
+
+**❌ BAD: Skipping screenshots for UI component**
+```
+Step: Implement SelectEditor (dropdown overlay)
+Agent reports: has_ui_changes = "yes", screenshots_captured = 0
+Reason given: "Demo page doesn't have select columns"
+```
+This is wrong. The agent has tools (widget bundle, standalone HTML) to create a page.
+
+**✅ GOOD: Creating standalone capture for new UI component**
+```
+Step: Implement SelectEditor (dropdown overlay)
+Agent: No demo page uses select columns → create standalone capture
+  1. Write capture-step-9.ts using widget bundle
+  2. Configure grid with { type: 'select', selectOptions: [...] }
+  3. Simulate click to open dropdown, capture open state
+  4. Simulate keyboard search, capture filtered state
+  5. Report: screenshots_captured = 4, screenshot_issues_count = 0
+```
+
+**❌ BAD: Reporting 0 screenshots without justification**
+```
+screenshots_captured: 0, screenshot_issues_count: 0
+→ Workflow sees 0 issues → skips fix step → generates empty report
+→ User gets report with no visual proof
+```
+
+**✅ GOOD: Non-UI change correctly skips screenshots**
+```
+Step: Refactor LayoutEngine internals (no rendering changes)
+Agent reports: has_ui_changes = "no"
+→ Screenshot validation node skipped entirely (correct)
+```
+
+**❌ BAD: Using demo app absence as excuse**
+```
+"Demo app doesn't have a page for this feature, so I couldn't take screenshots"
+```
+The widget bundle exists specifically for standalone captures without the demo app.
+
+**✅ GOOD: Overlay/editor capture strategy**
+```
+Step: New DateTimeEditor
+Captures:
+  01-grid-datetime-column.png  — grid with datetime values displayed
+  02-editor-open.png           — click cell → editor overlay visible
+  03-editor-time-controls.png  — hour/minute controls in use
+  04-editor-commit.png         — after OK → cell shows new value
+```
+
 ## Workflow Variable
 
 The development workflow stores the path to this file in:
@@ -144,6 +224,16 @@ For each step, capture:
 - Interactive states (editing mode, date picker open, selection active)
 - Data states (cells with values, formatted numbers, dates)
 - Edge cases (empty grid, large dataset, scrolled state)
+
+### Pre-Capture Verification
+
+Before reporting screenshot results to the workflow, verify:
+
+1. **`has_ui_changes` matches reality** — if the step created/modified visual components, it must be `"yes"`
+2. **`screenshots_captured > 0`** when `has_ui_changes = "yes"` — zero captures is always wrong
+3. **All new UI elements have at least one capture** — dropdown open, popup visible, overlay positioned
+4. **Interactive states shown** — don't just capture static grid; show the feature in action
+5. **Capture script is saved** to `screenshots/capture-step-N.ts` for reproducibility
 
 ## Running Scripts
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -73,6 +73,7 @@ Full documentation is available at [spreadsheet.witqq.dev](https://spreadsheet.w
 - [Locale System](docs/guides/locale.md)
 - [Cell Merging](docs/guides/merging.md)
 - [Migration from Handsontable](docs/guides/migration-from-handsontable.md)
+- [Migration Notes](docs/guides/migration-notes.md)
 - [Pivot Tables](docs/guides/pivot.md)
 - [Print Support](docs/guides/print.md)
 - [Column & Row Resize](docs/guides/resize.md)

--- a/packages/core/src/autofill/autofill-manager.ts
+++ b/packages/core/src/autofill/autofill-manager.ts
@@ -31,6 +31,8 @@ export interface AutofillManagerConfig {
   rowCount: number;
   colCount: number;
   mergeManager?: MergeManager;
+  /** Returns true when the cell at (visual row, col) is editable. */
+  isCellEditable?: (row: number, col: number) => boolean;
 }
 
 /** Pixel size of the fill handle square. */
@@ -57,6 +59,7 @@ export class AutofillManager {
   private readonly rowCount: number;
   private readonly colCount: number;
   private readonly mergeManager?: MergeManager;
+  private readonly isCellEditable?: (row: number, col: number) => boolean;
 
   private scrollContainer: HTMLElement | null = null;
 
@@ -78,6 +81,7 @@ export class AutofillManager {
     this.rowCount = config.rowCount;
     this.colCount = config.colCount;
     this.mergeManager = config.mergeManager;
+    this.isCellEditable = config.isCellEditable;
   }
 
   attach(scrollContainer: HTMLElement): void {
@@ -355,6 +359,7 @@ export class AutofillManager {
           const physR = this.dataView.getPhysicalRow(r);
           // Skip hidden cells in merged regions in target area
           if (this.mergeManager?.isHiddenCell(physR, c)) continue;
+          if (this.isCellEditable && !this.isCellEditable(r, c)) continue;
           const oldValue = this.cellStore.get(physR, c)?.value ?? null;
           edits.push({ row: physR, col: c, oldValue, newValue: extended[i] });
         }
@@ -380,6 +385,7 @@ export class AutofillManager {
           const physR = this.dataView.getPhysicalRow(r);
           // Skip hidden cells in merged regions in target area
           if (this.mergeManager?.isHiddenCell(physR, c)) continue;
+          if (this.isCellEditable && !this.isCellEditable(r, c)) continue;
           const oldValue = this.cellStore.get(physR, c)?.value ?? null;
           edits.push({ row: physR, col: c, oldValue, newValue: extended[i] });
         }

--- a/packages/core/src/clipboard/clipboard-manager.ts
+++ b/packages/core/src/clipboard/clipboard-manager.ts
@@ -28,6 +28,8 @@ export interface ClipboardManagerConfig {
   eventBus: EventBus;
   /** Returns true when the inline editor is active (clipboard events pass through). */
   isEditing: () => boolean;
+  /** Returns true when the cell at (visual row, col) is editable. */
+  isCellEditable: (row: number, col: number) => boolean;
   /** Callback to trigger re-render after data changes. */
   onDataChange: () => void;
 }
@@ -39,6 +41,7 @@ export class ClipboardManager {
   private readonly commandManager: CommandManager;
   private readonly eventBus: EventBus;
   private readonly isEditing: () => boolean;
+  private readonly isCellEditable: (row: number, col: number) => boolean;
   private readonly onDataChange: () => void;
   private scrollContainer: HTMLElement | null = null;
 
@@ -49,6 +52,7 @@ export class ClipboardManager {
     this.commandManager = config.commandManager;
     this.eventBus = config.eventBus;
     this.isEditing = config.isEditing;
+    this.isCellEditable = config.isCellEditable;
     this.onDataChange = config.onDataChange;
   }
 
@@ -125,12 +129,13 @@ export class ClipboardManager {
     e.clipboardData?.setData('text/plain', tsv);
     e.clipboardData?.setData('text/html', html);
 
-    // Clear source cells via undoable command
+    // Clear source cells via undoable command (skip read-only cells)
     const range = sel.ranges[0];
     const edits: CellEdit[] = [];
     for (let row = range.startRow; row <= range.endRow; row++) {
       const physRow = this.dataView.getPhysicalRow(row);
       for (let col = range.startCol; col <= range.endCol; col++) {
+        if (!this.isCellEditable(row, col)) continue;
         const cell = this.cellStore.get(physRow, col);
         const oldValue = cell?.value ?? null;
         if (oldValue !== null) {
@@ -183,6 +188,7 @@ export class ClipboardManager {
       for (let c = 0; c < data[r].length; c++) {
         const targetCol = startCol + c;
         if (targetCol > maxCol) break;
+        if (!this.isCellEditable(targetRow, targetCol)) continue;
         const oldCell = this.cellStore.get(physRow, targetCol);
         const oldValue = oldCell?.value ?? null;
         const newValue = data[r][c];
@@ -200,6 +206,8 @@ export class ClipboardManager {
     this.eventBus.emit('clipboardPaste', {
       rowCount: data.length,
       colCount: data[0]?.length ?? 0,
+      startRow,
+      startCol,
     });
   };
 }

--- a/packages/core/src/context-menu/context-menu-manager.ts
+++ b/packages/core/src/context-menu/context-menu-manager.ts
@@ -54,6 +54,18 @@ interface MenuLevel {
 const SUBMENU_OPEN_DELAY = 200;
 const SUBMENU_CLOSE_DELAY = 150;
 
+/** IDs of built-in default menu items that setItems() preserves. */
+export const DEFAULT_MENU_ITEM_IDS = new Set([
+  'cut',
+  'copy',
+  'paste',
+  'sort-asc',
+  'sort-desc',
+  'insert-row-above',
+  'insert-row-below',
+  'delete-row',
+]);
+
 export class ContextMenuManager {
   private readonly container: HTMLElement;
   private readonly engine: SpreadsheetEngine;
@@ -103,20 +115,30 @@ export class ContextMenuManager {
   /** Update locale for runtime locale switching. Replaces default items with new locale strings. */
   setLocale(locale: ResolvedLocale): void {
     // Remove old default items and re-register with new locale
-    const defaultIds = new Set([
-      'cut',
-      'copy',
-      'paste',
-      'sort-asc',
-      'sort-desc',
-      'insert-row-above',
-      'insert-row-below',
-      'delete-row',
-    ]);
-    for (const id of defaultIds) {
+    for (const id of DEFAULT_MENU_ITEM_IDS) {
       this.items.delete(id);
     }
     for (const item of createDefaultMenuItems(locale)) {
+      this.items.set(item.id, item);
+    }
+  }
+
+  /**
+   * Atomically replace all user-registered (custom) menu items.
+   *
+   * Default items (cut, copy, paste, sort, row operations) are preserved
+   * and not affected. Accepts an array of custom items and replaces the
+   * entire custom items registry in one operation.
+   */
+  setItems(items: ReadonlyArray<ContextMenuItem>): void {
+    // Remove all non-default items
+    for (const id of this.items.keys()) {
+      if (!DEFAULT_MENU_ITEM_IDS.has(id)) {
+        this.items.delete(id);
+      }
+    }
+    // Register new custom items
+    for (const item of items) {
       this.items.set(item.id, item);
     }
   }

--- a/packages/core/src/editing/base-calendar-overlay-editor.ts
+++ b/packages/core/src/editing/base-calendar-overlay-editor.ts
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+/**
+ * BaseCalendarOverlayEditor — abstract calendar base for overlay editors.
+ *
+ * Extends {@link BaseOverlayEditor} with calendar-specific state (viewYear,
+ * viewMonth, selectedDate, focusedDay), calendar grid rendering, month
+ * navigation, and day focus movement. DatePickerEditor and DateTimeEditor
+ * extend this class.
+ */
+
+import type { CellValue } from '../types/interfaces';
+import { BaseOverlayEditor } from './base-overlay-editor';
+import {
+  DAYS_IN_WEEK,
+  WEEK_LABELS,
+  MONTH_NAMES,
+  daysInMonth,
+  firstDayOfMonth,
+  isSameDay,
+} from './calendar-utils';
+
+export abstract class BaseCalendarOverlayEditor extends BaseOverlayEditor {
+  // Calendar state
+  protected viewYear = 0;
+  protected viewMonth = 0;
+  protected selectedDate: Date | null = null;
+  protected focusedDay = 1;
+
+  // ─── Abstract methods (calendar-specific) ────────────────────
+
+  /** Parse the cell value into a Date for calendar initialization. */
+  protected abstract parseValue(value: CellValue): Date | null;
+
+  /** Called after base calendar state is initialized. Set up subclass-specific state. */
+  protected abstract initializeState(parsed: Date | null, now: Date): void;
+
+  // ─── BaseOverlayEditor implementation ────────────────────────
+
+  protected initializeFromValue(value: CellValue): void {
+    const parsed = this.parseValue(value);
+    const now = new Date();
+    this.selectedDate = parsed;
+    this.viewYear = parsed ? parsed.getFullYear() : now.getFullYear();
+    this.viewMonth = parsed ? parsed.getMonth() : now.getMonth();
+    this.focusedDay = parsed ? parsed.getDate() : now.getDate();
+    this.initializeState(parsed, now);
+  }
+
+  // ─── Calendar rendering helpers ──────────────────────────────
+
+  /**
+   * Render calendar grid into the overlay: header, week labels, day cells.
+   * @param onDayClick Callback when a day cell is clicked.
+   */
+  protected renderCalendarGrid(onDayClick: (day: number) => void): void {
+    if (!this.overlay || !this.theme) return;
+
+    const theme = this.theme;
+
+    // Header: ◀ Month Year ▶
+    const header = document.createElement('div');
+    header.style.display = 'flex';
+    header.style.alignItems = 'center';
+    header.style.justifyContent = 'space-between';
+    header.style.padding = '8px';
+    header.style.borderBottom = `1px solid ${theme.colors.gridLine}`;
+
+    const prevBtn = this.createNavButton('◀', () => this.navigateMonth(-1));
+    const nextBtn = this.createNavButton('▶', () => this.navigateMonth(1));
+
+    const title = document.createElement('span');
+    title.style.fontWeight = 'bold';
+    const monthNames = this.locale?.datePicker?.monthNames ?? MONTH_NAMES;
+    title.textContent = `${monthNames[this.viewMonth]} ${this.viewYear}`;
+
+    header.appendChild(prevBtn);
+    header.appendChild(title);
+    header.appendChild(nextBtn);
+    this.overlay.appendChild(header);
+
+    // Week labels
+    const weekRow = document.createElement('div');
+    weekRow.style.display = 'grid';
+    weekRow.style.gridTemplateColumns = `repeat(${DAYS_IN_WEEK}, 1fr)`;
+    weekRow.style.padding = '4px 4px 0';
+
+    const weekLabels = this.locale?.datePicker?.weekLabels ?? WEEK_LABELS;
+    for (const label of weekLabels) {
+      const cell = document.createElement('div');
+      cell.style.textAlign = 'center';
+      cell.style.fontSize = '10px';
+      cell.style.color = theme.colors.headerText ?? theme.colors.cellText;
+      cell.style.padding = '2px 0';
+      cell.textContent = label;
+      weekRow.appendChild(cell);
+    }
+    this.overlay.appendChild(weekRow);
+
+    // Day grid
+    const daysGrid = document.createElement('div');
+    daysGrid.style.display = 'grid';
+    daysGrid.style.gridTemplateColumns = `repeat(${DAYS_IN_WEEK}, 1fr)`;
+    daysGrid.style.padding = '4px';
+    daysGrid.style.gap = '2px';
+
+    const firstDay = firstDayOfMonth(this.viewYear, this.viewMonth);
+    const totalDays = daysInMonth(this.viewYear, this.viewMonth);
+    const today = new Date();
+
+    for (let i = 0; i < firstDay; i++) {
+      daysGrid.appendChild(document.createElement('div'));
+    }
+
+    for (let day = 1; day <= totalDays; day++) {
+      const cell = document.createElement('div');
+      cell.textContent = String(day);
+      cell.style.textAlign = 'center';
+      cell.style.padding = '4px 0';
+      cell.style.borderRadius = '3px';
+      cell.style.cursor = 'pointer';
+      cell.dataset.day = String(day);
+
+      const cellDate = new Date(this.viewYear, this.viewMonth, day);
+
+      if (isSameDay(cellDate, today)) {
+        cell.style.border = `1px solid ${theme.colors.activeCellBorder}`;
+      }
+
+      if (this.selectedDate && isSameDay(cellDate, this.selectedDate)) {
+        cell.style.backgroundColor = theme.colors.activeCellBorder;
+        cell.style.color = '#fff';
+      }
+
+      if (day === this.focusedDay) {
+        if (!(this.selectedDate && isSameDay(cellDate, this.selectedDate))) {
+          cell.style.backgroundColor = theme.colors.selectionFill;
+        }
+      }
+
+      cell.addEventListener('mouseenter', () => {
+        if (!(this.selectedDate && isSameDay(cellDate, this.selectedDate))) {
+          cell.style.backgroundColor = theme.colors.selectionFill;
+        }
+      });
+      cell.addEventListener('mouseleave', () => {
+        if (this.selectedDate && isSameDay(cellDate, this.selectedDate)) {
+          cell.style.backgroundColor = theme.colors.activeCellBorder;
+        } else if (day === this.focusedDay) {
+          cell.style.backgroundColor = theme.colors.selectionFill;
+        } else {
+          cell.style.backgroundColor = '';
+        }
+      });
+
+      cell.addEventListener('click', (e) => {
+        e.stopPropagation();
+        onDayClick(day);
+      });
+
+      daysGrid.appendChild(cell);
+    }
+
+    this.overlay.appendChild(daysGrid);
+  }
+
+  /** Create a navigation button (◀/▶). */
+  protected createNavButton(text: string, onClick: () => void): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.textContent = text;
+    btn.style.background = 'none';
+    btn.style.border = 'none';
+    btn.style.cursor = 'pointer';
+    btn.style.fontSize = '12px';
+    btn.style.padding = '4px 8px';
+    btn.style.color = this.theme?.colors.cellText ?? '#333';
+    btn.tabIndex = -1;
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      onClick();
+    });
+    return btn;
+  }
+
+  /** Create a footer action button (Today, Now, OK). */
+  protected createFooterButton(text: string, onClick: () => void): HTMLButtonElement {
+    if (!this.theme) throw new Error('Theme not set');
+    const theme = this.theme;
+    const btn = document.createElement('button');
+    btn.textContent = text;
+    btn.style.background = 'none';
+    btn.style.border = `1px solid ${theme.colors.gridLine}`;
+    btn.style.borderRadius = '3px';
+    btn.style.padding = '2px 12px';
+    btn.style.cursor = 'pointer';
+    btn.style.fontSize = `${theme.fonts.cellSize}px`;
+    btn.style.fontFamily = theme.fonts.cell;
+    btn.style.color = theme.colors.cellText;
+    btn.tabIndex = -1;
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      onClick();
+    });
+    return btn;
+  }
+
+  /** Navigate to the previous or next month. */
+  protected navigateMonth(delta: number): void {
+    this.viewMonth += delta;
+    if (this.viewMonth < 0) {
+      this.viewMonth = 11;
+      this.viewYear--;
+    } else if (this.viewMonth > 11) {
+      this.viewMonth = 0;
+      this.viewYear++;
+    }
+    const maxDays = daysInMonth(this.viewYear, this.viewMonth);
+    if (this.focusedDay > maxDays) this.focusedDay = maxDays;
+    this.rebuildOverlay();
+    this.overlay?.focus();
+  }
+
+  /** Move calendar focus by a number of days. */
+  protected moveFocus(delta: number): void {
+    const newDay = this.focusedDay + delta;
+    const maxDays = daysInMonth(this.viewYear, this.viewMonth);
+
+    if (newDay < 1) {
+      this.navigateMonth(-1);
+      const prevMaxDays = daysInMonth(this.viewYear, this.viewMonth);
+      this.focusedDay = prevMaxDays + newDay;
+      this.rebuildOverlay();
+      this.overlay?.focus();
+      return;
+    }
+    if (newDay > maxDays) {
+      const overflow = newDay - maxDays;
+      this.navigateMonth(1);
+      this.focusedDay = overflow;
+      this.rebuildOverlay();
+      this.overlay?.focus();
+      return;
+    }
+
+    this.focusedDay = newDay;
+    this.rebuildOverlay();
+    this.overlay?.focus();
+  }
+}

--- a/packages/core/src/editing/base-overlay-editor.ts
+++ b/packages/core/src/editing/base-overlay-editor.ts
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+/**
+ * BaseOverlayEditor — abstract base class for overlay cell editors.
+ *
+ * Provides shared overlay lifecycle: positioning relative to the cell,
+ * scroll-close for non-frozen cells, click-outside detection, keyboard
+ * delegation, and theme/locale propagation. Subclasses implement value
+ * initialization, content rendering, and keyboard behavior.
+ *
+ * Calendar-specific editors should extend {@link BaseCalendarOverlayEditor}
+ * which adds calendar grid rendering and month navigation on top of this base.
+ */
+
+import type { SpreadsheetTheme } from '../themes/theme-types';
+import type { CellValue, ColumnDef } from '../types/interfaces';
+import type { LayoutEngine } from '../renderer/layout-engine';
+import type { ScrollManager } from '../renderer/scroll-manager';
+import type { EditorCloseReason } from './inline-editor';
+import type {
+  CellEditor,
+  CellEditorContext,
+  CellEditorCommit,
+  CellEditorClose,
+} from './cell-editor';
+import type { ResolvedLocale } from '../locale/resolve-locale';
+
+export abstract class BaseOverlayEditor implements CellEditor {
+  abstract readonly id: string;
+
+  protected overlay: HTMLDivElement | null = null;
+  protected _isOpen = false;
+  protected _editingRow = -1;
+  protected _editingCol = -1;
+  protected closeFn: CellEditorClose | null = null;
+  protected commitFn: CellEditorCommit | null = null;
+  protected originalValue: CellValue = null;
+
+  // Context refs
+  protected theme: SpreadsheetTheme | null = null;
+  protected locale: ResolvedLocale | null = null;
+  protected column: ColumnDef | null = null;
+  protected container: HTMLElement | null = null;
+  protected scrollContainerEl: HTMLElement | null = null;
+  protected layoutEngine: LayoutEngine | null = null;
+  protected scrollManager: ScrollManager | null = null;
+  protected frozenRows = 0;
+  protected frozenColumns = 0;
+
+  // Event handler refs
+  private scrollHandler: (() => void) | null = null;
+  private outsideClickHandler: ((e: MouseEvent) => void) | null = null;
+
+  // ─── Abstract methods ──────────────────────────────────────
+
+  /** Width of the overlay in pixels. */
+  protected abstract get overlayWidth(): number;
+
+  /** Approximate height of the overlay in pixels (for positioning). */
+  protected abstract get overlayHeight(): number;
+
+  /** ARIA label for the overlay dialog. */
+  protected abstract getAriaLabel(): string;
+
+  /** Called after context is stored. Set up subclass-specific state from the cell value. */
+  protected abstract initializeFromValue(value: CellValue): void;
+
+  /** Render the overlay content. */
+  protected abstract renderContent(): void;
+
+  /** Handle keydown events on the overlay. */
+  protected abstract onKeyDown(e: KeyboardEvent): void;
+
+  // ─── Virtual methods (overridable) ──────────────────────────────
+
+  /** Subclass cleanup on close (e.g., clear input refs). */
+  protected onCloseCleanup(): void {
+    // Default: no-op
+  }
+
+  // ─── CellEditor interface ──────────────────────────────────────
+
+  get isOpen(): boolean {
+    return this._isOpen;
+  }
+
+  get editingRow(): number {
+    return this._editingRow;
+  }
+
+  get editingCol(): number {
+    return this._editingCol;
+  }
+
+  open(context: CellEditorContext, commitFn: CellEditorCommit, closeFn: CellEditorClose): void {
+    if (this._isOpen) {
+      this.close('programmatic');
+    }
+
+    this.closeFn = closeFn;
+    this.commitFn = commitFn;
+    this._editingRow = context.row;
+    this._editingCol = context.col;
+    this.originalValue = context.value;
+    this.theme = context.theme;
+    this.locale = context.locale;
+    this.column = context.column;
+    this.layoutEngine = context.layoutEngine;
+    this.scrollManager = context.scrollManager;
+    this.container = context.container;
+    this.scrollContainerEl = context.scrollContainer;
+    this.frozenRows = context.frozenRows;
+    this.frozenColumns = context.frozenColumns;
+
+    this.initializeFromValue(context.value);
+
+    this.overlay = document.createElement('div');
+    this.overlay.setAttribute('role', 'dialog');
+    this.overlay.setAttribute('aria-label', this.getAriaLabel());
+    this.applyBaseStyles();
+    this.renderContent();
+    this.positionOverlay();
+
+    this.overlay.addEventListener('keydown', this.handleKeyDownBound);
+    context.container.appendChild(this.overlay);
+    this._isOpen = true;
+
+    this.overlay.focus();
+
+    // Scroll closes the editor (unless frozen cell)
+    this.scrollHandler = () => {
+      if (this._isOpen) {
+        if (this._editingRow < this.frozenRows && this._editingCol < this.frozenColumns) return;
+        this.close('scroll');
+      }
+    };
+    if (this.scrollContainerEl) {
+      this.scrollContainerEl.addEventListener('scroll', this.scrollHandler, { passive: true });
+    }
+
+    // Outside click closes
+    this.outsideClickHandler = (e: MouseEvent) => {
+      if (this.overlay && !this.overlay.contains(e.target as Node)) {
+        this.close('blur');
+      }
+    };
+    setTimeout(() => {
+      if (this._isOpen) {
+        document.addEventListener('mousedown', this.outsideClickHandler!);
+      }
+    }, 0);
+  }
+
+  close(reason: EditorCloseReason): void {
+    if (!this._isOpen) return;
+    this._isOpen = false;
+
+    this.onCloseCleanup();
+
+    if (this.overlay) {
+      this.overlay.removeEventListener('keydown', this.handleKeyDownBound);
+      if (this.overlay.parentNode) {
+        this.overlay.parentNode.removeChild(this.overlay);
+      }
+      this.overlay = null;
+    }
+
+    if (this.scrollHandler && this.scrollContainerEl) {
+      this.scrollContainerEl.removeEventListener('scroll', this.scrollHandler);
+      this.scrollHandler = null;
+    }
+
+    if (this.outsideClickHandler) {
+      document.removeEventListener('mousedown', this.outsideClickHandler);
+      this.outsideClickHandler = null;
+    }
+
+    this.closeFn?.(reason);
+  }
+
+  setTheme(theme: SpreadsheetTheme): void {
+    this.theme = theme;
+  }
+
+  setLocale(locale: ResolvedLocale): void {
+    this.locale = locale;
+  }
+
+  destroy(): void {
+    if (this._isOpen) {
+      this.close('programmatic');
+    }
+    this.overlay = null;
+    this.closeFn = null;
+    this.commitFn = null;
+  }
+
+  // ─── Positioning ──────────────────────────────────────
+
+  protected positionOverlay(): void {
+    if (!this.overlay || !this.layoutEngine || !this.scrollManager) return;
+
+    const le = this.layoutEngine;
+    const sm = this.scrollManager;
+
+    const cellRect = le.getCellRect(this._editingRow, this._editingCol);
+    const scrollXOffset = this._editingCol < this.frozenColumns ? 0 : sm.scrollX;
+    const scrollYOffset = this._editingRow < this.frozenRows ? 0 : sm.scrollY;
+
+    const x = cellRect.x - scrollXOffset;
+    const y = cellRect.y - scrollYOffset + cellRect.height;
+
+    if (!this.container) return;
+    const containerRect = this.container.getBoundingClientRect();
+
+    let left = x;
+    let top = y;
+
+    if (left + this.overlayWidth > containerRect.width) {
+      left = containerRect.width - this.overlayWidth;
+    }
+    if (left < 0) left = 0;
+
+    if (top + this.overlayHeight > containerRect.height) {
+      top = cellRect.y - scrollYOffset - this.overlayHeight;
+    }
+    if (top < 0) top = 0;
+
+    const s = this.overlay.style;
+    s.position = 'absolute';
+    s.left = `${left}px`;
+    s.top = `${top}px`;
+    s.zIndex = '50';
+  }
+
+  // ─── Styling ──────────────────────────────────────
+
+  private applyBaseStyles(): void {
+    if (!this.overlay || !this.theme) return;
+
+    const o = this.overlay;
+    o.style.width = `${this.overlayWidth}px`;
+    o.style.backgroundColor = this.theme.colors.cellEditBackground;
+    o.style.border = `1px solid ${this.theme.colors.gridLine}`;
+    o.style.borderRadius = '4px';
+    o.style.boxShadow = '0 2px 8px rgba(0,0,0,0.15)';
+    o.style.fontFamily = this.theme.fonts.cell;
+    o.style.fontSize = `${this.theme.fonts.cellSize}px`;
+    o.style.color = this.theme.colors.cellText;
+    o.style.userSelect = 'none';
+    o.style.outline = 'none';
+    o.tabIndex = 0;
+  }
+
+  /** Clear and re-render overlay content. */
+  protected rebuildOverlay(): void {
+    if (!this.overlay) return;
+    this.overlay.innerHTML = '';
+    this.renderContent();
+  }
+
+  // ─── Internal ──────────────────────────────────────
+
+  private handleKeyDownBound = (e: KeyboardEvent): void => {
+    this.onKeyDown(e);
+  };
+}

--- a/packages/core/src/editing/calendar-utils.ts
+++ b/packages/core/src/editing/calendar-utils.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+/**
+ * Shared calendar utility functions and constants used by overlay editors.
+ */
+
+export const DAYS_IN_WEEK = 7;
+
+export const WEEK_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+export const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+/** Get the number of days in a month (0-indexed month). */
+export function daysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+/** Get day of week (0=Sun) for the first day of a month. */
+export function firstDayOfMonth(year: number, month: number): number {
+  return new Date(year, month, 1).getDay();
+}
+
+/** Compare two dates ignoring time. */
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/** Pad number to 2 digits. */
+export function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** Clamp value between min and max. */
+export function clamp(val: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, val));
+}

--- a/packages/core/src/editing/date-picker-editor.ts
+++ b/packages/core/src/editing/date-picker-editor.ts
@@ -2,97 +2,105 @@
 // Copyright (c) 2025 witqq contributors
 
 /**
- * DatePickerEditor — CellEditor adapter wrapping DatePickerOverlay.
+ * DatePickerEditor — CellEditor for 'date' columns.
  *
- * Registered in CellEditorRegistry for columns with `type: 'date'`.
- * Delegates rendering to DatePickerOverlay with the new CellEditor lifecycle.
+ * Renders a calendar overlay below the target cell. Clicking a day or
+ * pressing Enter commits the date and closes. Extends BaseOverlayEditor
+ * for shared overlay lifecycle and calendar rendering.
  */
 
-import type { SpreadsheetTheme } from '../themes/theme-types';
-import type { ResolvedLocale } from '../locale/resolve-locale';
-import type { EditorCloseReason } from './inline-editor';
-import type {
-  CellEditor,
-  CellEditorContext,
-  CellEditorCommit,
-  CellEditorClose,
-} from './cell-editor';
-import { DatePickerOverlay } from './date-picker-overlay';
+import type { CellValue } from '../types/interfaces';
+import { BaseCalendarOverlayEditor } from './base-calendar-overlay-editor';
+import { formatDate, toDate } from '../utils/date-format';
 
-export class DatePickerEditor implements CellEditor {
+export class DatePickerEditor extends BaseCalendarOverlayEditor {
   readonly id = 'date-picker';
 
-  private overlay: DatePickerOverlay | null = null;
-  private _isOpen = false;
-  private _editingRow = -1;
-  private _editingCol = -1;
-  private closeFn: CellEditorClose | null = null;
-
-  get isOpen(): boolean {
-    return this._isOpen;
+  protected get overlayWidth(): number {
+    return 224;
   }
 
-  get editingRow(): number {
-    return this._editingRow;
+  protected get overlayHeight(): number {
+    return 260;
   }
 
-  get editingCol(): number {
-    return this._editingCol;
+  protected parseValue(value: CellValue): Date | null {
+    return toDate(value, this.column?.dateFormat);
   }
 
-  open(context: CellEditorContext, commitFn: CellEditorCommit, closeFn: CellEditorClose): void {
-    if (this._isOpen) {
-      this.close('programmatic');
-    }
+  protected getAriaLabel(): string {
+    return this.locale?.datePicker?.ariaLabel ?? 'Date picker';
+  }
 
-    this.closeFn = closeFn;
-    this._editingRow = context.row;
-    this._editingCol = context.col;
+  protected initializeState(): void {
+    // No additional state for date-only picker
+  }
 
-    // Create a fresh DatePickerOverlay for each open
-    this.overlay = new DatePickerOverlay({
-      container: context.container,
-      scrollContainer: context.scrollContainer,
-      layoutEngine: context.layoutEngine,
-      scrollManager: context.scrollManager,
-      theme: context.theme,
-      frozenRows: context.frozenRows,
-      frozenColumns: context.frozenColumns,
-      onCommit: commitFn,
-      onClose: (reason: EditorCloseReason) => {
-        this._isOpen = false;
-        this.overlay = null;
-        this.closeFn?.(reason);
+  protected renderContent(): void {
+    this.renderCalendarGrid((day) => this.selectDate(day));
+
+    if (!this.overlay || !this.theme) return;
+
+    // Footer with Today button
+    const footer = document.createElement('div');
+    footer.style.padding = '4px 8px 8px';
+    footer.style.borderTop = `1px solid ${this.theme.colors.gridLine}`;
+    footer.style.textAlign = 'center';
+
+    const todayBtn = this.createFooterButton(
+      this.locale?.datePicker?.today ?? 'Today',
+      () => {
+        const t = new Date();
+        this.viewYear = t.getFullYear();
+        this.viewMonth = t.getMonth();
+        this.selectDate(t.getDate());
       },
-    });
+    );
+    footer.appendChild(todayBtn);
+    this.overlay.appendChild(footer);
+  }
 
-    if (context.locale) {
-      this.overlay.setLocale(context.locale);
+  protected onKeyDown(e: KeyboardEvent): void {
+    e.stopPropagation();
+
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        this.close('escape');
+        break;
+      case 'Enter':
+        e.preventDefault();
+        this.selectDate(this.focusedDay);
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        this.moveFocus(-1);
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        this.moveFocus(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        this.moveFocus(-7);
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        this.moveFocus(7);
+        break;
+      case 'Tab':
+        e.preventDefault();
+        this.selectDate(this.focusedDay);
+        break;
     }
-
-    this.overlay.open(context.row, context.col, context.value);
-    this._isOpen = true;
   }
 
-  close(reason: EditorCloseReason): void {
-    if (!this._isOpen || !this.overlay) return;
-    this.overlay.close(reason);
-    // The onClose callback sets _isOpen = false and clears overlay
-  }
-
-  setTheme(theme: SpreadsheetTheme): void {
-    this.overlay?.setTheme(theme);
-  }
-
-  setLocale(locale: ResolvedLocale): void {
-    this.overlay?.setLocale(locale);
-  }
-
-  destroy(): void {
-    if (this._isOpen) {
-      this.close('programmatic');
-    }
-    this.overlay = null;
-    this.closeFn = null;
+  private selectDate(day: number): void {
+    const date = new Date(this.viewYear, this.viewMonth, day);
+    const commitStr = this.column?.dateFormat
+      ? formatDate(date, this.column.dateFormat)
+      : `${this.viewYear}-${String(this.viewMonth + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    this.commitFn?.(this._editingRow, this._editingCol, this.originalValue, commitStr);
+    this.close('enter');
   }
 }

--- a/packages/core/src/editing/date-picker-overlay.ts
+++ b/packages/core/src/editing/date-picker-overlay.ts
@@ -16,6 +16,15 @@ import type { SpreadsheetTheme } from '../themes/theme-types';
 import type { CellValue } from '../types/interfaces';
 import type { EditorCloseReason } from './inline-editor';
 import type { ResolvedLocale } from '../locale/resolve-locale';
+import { formatDate, toDate } from '../utils/date-format';
+import {
+  DAYS_IN_WEEK,
+  WEEK_LABELS,
+  MONTH_NAMES,
+  daysInMonth,
+  firstDayOfMonth,
+  isSameDay,
+} from './calendar-utils';
 
 export interface DatePickerConfig {
   container: HTMLElement;
@@ -27,61 +36,12 @@ export interface DatePickerConfig {
   onClose: (reason: EditorCloseReason) => void;
   frozenRows?: number;
   frozenColumns?: number;
+  dateFormat?: string;
 }
-
-const DAYS_IN_WEEK = 7;
-const WEEK_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
 
 /** Parse a cell value into a Date (local time) or null. */
-function parseDate(value: CellValue): Date | null {
-  if (value instanceof Date && !isNaN(value.getTime())) return value;
-  if (typeof value === 'string') {
-    // Parse YYYY-MM-DD as local date (avoid UTC interpretation)
-    const isoMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-    if (isoMatch) {
-      return new Date(Number(isoMatch[1]), Number(isoMatch[2]) - 1, Number(isoMatch[3]));
-    }
-    const d = new Date(value);
-    if (!isNaN(d.getTime())) return d;
-  }
-  if (typeof value === 'number') {
-    const d = new Date(value);
-    if (!isNaN(d.getTime())) return d;
-  }
-  return null;
-}
-
-/** Get the number of days in a month (0-indexed month). */
-function daysInMonth(year: number, month: number): number {
-  return new Date(year, month + 1, 0).getDate();
-}
-
-/** Get day of week (0=Sun) for the first day of a month. */
-function firstDayOfMonth(year: number, month: number): number {
-  return new Date(year, month, 1).getDay();
-}
-
-/** Compare two dates ignoring time. */
-function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
+function parseDate(value: CellValue, dateFormat?: string): Date | null {
+  return toDate(value, dateFormat);
 }
 
 export class DatePickerOverlay {
@@ -144,7 +104,7 @@ export class DatePickerOverlay {
     this.currentCol = col;
     this.originalValue = currentValue;
 
-    const parsed = parseDate(currentValue);
+    const parsed = parseDate(currentValue, this.config.dateFormat);
     const today = new Date();
     this.selectedDate = parsed;
     this.viewYear = parsed ? parsed.getFullYear() : today.getFullYear();
@@ -216,11 +176,11 @@ export class DatePickerOverlay {
 
   /** Select a date, commit value, and close. */
   private selectDate(day: number): void {
-    // Format as YYYY-MM-DD using local date components (avoid UTC timezone shift)
-    const mm = String(this.viewMonth + 1).padStart(2, '0');
-    const dd = String(day).padStart(2, '0');
-    const isoStr = `${this.viewYear}-${mm}-${dd}`;
-    this.config.onCommit(this.currentRow, this.currentCol, this.originalValue, isoStr);
+    const date = new Date(this.viewYear, this.viewMonth, day);
+    const commitStr = this.config.dateFormat
+      ? formatDate(date, this.config.dateFormat)
+      : `${this.viewYear}-${String(this.viewMonth + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    this.config.onCommit(this.currentRow, this.currentCol, this.originalValue, commitStr);
     this.close('enter');
   }
 

--- a/packages/core/src/editing/date-time-editor.ts
+++ b/packages/core/src/editing/date-time-editor.ts
@@ -6,42 +6,41 @@
  *
  * Renders a combined date+time picker: calendar grid on top, hour/minute
  * spin controls below. Commits an ISO datetime string (YYYY-MM-DDTHH:mm).
+ * Extends BaseOverlayEditor for shared overlay lifecycle and calendar rendering.
  */
 
-import type { LayoutEngine } from '../renderer/layout-engine';
-import type { ScrollManager } from '../renderer/scroll-manager';
-import type { SpreadsheetTheme } from '../themes/theme-types';
 import type { CellValue } from '../types/interfaces';
-import type { EditorCloseReason } from './inline-editor';
-import type {
-  CellEditor,
-  CellEditorContext,
-  CellEditorCommit,
-  CellEditorClose,
-} from './cell-editor';
-import type { ResolvedLocale } from '../locale/resolve-locale';
+import { BaseCalendarOverlayEditor } from './base-calendar-overlay-editor';
+import { formatDate, toDate } from '../utils/date-format';
+import { pad2, clamp } from './calendar-utils';
 
-const DAYS_IN_WEEK = 7;
-const WEEK_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
-
-/** Parse a cell value into a Date (local time) or null. */
-function parseDateTime(value: CellValue): Date | null {
+/** Parse a cell value into a Date (local time) or null, with datetime support. */
+function parseDateTime(value: CellValue, dateFormat?: string): Date | null {
   if (value instanceof Date && !isNaN(value.getTime())) return value;
   if (typeof value === 'string') {
+    // Try custom dateFormat with time suffix: "DD.MM.YYYYTHH:mm"
+    if (dateFormat) {
+      const tIdx = value.indexOf('T');
+      if (tIdx > 0) {
+        const datePart = value.substring(0, tIdx);
+        const timePart = value.substring(tIdx + 1);
+        const date = toDate(datePart, dateFormat);
+        if (date) {
+          const timeMatch = timePart.match(/^(\d{2}):(\d{2})(?::(\d{2}))?$/);
+          if (timeMatch) {
+            date.setHours(
+              Number(timeMatch[1]),
+              Number(timeMatch[2]),
+              timeMatch[3] ? Number(timeMatch[3]) : 0,
+            );
+            return date;
+          }
+        }
+      }
+      // Try date-only with custom format
+      const date = toDate(value, dateFormat);
+      if (date) return date;
+    }
     // ISO datetime: YYYY-MM-DDTHH:mm or YYYY-MM-DDTHH:mm:ss
     const isoMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/);
     if (isoMatch) {
@@ -69,53 +68,14 @@ function parseDateTime(value: CellValue): Date | null {
   return null;
 }
 
-function daysInMonth(year: number, month: number): number {
-  return new Date(year, month + 1, 0).getDate();
-}
-
-function firstDayOfMonth(year: number, month: number): number {
-  return new Date(year, month, 1).getDay();
-}
-
-function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
-}
-
-function pad2(n: number): string {
-  return String(n).padStart(2, '0');
-}
-
-/** Clamp value between min and max. */
-function clamp(val: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, val));
-}
-
 /**
  * Focus section identifier for keyboard Tab cycling.
  * calendar → hour → minute → calendar → ...
  */
 type FocusSection = 'calendar' | 'hour' | 'minute';
 
-export class DateTimeEditor implements CellEditor {
+export class DateTimeEditor extends BaseCalendarOverlayEditor {
   readonly id = 'date-time-picker';
-
-  private overlay: HTMLDivElement | null = null;
-  private _isOpen = false;
-  private _editingRow = -1;
-  private _editingCol = -1;
-  private closeFn: CellEditorClose | null = null;
-  private commitFn: CellEditorCommit | null = null;
-  private originalValue: CellValue = null;
-
-  // Calendar state
-  private viewYear = 0;
-  private viewMonth = 0;
-  private selectedDate: Date | null = null;
-  private focusedDay = 1;
 
   // Time state
   private hour = 0;
@@ -126,334 +86,46 @@ export class DateTimeEditor implements CellEditor {
   private hourInput: HTMLInputElement | null = null;
   private minuteInput: HTMLInputElement | null = null;
 
-  // Event handler refs
-  private scrollHandler: (() => void) | null = null;
-  private outsideClickHandler: ((e: MouseEvent) => void) | null = null;
-  private scrollContainer: HTMLElement | null = null;
-
-  // Layout refs (for positioning)
-  private layoutEngine: LayoutEngine | null = null;
-  private scrollManager: ScrollManager | null = null;
-  private container: HTMLElement | null = null;
-  private frozenRows = 0;
-  private frozenColumns = 0;
-
-  private theme: SpreadsheetTheme | null = null;
-  private locale: ResolvedLocale | null = null;
-
-  get isOpen(): boolean {
-    return this._isOpen;
+  protected get overlayWidth(): number {
+    return 240;
   }
 
-  get editingRow(): number {
-    return this._editingRow;
+  protected get overlayHeight(): number {
+    return 320;
   }
 
-  get editingCol(): number {
-    return this._editingCol;
+  protected parseValue(value: CellValue): Date | null {
+    return parseDateTime(value, this.column?.dateFormat);
   }
 
-  open(context: CellEditorContext, commitFn: CellEditorCommit, closeFn: CellEditorClose): void {
-    if (this._isOpen) {
-      this.close('programmatic');
-    }
+  protected getAriaLabel(): string {
+    return this.locale?.dateTimePicker?.ariaLabel ?? 'Date and time picker';
+  }
 
-    this.closeFn = closeFn;
-    this.commitFn = commitFn;
-    this._editingRow = context.row;
-    this._editingCol = context.col;
-    this.originalValue = context.value;
-    this.theme = context.theme;
-    this.locale = context.locale;
-    this.layoutEngine = context.layoutEngine;
-    this.scrollManager = context.scrollManager;
-    this.container = context.container;
-    this.frozenRows = context.frozenRows;
-    this.frozenColumns = context.frozenColumns;
-
-    const parsed = parseDateTime(context.value);
-    const now = new Date();
-    this.selectedDate = parsed;
-    this.viewYear = parsed ? parsed.getFullYear() : now.getFullYear();
-    this.viewMonth = parsed ? parsed.getMonth() : now.getMonth();
-    this.focusedDay = parsed ? parsed.getDate() : now.getDate();
+  protected initializeState(parsed: Date | null, now: Date): void {
     this.hour = parsed ? parsed.getHours() : now.getHours();
     this.minute = parsed ? parsed.getMinutes() : now.getMinutes();
     this.focusSection = 'calendar';
-
-    this.overlay = document.createElement('div');
-    this.overlay.setAttribute('role', 'dialog');
-    this.overlay.setAttribute(
-      'aria-label',
-      this.locale?.dateTimePicker?.ariaLabel ?? 'Date and time picker',
-    );
-    this.renderOverlay();
-    this.positionOverlay();
-
-    context.container.appendChild(this.overlay);
-    this._isOpen = true;
-
-    this.overlay.focus();
-
-    // Scroll closes the picker (unless frozen cell)
-    this.scrollHandler = () => {
-      if (this._isOpen) {
-        if (this._editingRow < this.frozenRows && this._editingCol < this.frozenColumns) return;
-        this.close('scroll');
-      }
-    };
-    this.scrollContainer = context.scrollContainer;
-    this.scrollContainer.addEventListener('scroll', this.scrollHandler, { passive: true });
-
-    this.outsideClickHandler = (e: MouseEvent) => {
-      if (this.overlay && !this.overlay.contains(e.target as Node)) {
-        this.close('blur');
-      }
-    };
-    setTimeout(() => {
-      if (this._isOpen) {
-        document.addEventListener('mousedown', this.outsideClickHandler!);
-      }
-    }, 0);
   }
 
-  close(reason: EditorCloseReason): void {
-    if (!this._isOpen) return;
-    this._isOpen = false;
-
-    if (this.overlay) {
-      this.overlay.removeEventListener('keydown', this.handleKeyDown);
-      if (this.overlay.parentNode) {
-        this.overlay.parentNode.removeChild(this.overlay);
-      }
-      this.overlay = null;
-    }
-
+  protected onCloseCleanup(): void {
     this.hourInput = null;
     this.minuteInput = null;
-
-    if (this.scrollHandler && this.scrollContainer) {
-      this.scrollContainer.removeEventListener('scroll', this.scrollHandler);
-      this.scrollHandler = null;
-      this.scrollContainer = null;
-    }
-
-    if (this.outsideClickHandler) {
-      document.removeEventListener('mousedown', this.outsideClickHandler);
-      this.outsideClickHandler = null;
-    }
-
-    this.closeFn?.(reason);
   }
 
-  setTheme(theme: SpreadsheetTheme): void {
-    this.theme = theme;
-  }
+  protected renderContent(): void {
+    // Calendar grid — day click selects (no commit)
+    this.renderCalendarGrid((day) => {
+      this.focusedDay = day;
+      this.selectedDate = new Date(this.viewYear, this.viewMonth, day, this.hour, this.minute);
+      this.rebuildOverlay();
+      this.overlay?.focus();
+    });
 
-  setLocale(locale: ResolvedLocale): void {
-    this.locale = locale;
-  }
-
-  destroy(): void {
-    if (this._isOpen) {
-      this.close('programmatic');
-    }
-    this.overlay = null;
-    this.closeFn = null;
-    this.commitFn = null;
-  }
-
-  // ─── Commit ──────────────────────────────────────
-
-  private commitValue(): void {
-    const mm = pad2(this.viewMonth + 1);
-    const dd = pad2(this.focusedDay);
-    const hh = pad2(this.hour);
-    const mi = pad2(this.minute);
-    const isoStr = `${this.viewYear}-${mm}-${dd}T${hh}:${mi}`;
-    this.commitFn?.(this._editingRow, this._editingCol, this.originalValue, isoStr);
-    this.close('enter');
-  }
-
-  // ─── Positioning ──────────────────────────────────────
-
-  private positionOverlay(): void {
-    if (!this.overlay || !this.layoutEngine || !this.scrollManager) return;
-
-    const le = this.layoutEngine;
-    const sm = this.scrollManager;
-
-    const cellRect = le.getCellRect(this._editingRow, this._editingCol);
-    const scrollXOffset = this._editingCol < this.frozenColumns ? 0 : sm.scrollX;
-    const scrollYOffset = this._editingRow < this.frozenRows ? 0 : sm.scrollY;
-
-    const x = cellRect.x - scrollXOffset;
-    const y = cellRect.y - scrollYOffset + cellRect.height;
-
-    const containerEl = this.container;
-    if (!containerEl) return;
-    const containerRect = containerEl.getBoundingClientRect();
-    const overlayWidth = 240;
-    const overlayHeight = 320;
-
-    let left = x;
-    let top = y;
-
-    if (left + overlayWidth > containerRect.width) {
-      left = containerRect.width - overlayWidth;
-    }
-    if (left < 0) left = 0;
-
-    if (top + overlayHeight > containerRect.height) {
-      top = cellRect.y - scrollYOffset - overlayHeight;
-    }
-    if (top < 0) top = 0;
-
-    const s = this.overlay.style;
-    s.position = 'absolute';
-    s.left = `${left}px`;
-    s.top = `${top}px`;
-    s.zIndex = '50';
-  }
-
-  // ─── Rendering ──────────────────────────────────────
-
-  private renderOverlay(): void {
     if (!this.overlay || !this.theme) return;
-
-    const o = this.overlay;
-    o.style.width = '240px';
-    o.style.backgroundColor = this.theme.colors.cellEditBackground;
-    o.style.border = `1px solid ${this.theme.colors.gridLine}`;
-    o.style.borderRadius = '4px';
-    o.style.boxShadow = '0 2px 8px rgba(0,0,0,0.15)';
-    o.style.fontFamily = this.theme.fonts.cell;
-    o.style.fontSize = `${this.theme.fonts.cellSize}px`;
-    o.style.color = this.theme.colors.cellText;
-    o.style.userSelect = 'none';
-    o.style.outline = 'none';
-    o.tabIndex = 0;
-
-    this.rebuildCalendar();
-
-    o.addEventListener('keydown', this.handleKeyDown);
-  }
-
-  private rebuildCalendar(): void {
-    if (!this.overlay || !this.theme) return;
-    this.overlay.innerHTML = '';
-
     const theme = this.theme;
 
-    // ── Header: < Month Year >
-    const header = document.createElement('div');
-    header.style.display = 'flex';
-    header.style.alignItems = 'center';
-    header.style.justifyContent = 'space-between';
-    header.style.padding = '8px';
-    header.style.borderBottom = `1px solid ${theme.colors.gridLine}`;
-
-    const prevBtn = this.createNavButton('◀', () => this.navigateMonth(-1));
-    const nextBtn = this.createNavButton('▶', () => this.navigateMonth(1));
-
-    const title = document.createElement('span');
-    title.style.fontWeight = 'bold';
-    const monthNames = this.locale?.datePicker?.monthNames ?? MONTH_NAMES;
-    title.textContent = `${monthNames[this.viewMonth]} ${this.viewYear}`;
-
-    header.appendChild(prevBtn);
-    header.appendChild(title);
-    header.appendChild(nextBtn);
-    this.overlay.appendChild(header);
-
-    // ── Day-of-week labels
-    const weekRow = document.createElement('div');
-    weekRow.style.display = 'grid';
-    weekRow.style.gridTemplateColumns = `repeat(${DAYS_IN_WEEK}, 1fr)`;
-    weekRow.style.padding = '4px 4px 0';
-
-    const weekLabels = this.locale?.datePicker?.weekLabels ?? WEEK_LABELS;
-    for (const label of weekLabels) {
-      const cell = document.createElement('div');
-      cell.style.textAlign = 'center';
-      cell.style.fontSize = '10px';
-      cell.style.color = theme.colors.headerText ?? theme.colors.cellText;
-      cell.style.padding = '2px 0';
-      cell.textContent = label;
-      weekRow.appendChild(cell);
-    }
-    this.overlay.appendChild(weekRow);
-
-    // ── Day grid
-    const daysGrid = document.createElement('div');
-    daysGrid.style.display = 'grid';
-    daysGrid.style.gridTemplateColumns = `repeat(${DAYS_IN_WEEK}, 1fr)`;
-    daysGrid.style.padding = '4px';
-    daysGrid.style.gap = '2px';
-
-    const firstDay = firstDayOfMonth(this.viewYear, this.viewMonth);
-    const totalDays = daysInMonth(this.viewYear, this.viewMonth);
-    const today = new Date();
-
-    for (let i = 0; i < firstDay; i++) {
-      daysGrid.appendChild(document.createElement('div'));
-    }
-
-    for (let day = 1; day <= totalDays; day++) {
-      const cell = document.createElement('div');
-      cell.textContent = String(day);
-      cell.style.textAlign = 'center';
-      cell.style.padding = '4px 0';
-      cell.style.borderRadius = '3px';
-      cell.style.cursor = 'pointer';
-      cell.dataset.day = String(day);
-
-      const cellDate = new Date(this.viewYear, this.viewMonth, day);
-
-      if (isSameDay(cellDate, today)) {
-        cell.style.border = `1px solid ${theme.colors.activeCellBorder}`;
-      }
-
-      if (this.selectedDate && isSameDay(cellDate, this.selectedDate)) {
-        cell.style.backgroundColor = theme.colors.activeCellBorder;
-        cell.style.color = '#fff';
-      }
-
-      if (day === this.focusedDay) {
-        if (!(this.selectedDate && isSameDay(cellDate, this.selectedDate))) {
-          cell.style.backgroundColor = theme.colors.selectionFill;
-        }
-      }
-
-      cell.addEventListener('mouseenter', () => {
-        if (!(this.selectedDate && isSameDay(cellDate, this.selectedDate))) {
-          cell.style.backgroundColor = theme.colors.selectionFill;
-        }
-      });
-      cell.addEventListener('mouseleave', () => {
-        if (this.selectedDate && isSameDay(cellDate, this.selectedDate)) {
-          cell.style.backgroundColor = theme.colors.activeCellBorder;
-        } else if (day === this.focusedDay) {
-          cell.style.backgroundColor = theme.colors.selectionFill;
-        } else {
-          cell.style.backgroundColor = '';
-        }
-      });
-
-      cell.addEventListener('click', (e) => {
-        e.stopPropagation();
-        this.focusedDay = day;
-        this.selectedDate = new Date(this.viewYear, this.viewMonth, day, this.hour, this.minute);
-        this.rebuildCalendar();
-        this.overlay?.focus();
-      });
-
-      daysGrid.appendChild(cell);
-    }
-
-    this.overlay.appendChild(daysGrid);
-
-    // ── Time controls
+    // Time controls
     const timeRow = document.createElement('div');
     timeRow.style.display = 'flex';
     timeRow.style.alignItems = 'center';
@@ -465,19 +137,16 @@ export class DateTimeEditor implements CellEditor {
     const hourLabel = this.locale?.dateTimePicker?.hour ?? 'Hour';
     const minuteLabel = this.locale?.dateTimePicker?.minute ?? 'Minute';
 
-    // Hour spin
     const hourGroup = this.createSpinGroup(hourLabel, this.hour, 0, 23, (val) => {
       this.hour = val;
     });
     this.hourInput = hourGroup.input;
 
-    // Separator
     const sep = document.createElement('span');
     sep.textContent = ':';
     sep.style.fontWeight = 'bold';
     sep.style.fontSize = '14px';
 
-    // Minute spin
     const minuteGroup = this.createSpinGroup(minuteLabel, this.minute, 0, 59, (val) => {
       this.minute = val;
     });
@@ -488,7 +157,7 @@ export class DateTimeEditor implements CellEditor {
     timeRow.appendChild(minuteGroup.el);
     this.overlay.appendChild(timeRow);
 
-    // ── Footer: Now + Commit
+    // Footer: Now + OK
     const footer = document.createElement('div');
     footer.style.display = 'flex';
     footer.style.justifyContent = 'space-between';
@@ -503,7 +172,7 @@ export class DateTimeEditor implements CellEditor {
       this.hour = n.getHours();
       this.minute = n.getMinutes();
       this.selectedDate = n;
-      this.rebuildCalendar();
+      this.rebuildOverlay();
       this.overlay?.focus();
     });
 
@@ -516,217 +185,11 @@ export class DateTimeEditor implements CellEditor {
     footer.appendChild(okBtn);
     this.overlay.appendChild(footer);
 
-    // Apply focus highlight
     this.applyFocusSectionStyle();
   }
 
-  private createSpinGroup(
-    label: string,
-    value: number,
-    min: number,
-    max: number,
-    onChange: (val: number) => void,
-  ): { el: HTMLDivElement; input: HTMLInputElement } {
-    const theme = this.theme!;
-    const group = document.createElement('div');
-    group.style.display = 'flex';
-    group.style.flexDirection = 'column';
-    group.style.alignItems = 'center';
-    group.style.gap = '2px';
-
-    const lbl = document.createElement('div');
-    lbl.textContent = label;
-    lbl.style.fontSize = '9px';
-    lbl.style.color = theme.colors.headerText ?? theme.colors.cellText;
-    group.appendChild(lbl);
-
-    const upBtn = this.createSpinButton('▲', () => {
-      const next = value >= max ? min : value + 1;
-      onChange(next);
-      this.rebuildCalendar();
-      this.overlay?.focus();
-    });
-
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.value = pad2(value);
-    input.style.width = '32px';
-    input.style.textAlign = 'center';
-    input.style.border = `1px solid ${theme.colors.gridLine}`;
-    input.style.borderRadius = '3px';
-    input.style.padding = '2px 0';
-    input.style.fontSize = `${theme.fonts.cellSize}px`;
-    input.style.fontFamily = theme.fonts.cell;
-    input.style.color = theme.colors.cellText;
-    input.style.backgroundColor = theme.colors.cellEditBackground;
-    input.style.outline = 'none';
-
-    input.addEventListener('focus', (e) => {
-      (e.target as HTMLInputElement).select();
-    });
-    input.addEventListener('change', () => {
-      const parsed = parseInt(input.value, 10);
-      if (!isNaN(parsed)) {
-        const clamped = clamp(parsed, min, max);
-        onChange(clamped);
-        input.value = pad2(clamped);
-      } else {
-        input.value = pad2(value);
-      }
-    });
-    // Allow arrow keys on the input to increment/decrement
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        e.stopPropagation();
-        const next = value >= max ? min : value + 1;
-        onChange(next);
-        this.rebuildCalendar();
-        // Re-focus the corresponding input after rebuild
-        if (this.focusSection === 'hour') this.hourInput?.focus();
-        else if (this.focusSection === 'minute') this.minuteInput?.focus();
-      } else if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        e.stopPropagation();
-        const next = value <= min ? max : value - 1;
-        onChange(next);
-        this.rebuildCalendar();
-        if (this.focusSection === 'hour') this.hourInput?.focus();
-        else if (this.focusSection === 'minute') this.minuteInput?.focus();
-      } else if (e.key === 'Enter') {
-        e.preventDefault();
-        e.stopPropagation();
-        // Trigger change first
-        input.dispatchEvent(new Event('change'));
-        this.commitValue();
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        e.stopPropagation();
-        this.close('escape');
-      } else if (e.key === 'Tab') {
-        e.preventDefault();
-        e.stopPropagation();
-        this.cycleFocus(e.shiftKey ? -1 : 1);
-      }
-    });
-
-    const downBtn = this.createSpinButton('▼', () => {
-      const next = value <= min ? max : value - 1;
-      onChange(next);
-      this.rebuildCalendar();
-      this.overlay?.focus();
-    });
-
-    group.appendChild(upBtn);
-    group.appendChild(input);
-    group.appendChild(downBtn);
-
-    return { el: group, input };
-  }
-
-  private createSpinButton(text: string, onClick: () => void): HTMLButtonElement {
-    const btn = document.createElement('button');
-    btn.textContent = text;
-    btn.style.background = 'none';
-    btn.style.border = 'none';
-    btn.style.cursor = 'pointer';
-    btn.style.fontSize = '8px';
-    btn.style.padding = '0 4px';
-    btn.style.color = this.theme?.colors.cellText ?? '#333';
-    btn.style.lineHeight = '1';
-    btn.tabIndex = -1;
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      onClick();
-    });
-    return btn;
-  }
-
-  private createNavButton(text: string, onClick: () => void): HTMLButtonElement {
-    const btn = document.createElement('button');
-    btn.textContent = text;
-    btn.style.background = 'none';
-    btn.style.border = 'none';
-    btn.style.cursor = 'pointer';
-    btn.style.fontSize = '12px';
-    btn.style.padding = '4px 8px';
-    btn.style.color = this.theme?.colors.cellText ?? '#333';
-    btn.tabIndex = -1;
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      onClick();
-    });
-    return btn;
-  }
-
-  private createFooterButton(text: string, onClick: () => void): HTMLButtonElement {
-    const theme = this.theme!;
-    const btn = document.createElement('button');
-    btn.textContent = text;
-    btn.style.background = 'none';
-    btn.style.border = `1px solid ${theme.colors.gridLine}`;
-    btn.style.borderRadius = '3px';
-    btn.style.padding = '2px 12px';
-    btn.style.cursor = 'pointer';
-    btn.style.fontSize = `${theme.fonts.cellSize}px`;
-    btn.style.fontFamily = theme.fonts.cell;
-    btn.style.color = theme.colors.cellText;
-    btn.tabIndex = -1;
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      onClick();
-    });
-    return btn;
-  }
-
-  private applyFocusSectionStyle(): void {
-    if (!this.theme) return;
-    const activeShadow = `0 0 0 1px ${this.theme.colors.activeCellBorder}`;
-    if (this.hourInput) {
-      this.hourInput.style.boxShadow = this.focusSection === 'hour' ? activeShadow : '';
-    }
-    if (this.minuteInput) {
-      this.minuteInput.style.boxShadow = this.focusSection === 'minute' ? activeShadow : '';
-    }
-  }
-
-  private navigateMonth(delta: number): void {
-    this.viewMonth += delta;
-    if (this.viewMonth < 0) {
-      this.viewMonth = 11;
-      this.viewYear--;
-    } else if (this.viewMonth > 11) {
-      this.viewMonth = 0;
-      this.viewYear++;
-    }
-    const maxDays = daysInMonth(this.viewYear, this.viewMonth);
-    if (this.focusedDay > maxDays) this.focusedDay = maxDays;
-    this.rebuildCalendar();
-    this.overlay?.focus();
-  }
-
-  // ─── Focus cycling ──────────────────────────────────────
-
-  private cycleFocus(direction: number): void {
-    const sections: FocusSection[] = ['calendar', 'hour', 'minute'];
-    const idx = sections.indexOf(this.focusSection);
-    const next = (idx + direction + sections.length) % sections.length;
-    this.focusSection = sections[next];
-    this.applyFocusSectionStyle();
-
-    if (this.focusSection === 'hour' && this.hourInput) {
-      this.hourInput.focus();
-    } else if (this.focusSection === 'minute' && this.minuteInput) {
-      this.minuteInput.focus();
-    } else {
-      this.overlay?.focus();
-    }
-  }
-
-  // ─── Keyboard ──────────────────────────────────────
-
-  private handleKeyDown = (e: KeyboardEvent): void => {
-    // If an input has focus, let it handle its own keys (handled in createSpinGroup)
+  protected onKeyDown(e: KeyboardEvent): void {
+    // Let input elements handle their own keys
     if (e.target instanceof HTMLInputElement) return;
 
     e.stopPropagation();
@@ -769,31 +232,163 @@ export class DateTimeEditor implements CellEditor {
         }
         break;
     }
-  };
+  }
 
-  private moveFocus(delta: number): void {
-    const newDay = this.focusedDay + delta;
-    const maxDays = daysInMonth(this.viewYear, this.viewMonth);
+  // ─── DateTime-specific methods ──────────────────────────────
 
-    if (newDay < 1) {
-      this.navigateMonth(-1);
-      const prevMaxDays = daysInMonth(this.viewYear, this.viewMonth);
-      this.focusedDay = prevMaxDays + newDay;
-      this.rebuildCalendar();
+  private commitValue(): void {
+    const date = new Date(this.viewYear, this.viewMonth, this.focusedDay);
+    const datePart = this.column?.dateFormat
+      ? formatDate(date, this.column.dateFormat)
+      : `${this.viewYear}-${pad2(this.viewMonth + 1)}-${pad2(this.focusedDay)}`;
+    const commitStr = `${datePart}T${pad2(this.hour)}:${pad2(this.minute)}`;
+    this.commitFn?.(this._editingRow, this._editingCol, this.originalValue, commitStr);
+    this.close('enter');
+  }
+
+  private cycleFocus(direction: number): void {
+    const sections: FocusSection[] = ['calendar', 'hour', 'minute'];
+    const idx = sections.indexOf(this.focusSection);
+    const next = (idx + direction + sections.length) % sections.length;
+    this.focusSection = sections[next];
+    this.applyFocusSectionStyle();
+
+    if (this.focusSection === 'hour' && this.hourInput) {
+      this.hourInput.focus();
+    } else if (this.focusSection === 'minute' && this.minuteInput) {
+      this.minuteInput.focus();
+    } else {
       this.overlay?.focus();
-      return;
     }
-    if (newDay > maxDays) {
-      const overflow = newDay - maxDays;
-      this.navigateMonth(1);
-      this.focusedDay = overflow;
-      this.rebuildCalendar();
-      this.overlay?.focus();
-      return;
-    }
+  }
 
-    this.focusedDay = newDay;
-    this.rebuildCalendar();
-    this.overlay?.focus();
+  private applyFocusSectionStyle(): void {
+    if (!this.theme) return;
+    const activeShadow = `0 0 0 1px ${this.theme.colors.activeCellBorder}`;
+    if (this.hourInput) {
+      this.hourInput.style.boxShadow = this.focusSection === 'hour' ? activeShadow : '';
+    }
+    if (this.minuteInput) {
+      this.minuteInput.style.boxShadow = this.focusSection === 'minute' ? activeShadow : '';
+    }
+  }
+
+  private createSpinGroup(
+    label: string,
+    value: number,
+    min: number,
+    max: number,
+    onChange: (val: number) => void,
+  ): { el: HTMLDivElement; input: HTMLInputElement } {
+    const theme = this.theme!;
+    const group = document.createElement('div');
+    group.style.display = 'flex';
+    group.style.flexDirection = 'column';
+    group.style.alignItems = 'center';
+    group.style.gap = '2px';
+
+    const lbl = document.createElement('div');
+    lbl.textContent = label;
+    lbl.style.fontSize = '9px';
+    lbl.style.color = theme.colors.headerText ?? theme.colors.cellText;
+    group.appendChild(lbl);
+
+    const upBtn = this.createSpinButton('▲', () => {
+      const next = value >= max ? min : value + 1;
+      onChange(next);
+      this.rebuildOverlay();
+      this.overlay?.focus();
+    });
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = pad2(value);
+    input.style.width = '32px';
+    input.style.textAlign = 'center';
+    input.style.border = `1px solid ${theme.colors.gridLine}`;
+    input.style.borderRadius = '3px';
+    input.style.padding = '2px 0';
+    input.style.fontSize = `${theme.fonts.cellSize}px`;
+    input.style.fontFamily = theme.fonts.cell;
+    input.style.color = theme.colors.cellText;
+    input.style.backgroundColor = theme.colors.cellEditBackground;
+    input.style.outline = 'none';
+
+    input.addEventListener('focus', (e) => {
+      (e.target as HTMLInputElement).select();
+    });
+    input.addEventListener('change', () => {
+      const parsed = parseInt(input.value, 10);
+      if (!isNaN(parsed)) {
+        const clamped = clamp(parsed, min, max);
+        onChange(clamped);
+        input.value = pad2(clamped);
+      } else {
+        input.value = pad2(value);
+      }
+    });
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        e.stopPropagation();
+        const next = value >= max ? min : value + 1;
+        onChange(next);
+        this.rebuildOverlay();
+        if (this.focusSection === 'hour') this.hourInput?.focus();
+        else if (this.focusSection === 'minute') this.minuteInput?.focus();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        e.stopPropagation();
+        const next = value <= min ? max : value - 1;
+        onChange(next);
+        this.rebuildOverlay();
+        if (this.focusSection === 'hour') this.hourInput?.focus();
+        else if (this.focusSection === 'minute') this.minuteInput?.focus();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        input.dispatchEvent(new Event('change'));
+        this.commitValue();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        this.close('escape');
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        e.stopPropagation();
+        this.cycleFocus(e.shiftKey ? -1 : 1);
+      }
+    });
+
+    const downBtn = this.createSpinButton('▼', () => {
+      const next = value <= min ? max : value - 1;
+      onChange(next);
+      this.rebuildOverlay();
+      this.overlay?.focus();
+    });
+
+    group.appendChild(upBtn);
+    group.appendChild(input);
+    group.appendChild(downBtn);
+
+    return { el: group, input };
+  }
+
+  private createSpinButton(text: string, onClick: () => void): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.textContent = text;
+    btn.style.background = 'none';
+    btn.style.border = 'none';
+    btn.style.cursor = 'pointer';
+    btn.style.fontSize = '8px';
+    btn.style.padding = '0 4px';
+    btn.style.color = this.theme?.colors.cellText ?? '#333';
+    btn.style.lineHeight = '1';
+    btn.tabIndex = -1;
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      onClick();
+    });
+    return btn;
   }
 }

--- a/packages/core/src/editing/select-editor.ts
+++ b/packages/core/src/editing/select-editor.ts
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+/**
+ * SelectEditor — CellEditor for 'select' columns.
+ *
+ * Renders a dropdown list of options from ColumnDef.selectOptions.
+ * Supports keyboard navigation (ArrowUp/Down), Enter to commit,
+ * Escape to close, and type-ahead filtering. Extends BaseOverlayEditor
+ * for shared overlay lifecycle.
+ */
+
+import type { CellValue, SelectOption } from '../types/interfaces';
+import { BaseOverlayEditor } from './base-overlay-editor';
+
+/** Maximum visible options before the list scrolls. */
+const MAX_VISIBLE_OPTIONS = 8;
+/** Height of each option row in pixels. */
+const OPTION_ROW_HEIGHT = 28;
+/** Height of the search input area in pixels. */
+const SEARCH_INPUT_HEIGHT = 32;
+
+export class SelectEditor extends BaseOverlayEditor {
+  readonly id = 'select';
+
+  private options: SelectOption[] = [];
+  private filteredOptions: SelectOption[] = [];
+  private highlightedIndex = -1;
+  private searchInput: HTMLInputElement | null = null;
+  private listContainer: HTMLDivElement | null = null;
+  private filterText = '';
+
+  protected get overlayWidth(): number {
+    return 200;
+  }
+
+  protected get overlayHeight(): number {
+    const visibleCount = Math.min(this.options.length, MAX_VISIBLE_OPTIONS);
+    return SEARCH_INPUT_HEIGHT + visibleCount * OPTION_ROW_HEIGHT + 2;
+  }
+
+  protected getAriaLabel(): string {
+    return this.locale?.select?.ariaLabel ?? 'Select option';
+  }
+
+  protected initializeFromValue(value: CellValue): void {
+    this.options = this.column?.selectOptions ?? [];
+    this.filteredOptions = [...this.options];
+    this.filterText = '';
+
+    // Pre-select the current value
+    const strValue = value == null ? '' : String(value);
+    this.highlightedIndex = this.filteredOptions.findIndex(
+      (o) => o.value === strValue,
+    );
+    if (this.highlightedIndex < 0 && this.filteredOptions.length > 0) {
+      this.highlightedIndex = 0;
+    }
+  }
+
+  protected renderContent(): void {
+    if (!this.overlay || !this.theme) return;
+
+    const theme = this.theme;
+
+    // Search input
+    const searchWrap = document.createElement('div');
+    searchWrap.style.padding = '4px';
+    searchWrap.style.borderBottom = `1px solid ${theme.colors.gridLine}`;
+
+    this.searchInput = document.createElement('input');
+    this.searchInput.type = 'text';
+    this.searchInput.placeholder = this.locale?.select?.searchPlaceholder ?? 'Search...';
+    this.searchInput.value = this.filterText;
+    this.searchInput.style.width = '100%';
+    this.searchInput.style.boxSizing = 'border-box';
+    this.searchInput.style.padding = '4px 8px';
+    this.searchInput.style.border = `1px solid ${theme.colors.gridLine}`;
+    this.searchInput.style.borderRadius = '3px';
+    this.searchInput.style.fontSize = `${theme.fonts.cellSize}px`;
+    this.searchInput.style.fontFamily = theme.fonts.cell;
+    this.searchInput.style.color = theme.colors.cellText;
+    this.searchInput.style.backgroundColor = theme.colors.cellEditBackground;
+    this.searchInput.style.outline = 'none';
+
+    this.searchInput.addEventListener('input', () => {
+      this.filterText = this.searchInput?.value ?? '';
+      this.applyFilter();
+    });
+
+    searchWrap.appendChild(this.searchInput);
+    this.overlay.appendChild(searchWrap);
+
+    // Options list
+    this.listContainer = document.createElement('div');
+    this.listContainer.setAttribute('role', 'listbox');
+    const maxHeight = MAX_VISIBLE_OPTIONS * OPTION_ROW_HEIGHT;
+    this.listContainer.style.maxHeight = `${maxHeight}px`;
+    this.listContainer.style.overflowY = 'auto';
+
+    this.renderOptionsList();
+    this.overlay.appendChild(this.listContainer);
+
+    // Focus search input after overlay is attached
+    setTimeout(() => this.searchInput?.focus(), 0);
+  }
+
+  protected onKeyDown(e: KeyboardEvent): void {
+    e.stopPropagation();
+
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        this.close('escape');
+        break;
+      case 'Enter':
+        e.preventDefault();
+        this.commitHighlighted();
+        break;
+      case 'Tab':
+        e.preventDefault();
+        this.commitHighlighted();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        this.moveHighlight(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        this.moveHighlight(-1);
+        break;
+    }
+  }
+
+  protected onCloseCleanup(): void {
+    this.searchInput = null;
+    this.listContainer = null;
+  }
+
+  // ─── Private helpers ──────────────────────────────────────
+
+  private applyFilter(): void {
+    const query = this.filterText.toLowerCase();
+    if (query === '') {
+      this.filteredOptions = [...this.options];
+    } else {
+      this.filteredOptions = this.options.filter((o) => {
+        const label = o.label ?? o.value;
+        return label.toLowerCase().includes(query);
+      });
+    }
+    this.highlightedIndex = this.filteredOptions.length > 0 ? 0 : -1;
+    this.renderOptionsList();
+  }
+
+  private renderOptionsList(): void {
+    if (!this.listContainer || !this.theme) return;
+
+    this.listContainer.innerHTML = '';
+    const theme = this.theme;
+    const currentValue = this.originalValue == null ? '' : String(this.originalValue);
+
+    if (this.filteredOptions.length === 0) {
+      const empty = document.createElement('div');
+      empty.style.padding = '8px';
+      empty.style.textAlign = 'center';
+      empty.style.color = theme.colors.headerText ?? theme.colors.cellText;
+      empty.style.fontSize = `${theme.fonts.cellSize}px`;
+      empty.textContent = this.locale?.select?.noResults ?? 'No results';
+      this.listContainer.appendChild(empty);
+      return;
+    }
+
+    for (let i = 0; i < this.filteredOptions.length; i++) {
+      const opt = this.filteredOptions[i];
+      const row = document.createElement('div');
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-selected', String(i === this.highlightedIndex));
+      row.dataset.index = String(i);
+
+      row.style.padding = '4px 8px';
+      row.style.cursor = 'pointer';
+      row.style.height = `${OPTION_ROW_HEIGHT}px`;
+      row.style.display = 'flex';
+      row.style.alignItems = 'center';
+      row.style.boxSizing = 'border-box';
+
+      if (i === this.highlightedIndex) {
+        row.style.backgroundColor = theme.colors.selectionFill;
+      }
+
+      if (opt.value === currentValue) {
+        row.style.fontWeight = 'bold';
+      }
+
+      const label = document.createElement('span');
+      label.textContent = opt.label ?? opt.value;
+      label.style.overflow = 'hidden';
+      label.style.textOverflow = 'ellipsis';
+      label.style.whiteSpace = 'nowrap';
+      row.appendChild(label);
+
+      const idx = i;
+      row.addEventListener('mouseenter', () => {
+        this.highlightedIndex = idx;
+        this.updateHighlight();
+      });
+      row.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.highlightedIndex = idx;
+        this.commitHighlighted();
+      });
+
+      this.listContainer.appendChild(row);
+    }
+
+    this.scrollHighlightedIntoView();
+  }
+
+  private moveHighlight(delta: number): void {
+    if (this.filteredOptions.length === 0) return;
+    this.highlightedIndex += delta;
+    if (this.highlightedIndex < 0) {
+      this.highlightedIndex = this.filteredOptions.length - 1;
+    } else if (this.highlightedIndex >= this.filteredOptions.length) {
+      this.highlightedIndex = 0;
+    }
+    this.updateHighlight();
+    this.scrollHighlightedIntoView();
+  }
+
+  private updateHighlight(): void {
+    if (!this.listContainer || !this.theme) return;
+    const rows = this.listContainer.querySelectorAll('[role="option"]');
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i] as HTMLElement;
+      row.setAttribute('aria-selected', String(i === this.highlightedIndex));
+      row.style.backgroundColor = i === this.highlightedIndex
+        ? this.theme.colors.selectionFill
+        : '';
+    }
+  }
+
+  private scrollHighlightedIntoView(): void {
+    if (!this.listContainer || this.highlightedIndex < 0) return;
+    const rows = this.listContainer.querySelectorAll('[role="option"]');
+    if (this.highlightedIndex < rows.length) {
+      const el = rows[this.highlightedIndex] as HTMLElement;
+      el.scrollIntoView?.({ block: 'nearest' });
+    }
+  }
+
+  private commitHighlighted(): void {
+    if (this.highlightedIndex >= 0 && this.highlightedIndex < this.filteredOptions.length) {
+      const selected = this.filteredOptions[this.highlightedIndex];
+      this.commitFn?.(this._editingRow, this._editingCol, this.originalValue, selected.value);
+    }
+    this.close('enter');
+  }
+}

--- a/packages/core/src/engine/spreadsheet-engine.ts
+++ b/packages/core/src/engine/spreadsheet-engine.ts
@@ -75,10 +75,12 @@ import { ColumnStretchManager } from '../resize/column-stretch-manager';
 import { CellEditorRegistry } from '../editing/cell-editor-registry';
 import { DatePickerEditor } from '../editing/date-picker-editor';
 import { DateTimeEditor } from '../editing/date-time-editor';
+import { SelectEditor } from '../editing/select-editor';
 import type { CellEditor, CellEditorContext } from '../editing/cell-editor';
 import type { SpreadsheetLocale } from '../locale/locale-types';
 import { resolveLocale } from '../locale/resolve-locale';
 import type { ResolvedLocale } from '../locale/resolve-locale';
+import { ImageManager } from '../renderer/image-manager';
 
 // Plugin API implementation for per-plugin state isolation
 class SpreadsheetPluginAPI implements PluginAPI {
@@ -146,6 +148,10 @@ export interface SpreadsheetEngineConfig {
   showGridLines?: boolean;
   /** Show row number column at left edge (default: true). */
   showRowNumbers?: boolean;
+  /** Show column header row at top edge (default: true). */
+  showColumnHeaders?: boolean;
+  /** Clip grid lines to the last data row/column boundary instead of extending to canvas edges (default: false). */
+  clipGridLinesToData?: boolean;
   /** Visual theme (default: lightTheme). */
   theme?: SpreadsheetTheme;
   /** Enable automatic row height based on cell content (default: false). */
@@ -163,6 +169,7 @@ export class SpreadsheetEngine {
   private layoutEngine: LayoutEngine | null = null;
   private viewportManager: ViewportManager | null = null;
   private renderScheduler: RenderScheduler | null = null;
+  private imageManager: ImageManager;
   private dirtyTracker: DirtyTracker | null = null;
   private scrollManager: ScrollManager | null = null;
 
@@ -213,6 +220,13 @@ export class SpreadsheetEngine {
     this.rowStore = new RowStore();
     this.eventBus = new EventBus();
     this.cellTypeRegistry = new CellTypeRegistry();
+
+    // Create ImageManager for async image loading
+    this.imageManager = new ImageManager({
+      onLoad: () => {
+        if (this.renderScheduler) this.renderScheduler.requestRender();
+      },
+    });
 
     // Create DataView for logical↔physical row mapping
     const rowCount = config.rowCount ?? config.data?.length ?? 0;
@@ -295,6 +309,7 @@ export class SpreadsheetEngine {
     const theme = this.config.theme ?? lightTheme;
     const data = this.config.data ?? [];
     const showRowNumbers = this.config.showRowNumbers ?? true;
+    const showColumnHeaders = this.config.showColumnHeaders ?? true;
     const rowCount = this.config.rowCount ?? data.length;
 
     // Populate CellStore from data array
@@ -323,7 +338,7 @@ export class SpreadsheetEngine {
       columns: this.config.columns,
       rowCount,
       rowHeight: theme.dimensions.rowHeight,
-      headerHeight: theme.dimensions.headerHeight,
+      headerHeight: showColumnHeaders ? theme.dimensions.headerHeight : 0,
       rowNumberWidth: showRowNumbers ? theme.dimensions.rowNumberWidth : 0,
       rowStore: this.rowStore,
     });
@@ -342,7 +357,14 @@ export class SpreadsheetEngine {
 
     // Create render scheduler and dirty tracker
     this.dirtyTracker = new DirtyTracker();
-    this.renderScheduler = new RenderScheduler(() => this.executeRender());
+    this.renderScheduler = new RenderScheduler((ts?: number) => this.executeRender(ts));
+
+    // Wire animation loop to animated decorator presence
+    this.cellTypeRegistry.setAnimatedChangeCallback((hasAnimated) => {
+      if (this.renderScheduler) {
+        this.renderScheduler.setAnimationLoop(hasAnimated);
+      }
+    });
 
     this.gridRenderer = new GridRenderer({
       columns: this.config.columns,
@@ -351,7 +373,9 @@ export class SpreadsheetEngine {
       rowCount,
       theme,
       showRowNumbers,
+      showColumnHeaders,
       showGridLines: this.config.showGridLines ?? true,
+      clipGridLinesToData: this.config.clipGridLinesToData ?? false,
       selectionManager: this.selectionManager,
       cellTypeRegistry: this.cellTypeRegistry,
       rowPositions: this.layoutEngine.getRowPositions(),
@@ -488,6 +512,8 @@ export class SpreadsheetEngine {
     this.cellEditorRegistry.registerForType(datePickerEditor, 'date', 0);
     const dateTimeEditor = new DateTimeEditor();
     this.cellEditorRegistry.registerForType(dateTimeEditor, 'datetime', 0);
+    const selectEditor = new SelectEditor();
+    this.cellEditorRegistry.registerForType(selectEditor, 'select', 0);
     this.cellEditorRegistry.setLocale(this.resolvedLocale);
 
     // Wire merge manager into selection, keyboard navigator, and inline editor
@@ -529,6 +555,7 @@ export class SpreadsheetEngine {
       eventBus: this.eventBus,
       isEditing: () =>
         (this.inlineEditor?.isEditing ?? false) || (this.activeOverlayEditor?.isOpen ?? false),
+      isCellEditable: (row: number, col: number) => this.isCellEditable(row, col),
       onDataChange: () => {
         if (this.dirtyTracker) this.dirtyTracker.markDirty('cell-update');
         if (this.renderScheduler) this.renderScheduler.requestRender();
@@ -640,6 +667,7 @@ export class SpreadsheetEngine {
       rowCount,
       colCount: visibleCols.length,
       mergeManager: this.mergeManager,
+      isCellEditable: (row: number, col: number) => this.isCellEditable(row, col),
     });
     this.autofillManager.attach(this.scrollManager.getElement());
 
@@ -865,8 +893,9 @@ export class SpreadsheetEngine {
     // Type-to-edit: printable character (not Ctrl+key) opens editor with that character
     // Overlay editors (date picker, etc.) use structured input, not free-text
     if (!event.ctrlKey && event.key.length === 1 && this.inlineEditor) {
-      event.originalEvent.preventDefault();
       const { row, col } = this.selectionManager.getSelection().activeCell;
+      if (!this.isCellEditable(row, col)) return;
+      event.originalEvent.preventDefault();
       const visibleCols = this.config.columns.filter((c) => !c.hidden);
       const column = visibleCols[col];
       const physRow = this.dataView.getPhysicalRow(row);
@@ -938,9 +967,31 @@ export class SpreadsheetEngine {
   }
 
   /**
+   * Determine whether a cell is editable based on the priority chain:
+   * CellData.readOnly > ColumnDef.editable > config.editable.
+   */
+  isCellEditable(row: number, col: number): boolean {
+    const globalEditable = this.config.editable ?? false;
+    const visibleCols = this.config.columns.filter((c) => !c.hidden);
+    const column = visibleCols[col];
+    const columnEditable = column?.editable ?? globalEditable;
+
+    const physRow = this.dataView.getPhysicalRow(row);
+    const cellData = this.cellStore.get(physRow, col);
+    if (cellData?.readOnly !== undefined) {
+      return !cellData.readOnly;
+    }
+
+    return columnEditable;
+  }
+
+  /**
    * Open the appropriate editor for a cell — overlay editor from registry, or InlineEditor fallback.
    */
   private openCellEditor(row: number, col: number): void {
+    // Check editability before opening any editor
+    if (!this.isCellEditable(row, col)) return;
+
     // Close any active editor first
     if (this.inlineEditor?.isEditing) {
       this.inlineEditor.commitAndClose('programmatic');
@@ -1242,6 +1293,13 @@ export class SpreadsheetEngine {
       this.canvasManager.destroy();
       this.canvasManager = null;
     }
+
+    // Clean up image manager cache
+    this.imageManager.clear();
+
+    // Disconnect animated decorator callback to avoid stale references
+    this.cellTypeRegistry.setAnimatedChangeCallback(null);
+
     this.gridRenderer = null;
     this.layoutEngine = null;
     this.viewportManager = null;
@@ -1530,7 +1588,7 @@ export class SpreadsheetEngine {
   /**
    * Execute the actual render. Called by RenderScheduler or directly.
    */
-  private executeRender(): void {
+  private executeRender(timestamp?: number): void {
     if (!this.mounted || !this.canvasManager || !this.gridRenderer || !this.viewportManager) return;
 
     // Flush dirty cells before flushing regions (flushCells reads region state)
@@ -1595,12 +1653,13 @@ export class SpreadsheetEngine {
           scrollY,
           dirtyRects,
           renderMode,
+          timestamp,
         );
         return;
       }
     }
 
-    this.gridRenderer.render(ctx, viewport, width, height, scrollX, scrollY, renderMode);
+    this.gridRenderer.render(ctx, viewport, width, height, scrollX, scrollY, renderMode, timestamp);
 
     // Post-render: measure visible rows for auto row height
     this.autoMeasureViewport(ctx, viewport, width, height, scrollX, scrollY);
@@ -1718,6 +1777,14 @@ export class SpreadsheetEngine {
 
   getScrollManager(): ScrollManager | null {
     return this.scrollManager;
+  }
+
+  /**
+   * Convenience method that returns the scroll container DOM element directly.
+   * Equivalent to `getScrollManager()?.getElement() ?? null`.
+   */
+  getScrollContainer(): HTMLDivElement | null {
+    return this.scrollManager?.getElement() ?? null;
   }
 
   getInlineEditor(): InlineEditor | null {
@@ -2063,6 +2130,11 @@ export class SpreadsheetEngine {
     return this.cellTypeRegistry;
   }
 
+  /** Get the ImageManager for async image loading. */
+  getImageManager(): ImageManager {
+    return this.imageManager;
+  }
+
   /** Handle row group toggle by logical row (from hit-test). */
   private handleRowGroupToggle(logicalRow: number, physRow?: number): void {
     const phys = physRow ?? this.dataView.getPhysicalRow(logicalRow);
@@ -2289,6 +2361,114 @@ export class SpreadsheetEngine {
   /** Get current total row count. */
   getRowCount(): number {
     return this.dataView.totalRowCount;
+  }
+
+  /**
+   * Replace all data atomically using row objects.
+   * Clears existing data, loads new rows, updates row count, and schedules a single render.
+   * No intermediate states are visible to event handlers.
+   *
+   * @param data - Array of row objects keyed by column key
+   * @param columnKeys - Column keys to extract from each row. If omitted, derived from current columns config.
+   */
+  setData(data: ReadonlyArray<Record<string, unknown>>, columnKeys?: ReadonlyArray<string>): void {
+    const keys = columnKeys ?? this.config.columns.map((col) => col.key);
+    this.cellStore.clear();
+    this.cellStore.bulkLoadChunk(0, data, keys);
+    this.setRowCount(data.length);
+    if (this.dirtyTracker) this.dirtyTracker.markDirty('full');
+    if (this.autoRowSizeManager) {
+      const rows: number[] = [];
+      for (let i = 0; i < data.length; i++) rows.push(i);
+      this.autoRowSizeManager.markDirtyRows(rows);
+    }
+    if (this.renderScheduler) this.renderScheduler.requestRender();
+  }
+
+  /**
+   * Replace all data atomically using 2D CellData arrays.
+   * Preserves styles, metadata, custom fields, and readOnly flags.
+   * Clears existing data, loads new CellData, updates row count, and schedules a single render.
+   *
+   * @param data - 2D array of CellData objects (rows × columns)
+   * @param startRow - Row offset for the first row of data (default: 0)
+   */
+  setDataCellData(
+    data: ReadonlyArray<ReadonlyArray<CellData | null | undefined>>,
+    startRow = 0,
+  ): void {
+    this.cellStore.clear();
+    this.cellStore.bulkLoadCellData(data, startRow);
+    const totalRows = startRow + data.length;
+    this.setRowCount(totalRows);
+    if (this.dirtyTracker) this.dirtyTracker.markDirty('full');
+    if (this.autoRowSizeManager) {
+      const rows: number[] = [];
+      for (let i = 0; i < data.length; i++) rows.push(startRow + i);
+      this.autoRowSizeManager.markDirtyRows(rows);
+    }
+    if (this.renderScheduler) this.renderScheduler.requestRender();
+  }
+
+  /**
+   * Append rows to existing data without clearing.
+   * Adds new rows after the current last row, updates row count, and schedules a single render.
+   *
+   * @param data - Array of row objects to append
+   * @param columnKeys - Column keys to extract. If omitted, derived from current columns config.
+   */
+  appendRows(
+    data: ReadonlyArray<Record<string, unknown>>,
+    columnKeys?: ReadonlyArray<string>,
+  ): void {
+    if (data.length === 0) return;
+    const keys = columnKeys ?? this.config.columns.map((col) => col.key);
+    const startRow = this.getRowCount();
+    this.cellStore.bulkLoadChunk(startRow, data, keys);
+    this.setRowCount(startRow + data.length);
+    if (this.dirtyTracker) this.dirtyTracker.markDirty('full');
+    if (this.autoRowSizeManager) {
+      const rows: number[] = [];
+      for (let i = 0; i < data.length; i++) rows.push(startRow + i);
+      this.autoRowSizeManager.markDirtyRows(rows);
+    }
+    if (this.renderScheduler) this.renderScheduler.requestRender();
+  }
+
+  /**
+   * Replace a range of rows starting at a specific offset.
+   * Overwrites cells in the target range without clearing other data.
+   * Updates row count if the replacement extends beyond current bounds.
+   *
+   * @param startRow - Row index where replacement begins
+   * @param data - Array of row objects to write at the offset
+   * @param columnKeys - Column keys to extract. If omitted, derived from current columns config.
+   */
+  replaceRows(
+    startRow: number,
+    data: ReadonlyArray<Record<string, unknown>>,
+    columnKeys?: ReadonlyArray<string>,
+  ): void {
+    if (data.length === 0) return;
+    const keys = columnKeys ?? this.config.columns.map((col) => col.key);
+    const colCount = this.config.columns.length;
+    for (let r = startRow; r < startRow + data.length; r++) {
+      for (let c = 0; c < colCount; c++) {
+        this.cellStore.delete(r, c);
+      }
+    }
+    this.cellStore.bulkLoadChunk(startRow, data, keys);
+    const newEnd = startRow + data.length;
+    if (newEnd > this.getRowCount()) {
+      this.setRowCount(newEnd);
+    }
+    if (this.dirtyTracker) this.dirtyTracker.markDirty('full');
+    if (this.autoRowSizeManager) {
+      const rows: number[] = [];
+      for (let i = 0; i < data.length; i++) rows.push(startRow + i);
+      this.autoRowSizeManager.markDirtyRows(rows);
+    }
+    if (this.renderScheduler) this.renderScheduler.requestRender();
   }
 
   /** Update row count across all subsystems. */

--- a/packages/core/src/events/event-bus.ts
+++ b/packages/core/src/events/event-bus.ts
@@ -40,7 +40,10 @@ export class EventBus {
   emit<K extends keyof SpreadsheetEvents>(
     event: K,
     ...args: Parameters<SpreadsheetEvents[K]>
-  ): void {
+  ): void;
+  /** Dispatch a dynamic event (plugin-defined custom events). */
+  emit(event: string, ...args: unknown[]): void;
+  emit(event: string, ...args: unknown[]): void {
     const set = this.listeners.get(event);
     if (!set) return;
     for (const handler of set) {

--- a/packages/core/src/events/event-translator.ts
+++ b/packages/core/src/events/event-translator.ts
@@ -21,6 +21,36 @@ import type { DataView } from '../dataview/data-view';
 import type { ColumnDef, CellType, CellValue } from '../types/interfaces';
 import type { RowGroupManager } from '../grouping/row-group-manager';
 import type { CellTypeRegistry } from '../types/cell-type-registry';
+import type { HitZonePadding } from '../types/cell-type-registry';
+
+/** Resolve per-side padding from a HitZonePadding value. */
+function resolvePadding(p: HitZonePadding | undefined): {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+} {
+  if (p == null) return { top: 0, right: 0, bottom: 0, left: 0 };
+  if (typeof p === 'number') return { top: p, right: p, bottom: p, left: p };
+  return p;
+}
+
+/** Check if a point (relX, relY) falls within a zone expanded by its padding. */
+function hitTestZone(
+  relX: number,
+  relY: number,
+  zoneX: number,
+  zoneY: number,
+  zone: { width: number; height: number; padding?: HitZonePadding },
+): boolean {
+  const pad = resolvePadding(zone.padding);
+  return (
+    relX >= zoneX - pad.left &&
+    relX <= zoneX + zone.width + pad.right &&
+    relY >= zoneY - pad.top &&
+    relY <= zoneY + zone.height + pad.bottom
+  );
+}
 
 export interface EventTranslatorConfig {
   /** Scroll container element to attach listeners to. */
@@ -271,12 +301,7 @@ export class EventTranslator {
         const zones = renderer.getHitZones(safeCellData, cellW, cellH, theme, physRow, col);
         if (zones && zones.length > 0) {
           for (const zone of zones) {
-            if (
-              relX >= zone.x &&
-              relX <= zone.x + zone.width &&
-              relY >= zone.y &&
-              relY <= zone.y + zone.height
-            ) {
+            if (hitTestZone(relX, relY, zone.x, zone.y, zone)) {
               return { id: zone.id, cursor: zone.cursor };
             }
           }
@@ -300,12 +325,7 @@ export class EventTranslator {
               for (const zone of zones) {
                 const zoneX = leftOffset + zone.x;
                 const zoneY = zone.y;
-                if (
-                  relX >= zoneX &&
-                  relX <= zoneX + zone.width &&
-                  relY >= zoneY &&
-                  relY <= zoneY + zone.height
-                ) {
+                if (hitTestZone(relX, relY, zoneX, zoneY, zone)) {
                   return { id: zone.id, cursor: zone.cursor };
                 }
               }
@@ -328,12 +348,7 @@ export class EventTranslator {
               for (const zone of zones) {
                 const zoneX = cellW - rightOffset + zone.x;
                 const zoneY = zone.y;
-                if (
-                  relX >= zoneX &&
-                  relX <= zoneX + zone.width &&
-                  relY >= zoneY &&
-                  relY <= zoneY + zone.height
-                ) {
+                if (hitTestZone(relX, relY, zoneX, zoneY, zone)) {
                   return { id: zone.id, cursor: zone.cursor };
                 }
               }
@@ -350,12 +365,7 @@ export class EventTranslator {
           try {
             const zones = dec.getHitZones(cellW, cellH, safeCellData, physRow, col);
             for (const zone of zones) {
-              if (
-                relX >= zone.x &&
-                relX <= zone.x + zone.width &&
-                relY >= zone.y &&
-                relY <= zone.y + zone.height
-              ) {
+              if (hitTestZone(relX, relY, zone.x, zone.y, zone)) {
                 return { id: zone.id, cursor: zone.cursor };
               }
             }

--- a/packages/core/src/events/event-types.ts
+++ b/packages/core/src/events/event-types.ts
@@ -102,6 +102,14 @@ export interface ClipboardDataEvent {
   colCount: number;
 }
 
+/** Extended paste event with target position. */
+export interface ClipboardPasteEvent extends ClipboardDataEvent {
+  /** Row index where the paste begins (the active cell row at paste time). */
+  startRow: number;
+  /** Column index where the paste begins (the active cell column at paste time). */
+  startCol: number;
+}
+
 // --- Column Resize Events ---
 
 export interface ColumnResizeEvent {
@@ -220,7 +228,7 @@ export interface SpreadsheetEvents {
   // Clipboard events
   clipboardCopy: (event: ClipboardDataEvent) => void;
   clipboardCut: (event: ClipboardDataEvent) => void;
-  clipboardPaste: (event: ClipboardDataEvent) => void;
+  clipboardPaste: (event: ClipboardPasteEvent) => void;
 
   // Column resize events
   columnResize: (event: ColumnResizeEvent) => void;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export type {
   CellRect,
   CellMetadata,
   ColumnDef,
+  SelectOption,
   Selection,
   MergedRegion,
   ValidationRule,
@@ -83,6 +84,7 @@ export type {
   CellChangeEvent,
   CommandEvent,
   ClipboardDataEvent,
+  ClipboardPasteEvent,
   ColumnResizeEvent,
   RowResizeEvent,
   CellStatusChangeEvent,
@@ -119,6 +121,8 @@ export type {
   FrozenViewportRanges,
 } from './renderer/viewport-manager';
 export { RenderScheduler } from './renderer/render-scheduler';
+export { ImageManager } from './renderer/image-manager';
+export type { ImageManagerOptions } from './renderer/image-manager';
 export { DirtyTracker } from './renderer/dirty-tracker';
 export type { DirtyRegion, DirtyCell, DirtyRect } from './renderer/dirty-tracker';
 export { ScrollManager } from './renderer/scroll-manager';
@@ -179,6 +183,9 @@ export { DatePickerOverlay } from './editing/date-picker-overlay';
 export type { DatePickerConfig } from './editing/date-picker-overlay';
 export { DatePickerEditor } from './editing/date-picker-editor';
 export { DateTimeEditor } from './editing/date-time-editor';
+export { BaseOverlayEditor } from './editing/base-overlay-editor';
+export { BaseCalendarOverlayEditor } from './editing/base-calendar-overlay-editor';
+export { SelectEditor } from './editing/select-editor';
 export { CellEditorRegistry } from './editing/cell-editor-registry';
 export type {
   CellEditor,
@@ -201,6 +208,7 @@ export type {
   CellTypeRenderer,
   CellAlignment,
   HitZone,
+  HitZonePadding,
   CellDecorator,
   CellDecoratorPosition,
   CellDecoratorRegistration,
@@ -251,9 +259,10 @@ export type {
 
 // Merge
 export { MergeManager } from './merge/merge-manager';
+export type { MergeValidationError, SetRegionsResult } from './merge/merge-manager';
 
 // Context Menu
-export { ContextMenuManager } from './context-menu/context-menu-manager';
+export { ContextMenuManager, DEFAULT_MENU_ITEM_IDS } from './context-menu/context-menu-manager';
 export type {
   ContextMenuItem,
   MenuContext,
@@ -261,6 +270,9 @@ export type {
   ContextMenuManagerConfig,
 } from './context-menu/context-menu-manager';
 export { createDefaultMenuItems } from './context-menu/default-items';
+
+// Date Format Utilities
+export { formatDate, parseDateString, toDate } from './utils/date-format';
 
 // ARIA Accessibility
 export { AriaManager } from './aria/aria-manager';

--- a/packages/core/src/locale/en.ts
+++ b/packages/core/src/locale/en.ts
@@ -50,6 +50,12 @@ export const enLocale: Required<SpreadsheetLocale> = {
     ariaLabel: 'Date and time picker',
   },
 
+  select: {
+    ariaLabel: 'Select option',
+    searchPlaceholder: 'Search...',
+    noResults: 'No results',
+  },
+
   filter: {
     equals: 'Equals',
     notEquals: 'Not equals',

--- a/packages/core/src/locale/locale-types.ts
+++ b/packages/core/src/locale/locale-types.ts
@@ -52,6 +52,13 @@ export interface SpreadsheetLocale {
     ariaLabel?: string;
   };
 
+  // ─── Select editor ───
+  select?: {
+    ariaLabel?: string;
+    searchPlaceholder?: string;
+    noResults?: string;
+  };
+
   // ─── Filter panel ───
   filter?: {
     equals?: string;

--- a/packages/core/src/locale/resolve-locale.ts
+++ b/packages/core/src/locale/resolve-locale.ts
@@ -19,6 +19,7 @@ export function resolveLocale(locale?: SpreadsheetLocale): ResolvedLocale {
     contextMenu: { ...enLocale.contextMenu, ...locale.contextMenu },
     datePicker: { ...enLocale.datePicker, ...locale.datePicker },
     dateTimePicker: { ...enLocale.dateTimePicker, ...locale.dateTimePicker },
+    select: { ...enLocale.select, ...locale.select },
     filter: { ...enLocale.filter, ...locale.filter },
     grouping: { ...enLocale.grouping, ...locale.grouping },
     emptyState: { ...enLocale.emptyState, ...locale.emptyState },

--- a/packages/core/src/locale/ru.ts
+++ b/packages/core/src/locale/ru.ts
@@ -48,6 +48,12 @@ export const ruLocale: Required<SpreadsheetLocale> = {
     ariaLabel: 'Выбор даты и времени',
   },
 
+  select: {
+    ariaLabel: 'Выберите значение',
+    searchPlaceholder: 'Поиск...',
+    noResults: 'Нет результатов',
+  },
+
   filter: {
     equals: 'Равно',
     notEquals: 'Не равно',

--- a/packages/core/src/merge/merge-manager.ts
+++ b/packages/core/src/merge/merge-manager.ts
@@ -3,6 +3,18 @@
 
 import type { MergedRegion } from '../types/interfaces';
 
+/** Result of a single region that failed validation in setRegions(). */
+export interface MergeValidationError {
+  readonly region: MergedRegion;
+  readonly error: string;
+}
+
+/** Result returned by setRegions(). */
+export interface SetRegionsResult {
+  readonly accepted: ReadonlyArray<MergedRegion>;
+  readonly rejected: ReadonlyArray<MergeValidationError>;
+}
+
 function cellKey(row: number, col: number): string {
   return `${row}:${col}`;
 }
@@ -87,6 +99,37 @@ export class MergeManager {
   clearAll(): void {
     this.spatialIndex.clear();
     this.regions.length = 0;
+  }
+
+  /**
+   * Atomically replace all merge regions.
+   *
+   * Clears existing regions, validates each new region (size, overlap within
+   * the new set, frozen pane boundaries), and adds valid ones. Returns which
+   * regions were accepted and which were rejected with reasons.
+   */
+  setRegions(
+    regions: ReadonlyArray<MergedRegion>,
+    frozenRows = 0,
+    frozenCols = 0,
+  ): SetRegionsResult {
+    this.clearAll();
+
+    const accepted: MergedRegion[] = [];
+    const rejected: MergeValidationError[] = [];
+
+    for (const region of regions) {
+      const error = this.validateMerge(region, frozenRows, frozenCols);
+      if (error) {
+        rejected.push({ region, error });
+      } else {
+        this.regions.push(region);
+        this.indexRegion(region);
+        accepted.push(region);
+      }
+    }
+
+    return { accepted, rejected };
   }
 
   /**

--- a/packages/core/src/renderer/grid-geometry.ts
+++ b/packages/core/src/renderer/grid-geometry.ts
@@ -14,6 +14,8 @@ export interface GridGeometryConfig {
   columns: ColumnDef[];
   theme: SpreadsheetTheme;
   showRowNumbers: boolean;
+  /** Show column header row (default: true). */
+  showColumnHeaders?: boolean;
   /** Cumulative row positions from LayoutEngine (shared reference). */
   rowPositions?: Float64Array;
   /** Per-row heights from LayoutEngine (shared reference). */
@@ -24,6 +26,7 @@ export class GridGeometry {
   private readonly columns: ColumnDef[];
   private theme: SpreadsheetTheme;
   private readonly showRowNumbers: boolean;
+  private readonly showColumnHeaders: boolean;
   private cachedColumnRects: CellRect[] | null = null;
   private cachedVisibleColumns: ColumnDef[] | null = null;
   private columnWidthOverrides: number[] | null = null;
@@ -34,6 +37,7 @@ export class GridGeometry {
     this.columns = config.columns;
     this.theme = config.theme;
     this.showRowNumbers = config.showRowNumbers;
+    this.showColumnHeaders = config.showColumnHeaders ?? true;
     this._rowPositions = config.rowPositions ?? null;
     this._rowHeights = config.rowHeights ?? null;
   }
@@ -43,7 +47,7 @@ export class GridGeometry {
   }
 
   get headerHeight(): number {
-    return this.theme.dimensions.headerHeight;
+    return this.showColumnHeaders ? this.theme.dimensions.headerHeight : 0;
   }
 
   /** Default row height from theme. Use getRowHeight(row) for per-row heights. */

--- a/packages/core/src/renderer/grid-renderer.ts
+++ b/packages/core/src/renderer/grid-renderer.ts
@@ -43,7 +43,9 @@ export interface GridRenderConfig {
   rowCount: number;
   theme: SpreadsheetTheme;
   showRowNumbers: boolean;
+  showColumnHeaders?: boolean;
   showGridLines: boolean;
+  clipGridLinesToData?: boolean;
   selectionManager?: SelectionManager;
   cellTypeRegistry?: CellTypeRegistry;
   /** Cumulative row positions from LayoutEngine (shared reference). */
@@ -57,7 +59,7 @@ export class GridRenderer {
   private readonly pipeline: RenderPipeline;
   private readonly rowCount: number;
   private readonly textMeasureCache: TextMeasureCache;
-  private readonly headerLayer: HeaderLayer;
+  private readonly headerLayer: HeaderLayer | null;
   private readonly emptyStateLayer: EmptyStateLayer;
   private frozenConfig: FrozenPaneConfig | undefined;
   private gridLinesLayer: GridLinesLayer | undefined;
@@ -71,6 +73,7 @@ export class GridRenderer {
       columns: config.columns,
       theme: config.theme,
       showRowNumbers: config.showRowNumbers,
+      showColumnHeaders: config.showColumnHeaders,
       rowPositions: config.rowPositions,
       rowHeights: config.rowHeights,
     });
@@ -90,12 +93,20 @@ export class GridRenderer {
     this.pipeline.addLayer(this.emptyStateLayer);
     // GridLines renders after cell content so it's always on top of plugin fills
     if (config.showGridLines) {
-      this.gridLinesLayer = new GridLinesLayer(config.cellStore, config.dataView);
+      this.gridLinesLayer = new GridLinesLayer(
+        config.cellStore,
+        config.dataView,
+        config.clipGridLinesToData,
+      );
       this.pipeline.addLayer(this.gridLinesLayer);
     }
     // Headers render after grid lines so header backgrounds cover grid lines cleanly
-    this.headerLayer = new HeaderLayer();
-    this.pipeline.addLayer(this.headerLayer);
+    if (config.showColumnHeaders ?? true) {
+      this.headerLayer = new HeaderLayer();
+      this.pipeline.addLayer(this.headerLayer);
+    } else {
+      this.headerLayer = null;
+    }
     if (config.showRowNumbers) {
       this.pipeline.addLayer(new RowNumberLayer());
     }
@@ -164,12 +175,12 @@ export class GridRenderer {
 
   /** Update sort state for header indicators. */
   setSortState(state: HeaderSortState): void {
-    this.headerLayer.setSortState(state);
+    this.headerLayer?.setSortState(state);
   }
 
   /** Update filter state for header indicators. */
   setFilterState(state: HeaderFilterState): void {
-    this.headerLayer.setFilterState(state);
+    this.headerLayer?.setFilterState(state);
   }
 
   /** Set frozen pane configuration for 4-region rendering. */
@@ -207,6 +218,7 @@ export class GridRenderer {
     scrollX: number,
     scrollY: number,
     renderMode: RenderMode = 'full',
+    timestamp?: number,
   ): void {
     this.pipeline.render(
       ctx,
@@ -217,6 +229,7 @@ export class GridRenderer {
       scrollY,
       renderMode,
       this.frozenConfig,
+      timestamp,
     );
   }
 
@@ -230,6 +243,7 @@ export class GridRenderer {
     scrollY: number,
     dirtyRects: DirtyRect[],
     renderMode: RenderMode = 'full',
+    timestamp?: number,
   ): void {
     this.pipeline.renderPartial(
       ctx,
@@ -241,6 +255,7 @@ export class GridRenderer {
       dirtyRects,
       renderMode,
       this.frozenConfig,
+      timestamp,
     );
   }
 }

--- a/packages/core/src/renderer/image-manager.ts
+++ b/packages/core/src/renderer/image-manager.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+/**
+ * ImageManager — async HTMLImageElement loading with LRU cache.
+ *
+ * Provides synchronous `getImage()` that returns cached images immediately
+ * or triggers a background load. When an image finishes loading, the
+ * `onLoad` callback (typically `requestRender()`) is called to refresh
+ * the display.
+ *
+ * Uses an LRU (Least Recently Used) eviction strategy to bound memory.
+ */
+
+export interface ImageManagerOptions {
+  /** Maximum number of cached images. Default: 100. */
+  readonly maxSize?: number;
+  /** Called when an image finishes loading (to trigger re-render). */
+  readonly onLoad?: () => void;
+}
+
+interface CacheEntry {
+  image: HTMLImageElement;
+  loaded: boolean;
+  error: boolean;
+}
+
+export class ImageManager {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly maxSize: number;
+  private readonly onLoad: (() => void) | undefined;
+
+  constructor(options: ImageManagerOptions = {}) {
+    this.maxSize = options.maxSize ?? 100;
+    this.onLoad = options.onLoad;
+  }
+
+  /**
+   * Get a cached image synchronously.
+   * Returns the HTMLImageElement if loaded and cached, or `null` if not yet
+   * available. Triggers a background load if the URL is not in the cache.
+   */
+  getImage(url: string): HTMLImageElement | null {
+    const entry = this.cache.get(url);
+    if (entry) {
+      // Move to end (most recently used)
+      this.cache.delete(url);
+      this.cache.set(url, entry);
+      return entry.loaded && !entry.error ? entry.image : null;
+    }
+    // Not in cache — trigger background load
+    this.loadImage(url);
+    return null;
+  }
+
+  /**
+   * Preload a batch of image URLs into the cache.
+   * Returns a promise that resolves when all images have loaded or failed.
+   */
+  preload(urls: readonly string[]): Promise<void> {
+    const promises = urls.map(
+      (url) =>
+        new Promise<void>((resolve) => {
+          if (this.cache.has(url)) {
+            resolve();
+            return;
+          }
+          const img = new Image();
+          const entry: CacheEntry = { image: img, loaded: false, error: false };
+          this.evictIfNeeded();
+          this.cache.set(url, entry);
+
+          img.onload = () => {
+            entry.loaded = true;
+            this.onLoad?.();
+            resolve();
+          };
+          img.onerror = () => {
+            entry.error = true;
+            resolve();
+          };
+          img.src = url;
+        }),
+    );
+    return Promise.all(promises).then(() => undefined);
+  }
+
+  /** Check whether a URL is in the cache and loaded. */
+  has(url: string): boolean {
+    const entry = this.cache.get(url);
+    return entry !== undefined && entry.loaded && !entry.error;
+  }
+
+  /** Number of entries currently in the cache (loaded + loading). */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /** Remove a specific URL from the cache. */
+  evict(url: string): void {
+    this.cache.delete(url);
+  }
+
+  /** Clear all cached images. */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  private loadImage(url: string): void {
+    const img = new Image();
+    const entry: CacheEntry = { image: img, loaded: false, error: false };
+    this.evictIfNeeded();
+    this.cache.set(url, entry);
+
+    img.onload = () => {
+      entry.loaded = true;
+      this.onLoad?.();
+    };
+    img.onerror = () => {
+      entry.error = true;
+    };
+    img.src = url;
+  }
+
+  private evictIfNeeded(): void {
+    while (this.cache.size >= this.maxSize) {
+      // Evict the least recently used (first key in Map iteration order)
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.cache.delete(oldestKey);
+      } else {
+        break;
+      }
+    }
+  }
+}

--- a/packages/core/src/renderer/layers/background-layer.ts
+++ b/packages/core/src/renderer/layers/background-layer.ts
@@ -27,9 +27,13 @@ export class BackgroundLayer implements RenderLayer {
       mergeManager,
     } = rc;
 
-    // Canvas-wide theme fill
-    ctx.fillStyle = theme.colors.background;
-    ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+    // Canvas-wide theme fill (use clearRect for transparent backgrounds)
+    if (theme.colors.background === 'transparent') {
+      ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+    } else {
+      ctx.fillStyle = theme.colors.background;
+      ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+    }
 
     // Per-cell bgColor fills
     const colRects = geometry.computeColumnRects();

--- a/packages/core/src/renderer/layers/cell-text-layer.ts
+++ b/packages/core/src/renderer/layers/cell-text-layer.ts
@@ -89,7 +89,7 @@ export class CellTextLayer implements RenderLayer {
         // Default: use text measure cache for wrapped text height
         if (renderer.render) continue; // Custom-rendered cells without measureHeight — skip
 
-        const text = renderer.format(cellData.value, cellData, physRow, c);
+        const text = renderer.format(cellData.value, cellData, physRow, c, col);
         if (text === '') continue;
 
         const cr = colRects[c];
@@ -158,6 +158,7 @@ export class CellTextLayer implements RenderLayer {
       canvasWidth,
       canvasHeight,
       mergeManager,
+      timestamp,
     } = rc;
     const colRects = geometry.computeColumnRects();
     const visibleCols = geometry.getVisibleColumns();
@@ -296,7 +297,7 @@ export class CellTextLayer implements RenderLayer {
         for (const dec of underlayDecorators) {
           ctx.save();
           try {
-            dec.render(ctx, cellData, cellX, y, cellWidth, cellHeight, theme, physRow, c);
+            dec.render(ctx, cellData, cellX, y, cellWidth, cellHeight, theme, physRow, c, timestamp);
           } catch {
             /* skip broken decorator */
           }
@@ -312,7 +313,7 @@ export class CellTextLayer implements RenderLayer {
           if (w > 0) {
             ctx.save();
             try {
-              dec.render(ctx, cellData, lx, y, w, cellHeight, theme, physRow, c);
+              dec.render(ctx, cellData, lx, y, w, cellHeight, theme, physRow, c, timestamp);
             } catch {
               /* skip broken decorator */
             }
@@ -331,7 +332,7 @@ export class CellTextLayer implements RenderLayer {
           if (w > 0) {
             ctx.save();
             try {
-              dec.render(ctx, cellData, rx, y, w, cellHeight, theme, physRow, c);
+              dec.render(ctx, cellData, rx, y, w, cellHeight, theme, physRow, c, timestamp);
             } catch {
               /* skip broken decorator */
             }
@@ -359,7 +360,7 @@ export class CellTextLayer implements RenderLayer {
           for (const dec of overlayDecorators) {
             ctx.save();
             try {
-              dec.render(ctx, cellData, cellX, y, cellWidth, cellHeight, theme, physRow, c);
+              dec.render(ctx, cellData, cellX, y, cellWidth, cellHeight, theme, physRow, c, timestamp);
             } catch {
               /* skip broken decorator */
             }
@@ -396,7 +397,7 @@ export class CellTextLayer implements RenderLayer {
 
       ctx.fillStyle = cellStyle?.textColor ?? theme.colors.cellText;
 
-      const text = renderer.format(rawValue, cellData, physRow, c);
+      const text = renderer.format(rawValue, cellData, physRow, c, col);
       if (text === '') continue;
 
       // Per-cell alignment, wrapping, and indent
@@ -451,7 +452,7 @@ export class CellTextLayer implements RenderLayer {
           for (const dec of overlayDecorators) {
             ctx.save();
             try {
-              dec.render(ctx, cellData, cellX, y, cellWidth, cellHeight, theme, physRow, c);
+              dec.render(ctx, cellData, cellX, y, cellWidth, cellHeight, theme, physRow, c, timestamp);
             } catch {
               /* skip broken decorator */
             }
@@ -493,7 +494,7 @@ export class CellTextLayer implements RenderLayer {
         for (const dec of overlayDecorators) {
           ctx.save();
           try {
-            dec.render(ctx, cellData, cellX, y, cellWidth, cellHeight, theme, physRow, c);
+            dec.render(ctx, cellData, cellX, y, cellWidth, cellHeight, theme, physRow, c, timestamp);
           } catch {
             /* skip broken decorator */
           }

--- a/packages/core/src/renderer/layers/grid-lines-layer.ts
+++ b/packages/core/src/renderer/layers/grid-lines-layer.ts
@@ -7,10 +7,15 @@ import type { DataView } from '../../dataview/data-view';
 import type { BorderStyle } from '../../types/interfaces';
 
 export class GridLinesLayer implements RenderLayer {
+  private readonly clipToData: boolean;
+
   constructor(
     private readonly cellStore?: CellStore,
     private readonly dataView?: DataView,
-  ) {}
+    clipGridLinesToData?: boolean,
+  ) {
+    this.clipToData = clipGridLinesToData ?? false;
+  }
 
   render(rc: RenderContext): void {
     const {
@@ -25,6 +30,24 @@ export class GridLinesLayer implements RenderLayer {
       mergeManager,
     } = rc;
     const colRects = geometry.computeColumnRects();
+
+    // Compute effective line boundaries (clip to data or extend to canvas)
+    let hLineEnd = canvasWidth;
+    let vLineEnd = canvasHeight;
+    if (this.clipToData) {
+      if (colRects.length > 0 && viewport.endRow >= viewport.startRow) {
+        const lastCol = colRects[colRects.length - 1];
+        hLineEnd = lastCol.x + lastCol.width - scrollX;
+        vLineEnd =
+          geometry.headerHeight +
+          geometry.getRowY(viewport.endRow) +
+          geometry.getRowHeight(viewport.endRow) -
+          scrollY;
+      } else if (viewport.endRow < viewport.startRow) {
+        // No data rows — clip vertical lines to header height
+        vLineEnd = geometry.headerHeight;
+      }
+    }
 
     ctx.strokeStyle = theme.colors.gridLine;
     ctx.lineWidth = theme.borders.gridLineWidth;
@@ -56,14 +79,16 @@ export class GridLinesLayer implements RenderLayer {
     // Horizontal lines for visible rows only (includes line above first and below last)
     // When no visible rows (filtered to 0), draw phantom grid lines to fill viewport
     if (viewport.endRow < viewport.startRow) {
-      // No data rows — draw empty grid skeleton
-      const rowH = geometry.getRowY(1); // height of one row
-      if (rowH > 0) {
-        let y = geometry.headerHeight;
-        while (y < canvasHeight) {
-          ctx.moveTo(0, y + 0.5);
-          ctx.lineTo(canvasWidth, y + 0.5);
-          y += rowH;
+      // No data rows — draw empty grid skeleton (skip when clipping to data)
+      if (!this.clipToData) {
+        const rowH = geometry.getRowY(1); // height of one row
+        if (rowH > 0) {
+          let y = geometry.headerHeight;
+          while (y < canvasHeight) {
+            ctx.moveTo(0, y + 0.5);
+            ctx.lineTo(canvasWidth, y + 0.5);
+            y += rowH;
+          }
         }
       }
     } else {
@@ -77,7 +102,7 @@ export class GridLinesLayer implements RenderLayer {
           colRects,
           regions,
           scrollX,
-          canvasWidth,
+          hLineEnd,
           viewport.startCol,
           viewport.endCol,
         );
@@ -89,19 +114,19 @@ export class GridLinesLayer implements RenderLayer {
       const cr = colRects[c];
       const x = cr.x + cr.width - scrollX;
       // Draw line in segments, skipping merged region interiors
-      this.drawVLineWithMergeGaps(ctx, x, c, geometry, regions, scrollY, canvasHeight);
+      this.drawVLineWithMergeGaps(ctx, x, c, geometry, regions, scrollY, vLineEnd);
     }
 
     // Row number gutter right border — fixed at rnWidth (doesn't scroll horizontally)
     if (geometry.rowNumberWidth > 0) {
       const gutterX = geometry.rowNumberWidth;
       ctx.moveTo(gutterX + 0.5, 0);
-      ctx.lineTo(gutterX + 0.5, canvasHeight);
+      ctx.lineTo(gutterX + 0.5, this.clipToData ? vLineEnd : canvasHeight);
     }
 
     // Outer frame: left border in data area (header portion drawn by HeaderLayer)
     ctx.moveTo(0.5, geometry.headerHeight);
-    ctx.lineTo(0.5, canvasHeight);
+    ctx.lineTo(0.5, this.clipToData ? vLineEnd : canvasHeight);
 
     ctx.stroke();
 

--- a/packages/core/src/renderer/render-layer.ts
+++ b/packages/core/src/renderer/render-layer.ts
@@ -35,6 +35,8 @@ export interface RenderContext {
   paneRegion: PaneRegion;
   /** MergeManager for merged cell lookup during rendering. */
   mergeManager?: MergeManager;
+  /** DOMHighResTimeStamp for animated decorators. Undefined in non-animation renders. */
+  timestamp?: number;
 }
 
 export interface RenderLayer {

--- a/packages/core/src/renderer/render-pipeline.ts
+++ b/packages/core/src/renderer/render-pipeline.ts
@@ -109,6 +109,7 @@ export class RenderPipeline {
     scrollY: number,
     renderMode: RenderMode = 'full',
     frozenConfig?: FrozenPaneConfig,
+    timestamp?: number,
   ): void {
     ctx.clearRect(0, 0, canvasWidth, canvasHeight);
 
@@ -129,6 +130,7 @@ export class RenderPipeline {
           renderMode,
           paneRegion: 'full',
           mergeManager: this.mergeManager,
+          timestamp,
         };
 
         layer.render(rc);
@@ -230,6 +232,7 @@ export class RenderPipeline {
           renderMode,
           paneRegion: spec.region,
           mergeManager: this.mergeManager,
+          timestamp,
         };
 
         layer.render(rc);
@@ -304,6 +307,7 @@ export class RenderPipeline {
             renderMode,
             paneRegion: 'corner',
             mergeManager: this.mergeManager,
+            timestamp,
           };
 
           layer.render(rc);
@@ -337,6 +341,7 @@ export class RenderPipeline {
           renderMode,
           paneRegion: 'frozenRow',
           mergeManager: this.mergeManager,
+          timestamp,
         };
 
         layer.render(rc);
@@ -365,6 +370,7 @@ export class RenderPipeline {
             renderMode,
             paneRegion: 'corner',
             mergeManager: this.mergeManager,
+            timestamp,
           };
 
           layer.render(rc);
@@ -398,6 +404,7 @@ export class RenderPipeline {
           renderMode,
           paneRegion: 'frozenCol',
           mergeManager: this.mergeManager,
+          timestamp,
         };
 
         layer.render(rc);
@@ -426,6 +433,7 @@ export class RenderPipeline {
     dirtyRects: DirtyRect[],
     renderMode: RenderMode = 'full',
     frozenConfig?: FrozenPaneConfig,
+    timestamp?: number,
   ): void {
     if (frozenConfig && (frozenConfig.frozenRows > 0 || frozenConfig.frozenColumns > 0)) {
       this.render(
@@ -437,6 +445,7 @@ export class RenderPipeline {
         scrollY,
         renderMode,
         frozenConfig,
+        timestamp,
       );
       return;
     }
@@ -466,6 +475,7 @@ export class RenderPipeline {
         renderMode,
         paneRegion: 'full',
         mergeManager: this.mergeManager,
+        timestamp,
       };
       layer.render(rc);
     }

--- a/packages/core/src/renderer/render-scheduler.ts
+++ b/packages/core/src/renderer/render-scheduler.ts
@@ -7,30 +7,66 @@
  * Uses requestAnimationFrame to ensure only one render executes per frame,
  * regardless of how many subsystems request a render.
  *
- * Pull-based rendering: nothing renders until requestRender() is called.
+ * Supports two modes:
+ * - **Pull-based** (default): nothing renders until requestRender() is called.
+ * - **Continuous** (animation): a persistent rAF loop runs, calling
+ *   renderCallback on every frame. Activated/deactivated via
+ *   `setAnimationLoop(true/false)`.
  */
 
 export class RenderScheduler {
   private dirty = false;
   private rafId: number | null = null;
-  private renderCallback: () => void;
+  private renderCallback: (timestamp?: number) => void;
+  private animating = false;
 
-  constructor(renderCallback: () => void) {
+  constructor(renderCallback: (timestamp?: number) => void) {
     this.renderCallback = renderCallback;
   }
 
   /**
    * Request a render on the next animation frame.
    * Multiple calls before the frame fires are coalesced into one render.
+   * In animation mode, this is a no-op (loop handles rendering).
    */
   requestRender(): void {
+    if (this.animating) return;
     if (this.dirty) return;
     this.dirty = true;
-    this.rafId = requestAnimationFrame(() => {
+    this.rafId = requestAnimationFrame((ts) => {
       this.dirty = false;
       this.rafId = null;
-      this.renderCallback();
+      this.renderCallback(ts);
     });
+  }
+
+  /**
+   * Enable or disable the continuous animation loop.
+   * When enabled, renderCallback fires every frame with a DOMHighResTimeStamp.
+   * When disabled, reverts to pull-based mode.
+   */
+  setAnimationLoop(enabled: boolean): void {
+    if (enabled === this.animating) return;
+    this.animating = enabled;
+    if (enabled) {
+      // Cancel any pending one-shot request
+      if (this.rafId !== null) {
+        cancelAnimationFrame(this.rafId);
+        this.rafId = null;
+        this.dirty = false;
+      }
+      this.animationTick();
+    } else {
+      if (this.rafId !== null) {
+        cancelAnimationFrame(this.rafId);
+        this.rafId = null;
+      }
+    }
+  }
+
+  /** Whether the continuous animation loop is running. */
+  isAnimating(): boolean {
+    return this.animating;
   }
 
   /**
@@ -42,12 +78,23 @@ export class RenderScheduler {
       this.rafId = null;
       this.dirty = false;
     }
+    this.animating = false;
   }
 
   /**
    * Whether a render is currently scheduled.
    */
   isPending(): boolean {
-    return this.dirty;
+    return this.dirty || this.animating;
+  }
+
+  private animationTick(): void {
+    if (!this.animating) return;
+    this.rafId = requestAnimationFrame((ts) => {
+      this.rafId = null;
+      if (!this.animating) return;
+      this.renderCallback(ts);
+      this.animationTick();
+    });
   }
 }

--- a/packages/core/src/types/cell-type-registry.ts
+++ b/packages/core/src/types/cell-type-registry.ts
@@ -13,8 +13,9 @@
  * the default text rendering path in CellTextLayer.
  */
 
-import type { CellType, CellValue, CellData } from './interfaces';
+import type { CellType, CellValue, CellData, ColumnDef } from './interfaces';
 import type { SpreadsheetTheme } from '../themes/theme-types';
+import { formatDate, toDate } from '../utils/date-format';
 
 export type CellAlignment = 'left' | 'center' | 'right';
 
@@ -48,7 +49,10 @@ export interface CellDecorator {
     row?: number,
     col?: number,
   ): number;
-  /** Render the decorator in its allocated area. */
+  /**
+   * Render the decorator in its allocated area.
+   * For animated decorators, `timestamp` is the DOMHighResTimeStamp from rAF.
+   */
   render(
     ctx: CanvasRenderingContext2D,
     cellData: CellData,
@@ -59,6 +63,7 @@ export interface CellDecorator {
     theme: SpreadsheetTheme,
     row?: number,
     col?: number,
+    timestamp?: number,
   ): void;
   /** Optional hit zones relative to the decorator's allocated area. */
   getHitZones?(
@@ -79,7 +84,21 @@ export interface CellDecoratorRegistration {
   decorator: CellDecorator;
   /** Returns true if this decorator should apply to the given cell. */
   appliesTo: (row: number, col: number, cellData: CellData) => boolean;
+  /**
+   * When true, signals that this decorator performs frame-based animation.
+   * The RenderScheduler will maintain a continuous rAF loop while any
+   * animated decorator is registered.
+   */
+  animated?: boolean;
 }
+
+/**
+ * Padding specification for expanding the interactive area of a hit zone
+ * beyond its visual bounds. Accepts a uniform number or per-side values.
+ */
+export type HitZonePadding =
+  | number
+  | { readonly top: number; readonly right: number; readonly bottom: number; readonly left: number };
 
 /** A rectangular interactive area within a cell for sub-cell hit testing. */
 export interface HitZone {
@@ -95,11 +114,22 @@ export interface HitZone {
   readonly height: number;
   /** Optional CSS cursor style when hovering this zone. */
   readonly cursor?: string;
+  /**
+   * Optional padding that expands the interactive (hit-test) area beyond the
+   * visual bounds. Rendering is unaffected — only click/hover detection grows.
+   */
+  readonly padding?: HitZonePadding;
 }
 
 export interface CellTypeRenderer {
   /** Format a cell value for text display. */
-  format(value: CellValue, cellData?: CellData, row?: number, col?: number): string;
+  format(
+    value: CellValue,
+    cellData?: CellData,
+    row?: number,
+    col?: number,
+    columnDef?: ColumnDef,
+  ): string;
   /** Text alignment for this cell type. */
   align: CellAlignment;
   /**
@@ -192,8 +222,13 @@ const booleanRenderer: CellTypeRenderer = {
 };
 
 const dateRenderer: CellTypeRenderer = {
-  format: (value) => {
+  format: (value, _cellData?, _row?, _col?, columnDef?) => {
     if (value == null) return '';
+    if (columnDef?.dateFormat) {
+      const date = toDate(value, columnDef.dateFormat);
+      if (date) return formatDate(date, columnDef.dateFormat);
+      return String(value);
+    }
     if (value instanceof Date) {
       return value.toLocaleDateString('en-US');
     }
@@ -213,6 +248,8 @@ export class CellTypeRegistry {
   private readonly renderers = new Map<CellType, CellTypeRenderer>();
   private readonly decoratorRegistrations: CellDecoratorRegistration[] = [];
   private formatLocale: string = 'en-US';
+  private animatedCount = 0;
+  private onAnimatedChange: ((hasAnimated: boolean) => void) | null = null;
 
   constructor() {
     // Register built-in types
@@ -245,8 +282,13 @@ export class CellTypeRegistry {
       align: 'right',
     });
     this.renderers.set('date', {
-      format: (value) => {
+      format: (value, _cellData?, _row?, _col?, columnDef?) => {
         if (value == null) return '';
+        if (columnDef?.dateFormat) {
+          const date = toDate(value, columnDef.dateFormat);
+          if (date) return formatDate(date, columnDef.dateFormat);
+          return String(value);
+        }
         if (value instanceof Date) return value.toLocaleDateString(loc);
         if (typeof value === 'string') {
           const parsed = new Date(value);
@@ -274,22 +316,41 @@ export class CellTypeRegistry {
     return 'string';
   }
 
+  /** Set callback for when animated decorator presence changes. */
+  setAnimatedChangeCallback(callback: ((hasAnimated: boolean) => void) | null): void {
+    this.onAnimatedChange = callback;
+  }
+
+  /** Whether any registered decorator is animated. */
+  hasAnimatedDecorators(): boolean {
+    return this.animatedCount > 0;
+  }
+
   /** Add a cell decorator with an applicability predicate. Replaces existing decorator with same ID. */
   addDecorator(registration: CellDecoratorRegistration): void {
     const existingIdx = this.decoratorRegistrations.findIndex(
       (r) => r.decorator.id === registration.decorator.id,
     );
     if (existingIdx >= 0) {
+      const old = this.decoratorRegistrations[existingIdx];
+      if (old.animated && !registration.animated) this.animatedCount--;
+      if (!old.animated && registration.animated) this.animatedCount++;
       this.decoratorRegistrations[existingIdx] = registration;
     } else {
+      if (registration.animated) this.animatedCount++;
       this.decoratorRegistrations.push(registration);
     }
+    this.onAnimatedChange?.(this.animatedCount > 0);
   }
 
   /** Remove a decorator by its ID. */
   removeDecorator(id: string): void {
     const idx = this.decoratorRegistrations.findIndex((r) => r.decorator.id === id);
-    if (idx >= 0) this.decoratorRegistrations.splice(idx, 1);
+    if (idx >= 0) {
+      if (this.decoratorRegistrations[idx].animated) this.animatedCount--;
+      this.decoratorRegistrations.splice(idx, 1);
+      this.onAnimatedChange?.(this.animatedCount > 0);
+    }
   }
 
   /** Get decorators applicable to a specific cell. */

--- a/packages/core/src/types/interfaces.ts
+++ b/packages/core/src/types/interfaces.ts
@@ -29,6 +29,13 @@ export interface CellData {
    * Preserved through all get/set/merge operations. Not used by the engine.
    */
   readonly custom?: Record<string, unknown>;
+  /**
+   * When true, this cell cannot be edited regardless of column or global settings.
+   * When false, this cell can be edited regardless of column settings.
+   * When undefined, editability is determined by column and global config.
+   * Priority chain: CellData.readOnly > ColumnDef.editable > config.editable.
+   */
+  readonly readOnly?: boolean;
 }
 
 /** Optional metadata attached to a cell. */
@@ -41,9 +48,31 @@ export interface CellMetadata {
   readonly link?: { url: string; label?: string };
   /** Comment text shown on hover. */
   readonly comment?: string;
+  /** Tree nesting level for hierarchical data (0-based). */
+  readonly treeLevel?: number;
+  /** Whether the tree node is expanded. */
+  readonly treeExpanded?: boolean;
+  /** Sort direction indicator for header cells. */
+  readonly sortDirection?: 'asc' | 'desc' | 'none';
+  /** Progress value (0–1 fraction or 0–100 percent). */
+  readonly progress?: number;
+  /** Image URL for thumbnail display. */
+  readonly imageUrl?: string;
+  /** Whether the cell is in a loading state (shows spinner). */
+  readonly loading?: boolean;
+  /** Allow plugin-defined metadata fields. */
+  readonly [key: string]: unknown;
 }
 
 /** Built-in and custom cell type identifiers. */
+/** Option for select/dynamicSelect columns. */
+export interface SelectOption {
+  /** Value stored in cell data when this option is selected. */
+  readonly value: string;
+  /** Display label shown in the dropdown. Defaults to value if omitted. */
+  readonly label?: string;
+}
+
 export type CellType =
   | 'string'
   | 'number'
@@ -165,6 +194,10 @@ export interface ColumnDef {
   readonly hidden?: boolean;
   /** Enable text wrapping for cells in this column. */
   readonly wrapText?: boolean;
+  /** Date format pattern for date columns (e.g., 'DD.MM.YYYY', 'MM/DD/YYYY'). */
+  readonly dateFormat?: string;
+  /** Options for select/dynamicSelect columns. */
+  readonly selectOptions?: SelectOption[];
   /** Validation rules applied to all cells in this column. */
   readonly validation?: import('../validation/validation-engine').SpreadsheetValidationRule[];
 }

--- a/packages/core/src/utils/date-format.ts
+++ b/packages/core/src/utils/date-format.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+/**
+ * Lightweight date format/parse utility for dateFormat column option.
+ * Supports tokens: YYYY (4-digit year), MM (2-digit month), DD (2-digit day).
+ * Zero external dependencies.
+ */
+
+/**
+ * Format a Date using a pattern string.
+ * Supported tokens: YYYY, MM, DD.
+ * @example formatDate(new Date(2025, 0, 15), 'DD.MM.YYYY') // '15.01.2025'
+ */
+export function formatDate(date: Date, pattern: string): string {
+  const yyyy = String(date.getFullYear());
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return pattern.replace('YYYY', yyyy).replace('MM', mm).replace('DD', dd);
+}
+
+/**
+ * Parse a date string according to a pattern. Returns null if invalid.
+ * The pattern must contain exactly YYYY, MM, DD tokens separated by
+ * a single non-letter character (e.g. '-', '.', '/').
+ * @example parseDateString('15.01.2025', 'DD.MM.YYYY') // Date(2025, 0, 15)
+ */
+export function parseDateString(value: string, pattern: string): Date | null {
+  const sepMatch = pattern.match(/[^A-Z]/);
+  if (!sepMatch) return null;
+  const sep = sepMatch[0];
+
+  const patternParts = pattern.split(sep);
+  const valueParts = value.split(sep);
+  if (patternParts.length !== valueParts.length) return null;
+
+  let year = -1;
+  let month = -1;
+  let day = -1;
+
+  for (let i = 0; i < patternParts.length; i++) {
+    const token = patternParts[i];
+    const num = parseInt(valueParts[i], 10);
+    if (isNaN(num)) return null;
+
+    if (token === 'YYYY') year = num;
+    else if (token === 'MM') month = num;
+    else if (token === 'DD') day = num;
+  }
+
+  if (year < 0 || month < 1 || month > 12 || day < 1 || day > 31) return null;
+
+  const date = new Date(year, month - 1, day);
+  // Validate: reject overflow dates (e.g. Feb 30 → Mar 2)
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null;
+  }
+  return date;
+}
+
+/**
+ * Parse a CellValue into a Date, trying the custom pattern first (if provided),
+ * then ISO format, then native Date parsing.
+ */
+export function toDate(value: unknown, pattern?: string): Date | null {
+  if (value instanceof Date && !isNaN(value.getTime())) return value;
+
+  if (typeof value === 'string') {
+    // Try custom pattern first
+    if (pattern) {
+      const custom = parseDateString(value, pattern);
+      if (custom) return custom;
+    }
+    // Try ISO YYYY-MM-DD (with optional time part)
+    const isoMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (isoMatch) {
+      return new Date(Number(isoMatch[1]), Number(isoMatch[2]) - 1, Number(isoMatch[3]));
+    }
+    const d = new Date(value);
+    if (!isNaN(d.getTime())) return d;
+  }
+
+  if (typeof value === 'number') {
+    const d = new Date(value);
+    if (!isNaN(d.getTime())) return d;
+  }
+
+  return null;
+}

--- a/packages/core/tests/animated-decorators.test.ts
+++ b/packages/core/tests/animated-decorators.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import { describe, it, expect, vi } from 'vitest';
+import { CellTypeRegistry } from '../src/types/cell-type-registry';
+import type { CellDecorator, CellDecoratorRegistration } from '../src/types/cell-type-registry';
+import type { CellData } from '../src/types/interfaces';
+import type { SpreadsheetTheme } from '../src/themes/theme-types';
+
+function createDecorator(id: string): CellDecorator {
+  return {
+    id,
+    position: 'overlay',
+    render: vi.fn(),
+  };
+}
+
+function alwaysApplies() {
+  return true;
+}
+
+describe('CellTypeRegistry - animated decorators', () => {
+  it('starts with no animated decorators', () => {
+    const registry = new CellTypeRegistry();
+    expect(registry.hasAnimatedDecorators()).toBe(false);
+  });
+
+  it('tracks animated decorator count on add', () => {
+    const registry = new CellTypeRegistry();
+    const callback = vi.fn();
+    registry.setAnimatedChangeCallback(callback);
+
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+      animated: true,
+    });
+
+    expect(registry.hasAnimatedDecorators()).toBe(true);
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('tracks animated decorator count on remove', () => {
+    const registry = new CellTypeRegistry();
+    const callback = vi.fn();
+    registry.setAnimatedChangeCallback(callback);
+
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+      animated: true,
+    });
+    callback.mockClear();
+
+    registry.removeDecorator('d1');
+    expect(registry.hasAnimatedDecorators()).toBe(false);
+    expect(callback).toHaveBeenCalledWith(false);
+  });
+
+  it('non-animated decorators do not affect animation count', () => {
+    const registry = new CellTypeRegistry();
+    const callback = vi.fn();
+    registry.setAnimatedChangeCallback(callback);
+
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+    });
+
+    expect(registry.hasAnimatedDecorators()).toBe(false);
+    expect(callback).toHaveBeenCalledWith(false);
+  });
+
+  it('replacing animated with non-animated decrements count', () => {
+    const registry = new CellTypeRegistry();
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+      animated: true,
+    });
+    expect(registry.hasAnimatedDecorators()).toBe(true);
+
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+      animated: false,
+    });
+    expect(registry.hasAnimatedDecorators()).toBe(false);
+  });
+
+  it('replacing non-animated with animated increments count', () => {
+    const registry = new CellTypeRegistry();
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+    });
+    expect(registry.hasAnimatedDecorators()).toBe(false);
+
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+      animated: true,
+    });
+    expect(registry.hasAnimatedDecorators()).toBe(true);
+  });
+
+  it('multiple animated decorators: removing one keeps animation active', () => {
+    const registry = new CellTypeRegistry();
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+      animated: true,
+    });
+    registry.addDecorator({
+      decorator: createDecorator('d2'),
+      appliesTo: alwaysApplies,
+      animated: true,
+    });
+    expect(registry.hasAnimatedDecorators()).toBe(true);
+
+    registry.removeDecorator('d1');
+    expect(registry.hasAnimatedDecorators()).toBe(true);
+
+    registry.removeDecorator('d2');
+    expect(registry.hasAnimatedDecorators()).toBe(false);
+  });
+
+  it('removing non-existent decorator is a no-op', () => {
+    const registry = new CellTypeRegistry();
+    const callback = vi.fn();
+    registry.setAnimatedChangeCallback(callback);
+
+    registry.removeDecorator('nonexistent');
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('setAnimatedChangeCallback(null) clears callback', () => {
+    const registry = new CellTypeRegistry();
+    const callback = vi.fn();
+    registry.setAnimatedChangeCallback(callback);
+    registry.setAnimatedChangeCallback(null);
+
+    registry.addDecorator({
+      decorator: createDecorator('d1'),
+      appliesTo: alwaysApplies,
+      animated: true,
+    });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('decorator render() receives timestamp parameter', () => {
+    const decorator = createDecorator('d1');
+    const renderFn = decorator.render as ReturnType<typeof vi.fn>;
+
+    // Simulate what CellTextLayer does — pass timestamp as last param
+    const mockCtx = {} as CanvasRenderingContext2D;
+    const mockCellData = { value: 'test' } as CellData;
+    const mockTheme = {} as SpreadsheetTheme;
+    decorator.render(mockCtx, mockCellData, 0, 0, 100, 30, mockTheme, 0, 0, 42.5);
+
+    expect(renderFn).toHaveBeenCalledWith(mockCtx, mockCellData, 0, 0, 100, 30, mockTheme, 0, 0, 42.5);
+  });
+});

--- a/packages/core/tests/base-calendar-overlay-editor.test.ts
+++ b/packages/core/tests/base-calendar-overlay-editor.test.ts
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BaseCalendarOverlayEditor } from '../src/editing/base-calendar-overlay-editor';
+import type {
+  CellEditorContext,
+  CellEditorCommit,
+  CellEditorClose,
+} from '../src/editing/cell-editor';
+import type { SpreadsheetTheme } from '../src/themes/theme-types';
+import type { ResolvedLocale } from '../src/locale/resolve-locale';
+import type { ColumnDef, CellValue } from '../src/types/interfaces';
+
+// ─── Stubs ──────────────────────────────────────
+
+const stubTheme: SpreadsheetTheme = {
+  colors: {
+    cellBackground: '#fff',
+    cellText: '#000',
+    cellEditBackground: '#fff',
+    gridLine: '#ccc',
+    headerBackground: '#f5f5f5',
+    headerText: '#333',
+    selectionBorder: 'blue',
+    selectionFill: 'rgba(0,0,255,0.1)',
+    activeCellBorder: '#4a90d9',
+    frozenLineBorder: '#aaa',
+    scrollbarThumb: '#bbb',
+    scrollbarTrack: '#eee',
+  },
+  fonts: {
+    cell: 'Arial',
+    cellSize: 12,
+    header: 'Arial',
+    headerSize: 12,
+  },
+};
+
+const stubLocale: ResolvedLocale = {
+  formatLocale: 'en-US',
+  datePicker: {
+    weekLabels: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+    monthNames: [
+      'January', 'February', 'March', 'April', 'May', 'June',
+      'July', 'August', 'September', 'October', 'November', 'December',
+    ],
+    today: 'Today',
+    ariaLabel: 'Date picker',
+  },
+  dateTimePicker: {
+    hour: 'Hour',
+    minute: 'Minute',
+    now: 'Now',
+    ariaLabel: 'Date and time picker',
+  },
+  select: {
+    ariaLabel: 'Select option',
+    searchPlaceholder: 'Search...',
+    noResults: 'No results',
+  },
+  contextMenu: {
+    cut: 'Cut', copy: 'Copy', paste: 'Paste',
+    sortAscending: 'Sort Ascending', sortDescending: 'Sort Descending',
+    insertRowAbove: 'Insert Row Above', insertRowBelow: 'Insert Row Below',
+    deleteRow: 'Delete Row',
+  },
+  filter: {
+    equals: 'Equals', notEquals: 'Not equals', contains: 'Contains',
+    startsWith: 'Starts with', endsWith: 'Ends with',
+    greaterThan: 'Greater than', lessThan: 'Less than',
+    greaterOrEqual: 'Greater or equal', lessOrEqual: 'Less or equal',
+    between: 'Between', isEmpty: 'Is empty', isNotEmpty: 'Is not empty',
+    valuePlaceholder: '', toValuePlaceholder: '', apply: 'Apply', clear: 'Clear',
+  },
+  grouping: { sum: 'Sum', count: 'Count', avg: 'Avg', min: 'Min', max: 'Max' },
+  emptyState: { noData: 'No data' },
+  print: { showingRows: '' },
+  aria: {
+    cellAnnouncement: '', cellEmpty: '', sortCleared: '',
+    sortAscending: '', sortDescending: '', sortedBy: '',
+    filterCleared: '', filterActive: '',
+  },
+};
+
+const column: ColumnDef = { key: 'date', title: 'Date', type: 'date' };
+
+// ─── Concrete test subclass ──────────────────────────────
+
+class TestCalendarEditor extends BaseCalendarOverlayEditor {
+  readonly id = 'test-calendar';
+
+  public dayClicks: number[] = [];
+  public keyDownCalls: KeyboardEvent[] = [];
+
+  protected get overlayWidth(): number {
+    return 200;
+  }
+
+  protected get overlayHeight(): number {
+    return 250;
+  }
+
+  protected parseValue(value: CellValue): Date | null {
+    if (typeof value === 'string') {
+      const d = new Date(value);
+      return isNaN(d.getTime()) ? null : d;
+    }
+    return null;
+  }
+
+  protected getAriaLabel(): string {
+    return 'Test calendar';
+  }
+
+  protected initializeState(): void {
+    // no extra state
+  }
+
+  protected renderContent(): void {
+    this.renderCalendarGrid((day) => {
+      this.dayClicks.push(day);
+    });
+  }
+
+  protected onKeyDown(e: KeyboardEvent): void {
+    this.keyDownCalls.push(e);
+    e.stopPropagation();
+
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        this.close('escape');
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        this.moveFocus(-1);
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        this.moveFocus(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        this.moveFocus(-7);
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        this.moveFocus(7);
+        break;
+    }
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────
+
+function makeContext(value: unknown = null): CellEditorContext {
+  const container = document.createElement('div');
+  Object.defineProperty(container, 'getBoundingClientRect', {
+    value: () => ({
+      x: 0, y: 0, width: 800, height: 600,
+      top: 0, left: 0, right: 800, bottom: 600,
+    }),
+    configurable: true,
+  });
+  const scrollContainer = document.createElement('div');
+
+  return {
+    row: 2,
+    col: 3,
+    value: value as never,
+    column,
+    container,
+    scrollContainer,
+    layoutEngine: {
+      getCellRect: () => ({ x: 100, y: 50, width: 120, height: 24 }),
+    } as never,
+    scrollManager: { scrollX: 0, scrollY: 0 } as never,
+    cellStore: {} as never,
+    dataView: {} as never,
+    theme: stubTheme,
+    locale: stubLocale,
+    mergeManager: null,
+    frozenRows: 0,
+    frozenColumns: 0,
+  };
+}
+
+function pressKey(overlay: HTMLElement, key: string): void {
+  overlay.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+// ─── Tests ──────────────────────────────────────
+
+describe('BaseCalendarOverlayEditor', () => {
+  let editor: TestCalendarEditor;
+  let commitFn: CellEditorCommit;
+  let closeFn: CellEditorClose;
+
+  beforeEach(() => {
+    editor = new TestCalendarEditor();
+    commitFn = vi.fn();
+    closeFn = vi.fn();
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  // ─── Calendar rendering ──────────────────────────────
+
+  describe('calendar rendering', () => {
+    it('renders calendar grid with month header and day cells', () => {
+      const ctx = makeContext('2025-03-15');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]')!;
+      const spans = overlay.querySelectorAll('span');
+      const titleSpan = Array.from(spans).find((s) => s.textContent?.includes('March'));
+      expect(titleSpan).toBeTruthy();
+      expect(titleSpan!.textContent).toBe('March 2025');
+
+      // Should have day cells (March has 31 days)
+      const dayCells = overlay.querySelectorAll('[data-day]');
+      expect(dayCells.length).toBe(31);
+    });
+  });
+
+  // ─── Calendar navigation ──────────────────────────────
+
+  describe('calendar navigation', () => {
+    it('ArrowRight moves focus by 1 day', () => {
+      const ctx = makeContext('2025-03-15');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      pressKey(overlay, 'ArrowRight');
+
+      const day16 = overlay.querySelector('[data-day="16"]') as HTMLElement;
+      expect(day16.style.backgroundColor).toBeTruthy();
+      expect(day16.style.backgroundColor).not.toBe('');
+    });
+
+    it('ArrowDown moves focus by 7 days', () => {
+      const ctx = makeContext('2025-03-15');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      pressKey(overlay, 'ArrowDown');
+
+      const day22 = overlay.querySelector('[data-day="22"]') as HTMLElement;
+      expect(day22.style.backgroundColor).toBeTruthy();
+      expect(day22.style.backgroundColor).not.toBe('');
+    });
+
+    it('navigates to previous month when focus goes before day 1', () => {
+      const ctx = makeContext('2025-03-02');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      pressKey(overlay, 'ArrowLeft');
+      pressKey(overlay, 'ArrowLeft');
+
+      const spans = overlay.querySelectorAll('span');
+      const titleSpan = Array.from(spans).find((s) => s.textContent?.includes('February'));
+      expect(titleSpan).toBeTruthy();
+    });
+
+    it('navigates to next month when focus exceeds last day', () => {
+      const ctx = makeContext('2025-03-31');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      pressKey(overlay, 'ArrowRight');
+
+      const spans = overlay.querySelectorAll('span');
+      const titleSpan = Array.from(spans).find((s) => s.textContent?.includes('April'));
+      expect(titleSpan).toBeTruthy();
+    });
+  });
+
+  // ─── Day click ──────────────────────────────────────
+
+  describe('day click', () => {
+    it('dispatches day click to subclass callback', () => {
+      const ctx = makeContext('2025-03-15');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      const day20 = overlay.querySelector('[data-day="20"]') as HTMLElement;
+      day20.click();
+
+      expect(editor.dayClicks).toEqual([20]);
+    });
+  });
+
+  // ─── Locale ──────────────────────────────────────
+
+  describe('locale', () => {
+    it('uses locale month names', () => {
+      const newLocale = {
+        ...stubLocale,
+        datePicker: {
+          ...stubLocale.datePicker!,
+          monthNames: [
+            'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь',
+            'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь',
+          ],
+        },
+      } as ResolvedLocale;
+      editor.setLocale(newLocale);
+
+      const ctx = makeContext('2025-03-15');
+      ctx.locale = newLocale;
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]')!;
+      const spans = overlay.querySelectorAll('span');
+      const titleSpan = Array.from(spans).find((s) => s.textContent?.includes('Март'));
+      expect(titleSpan).toBeTruthy();
+    });
+  });
+});

--- a/packages/core/tests/base-overlay-editor.test.ts
+++ b/packages/core/tests/base-overlay-editor.test.ts
@@ -1,0 +1,431 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BaseOverlayEditor } from '../src/editing/base-overlay-editor';
+import type {
+  CellEditorContext,
+  CellEditorCommit,
+  CellEditorClose,
+} from '../src/editing/cell-editor';
+import type { SpreadsheetTheme } from '../src/themes/theme-types';
+import type { ResolvedLocale } from '../src/locale/resolve-locale';
+import type { ColumnDef, CellValue } from '../src/types/interfaces';
+
+// ─── Stubs ──────────────────────────────────────
+
+const stubTheme: SpreadsheetTheme = {
+  colors: {
+    cellBackground: '#fff',
+    cellText: '#000',
+    cellEditBackground: '#fff',
+    gridLine: '#ccc',
+    headerBackground: '#f5f5f5',
+    headerText: '#333',
+    selectionBorder: 'blue',
+    selectionFill: 'rgba(0,0,255,0.1)',
+    activeCellBorder: '#4a90d9',
+    frozenLineBorder: '#aaa',
+    scrollbarThumb: '#bbb',
+    scrollbarTrack: '#eee',
+  },
+  fonts: {
+    cell: 'Arial',
+    cellSize: 12,
+    header: 'Arial',
+    headerSize: 12,
+  },
+};
+
+const stubLocale: ResolvedLocale = {
+  formatLocale: 'en-US',
+  datePicker: {
+    weekLabels: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+    monthNames: [
+      'January', 'February', 'March', 'April', 'May', 'June',
+      'July', 'August', 'September', 'October', 'November', 'December',
+    ],
+    today: 'Today',
+    ariaLabel: 'Date picker',
+  },
+  dateTimePicker: {
+    hour: 'Hour',
+    minute: 'Minute',
+    now: 'Now',
+    ariaLabel: 'Date and time picker',
+  },
+  select: {
+    ariaLabel: 'Select option',
+    searchPlaceholder: 'Search...',
+    noResults: 'No results',
+  },
+  contextMenu: {
+    cut: 'Cut', copy: 'Copy', paste: 'Paste',
+    sortAscending: 'Sort Ascending', sortDescending: 'Sort Descending',
+    insertRowAbove: 'Insert Row Above', insertRowBelow: 'Insert Row Below',
+    deleteRow: 'Delete Row',
+  },
+  filter: {
+    equals: 'Equals', notEquals: 'Not equals', contains: 'Contains',
+    startsWith: 'Starts with', endsWith: 'Ends with',
+    greaterThan: 'Greater than', lessThan: 'Less than',
+    greaterOrEqual: 'Greater or equal', lessOrEqual: 'Less or equal',
+    between: 'Between', isEmpty: 'Is empty', isNotEmpty: 'Is not empty',
+    valuePlaceholder: '', toValuePlaceholder: '', apply: 'Apply', clear: 'Clear',
+  },
+  grouping: { sum: 'Sum', count: 'Count', avg: 'Avg', min: 'Min', max: 'Max' },
+  emptyState: { noData: 'No data' },
+  print: { showingRows: '' },
+  aria: {
+    cellAnnouncement: '', cellEmpty: '', sortCleared: '',
+    sortAscending: '', sortDescending: '', sortedBy: '',
+    filterCleared: '', filterActive: '',
+  },
+};
+
+const column: ColumnDef = { key: 'test', title: 'Test' };
+
+// ─── Concrete test subclass ──────────────────────────────
+
+class TestOverlayEditor extends BaseOverlayEditor {
+  readonly id = 'test-overlay';
+
+  public keyDownCalls: KeyboardEvent[] = [];
+  public lastInitValue: CellValue | undefined;
+
+  protected get overlayWidth(): number {
+    return 200;
+  }
+
+  protected get overlayHeight(): number {
+    return 250;
+  }
+
+  protected getAriaLabel(): string {
+    return 'Test overlay';
+  }
+
+  protected initializeFromValue(value: CellValue): void {
+    this.lastInitValue = value;
+  }
+
+  protected renderContent(): void {
+    const content = document.createElement('div');
+    content.className = 'test-content';
+    content.textContent = 'Test content';
+    this.overlay!.appendChild(content);
+  }
+
+  protected onKeyDown(e: KeyboardEvent): void {
+    this.keyDownCalls.push(e);
+    e.stopPropagation();
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.close('escape');
+    }
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────
+
+function makeContext(value: unknown = null): CellEditorContext {
+  const container = document.createElement('div');
+  Object.defineProperty(container, 'getBoundingClientRect', {
+    value: () => ({
+      x: 0, y: 0, width: 800, height: 600,
+      top: 0, left: 0, right: 800, bottom: 600,
+    }),
+    configurable: true,
+  });
+  const scrollContainer = document.createElement('div');
+
+  return {
+    row: 2,
+    col: 3,
+    value: value as never,
+    column,
+    container,
+    scrollContainer,
+    layoutEngine: {
+      getCellRect: () => ({ x: 100, y: 50, width: 120, height: 24 }),
+    } as never,
+    scrollManager: { scrollX: 0, scrollY: 0 } as never,
+    cellStore: {} as never,
+    dataView: {} as never,
+    theme: stubTheme,
+    locale: stubLocale,
+    mergeManager: null,
+    frozenRows: 0,
+    frozenColumns: 0,
+  };
+}
+
+function pressKey(overlay: HTMLElement, key: string): void {
+  overlay.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+// ─── Tests ──────────────────────────────────────
+
+describe('BaseOverlayEditor', () => {
+  let editor: TestOverlayEditor;
+  let commitFn: CellEditorCommit;
+  let closeFn: CellEditorClose;
+
+  beforeEach(() => {
+    editor = new TestOverlayEditor();
+    commitFn = vi.fn();
+    closeFn = vi.fn();
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  // ─── Lifecycle ──────────────────────────────────────
+
+  describe('lifecycle', () => {
+    it('starts closed with default row/col', () => {
+      expect(editor.isOpen).toBe(false);
+      expect(editor.editingRow).toBe(-1);
+      expect(editor.editingCol).toBe(-1);
+    });
+
+    it('opens and renders overlay with ARIA attributes', () => {
+      const ctx = makeContext('test-value');
+      editor.open(ctx, commitFn, closeFn);
+
+      expect(editor.isOpen).toBe(true);
+      expect(editor.editingRow).toBe(2);
+      expect(editor.editingCol).toBe(3);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]');
+      expect(overlay).toBeTruthy();
+      expect(overlay!.getAttribute('aria-label')).toBe('Test overlay');
+    });
+
+    it('calls initializeFromValue with context value', () => {
+      const ctx = makeContext('hello');
+      editor.open(ctx, commitFn, closeFn);
+      expect(editor.lastInitValue).toBe('hello');
+    });
+
+    it('renders subclass content', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]')!;
+      const content = overlay.querySelector('.test-content');
+      expect(content).toBeTruthy();
+      expect(content!.textContent).toBe('Test content');
+    });
+
+    it('close removes overlay from DOM', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+      expect(ctx.container.querySelector('[role="dialog"]')).toBeTruthy();
+
+      editor.close('escape');
+      expect(ctx.container.querySelector('[role="dialog"]')).toBeNull();
+      expect(editor.isOpen).toBe(false);
+      expect(closeFn).toHaveBeenCalledWith('escape');
+    });
+
+    it('close is idempotent', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      editor.close('escape');
+      editor.close('escape');
+      expect(closeFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('destroy cleans up open overlay', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+      editor.destroy();
+
+      expect(editor.isOpen).toBe(false);
+      expect(closeFn).toHaveBeenCalledWith('programmatic');
+    });
+
+    it('re-open closes previous overlay', () => {
+      const ctx1 = makeContext('val-1');
+      editor.open(ctx1, commitFn, closeFn);
+      expect(closeFn).not.toHaveBeenCalled();
+
+      const ctx2 = makeContext('val-2');
+      editor.open(ctx2, commitFn, closeFn);
+      expect(closeFn).toHaveBeenCalledWith('programmatic');
+      expect(editor.isOpen).toBe(true);
+
+      const overlays = ctx2.container.querySelectorAll('[role="dialog"]');
+      expect(overlays.length).toBe(1);
+    });
+  });
+
+  // ─── Positioning ──────────────────────────────────────
+
+  describe('positioning', () => {
+    it('positions overlay below cell', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      expect(overlay.style.position).toBe('absolute');
+      expect(overlay.style.left).toBe('100px');
+      // y=50 + height=24 = 74
+      expect(overlay.style.top).toBe('74px');
+      expect(overlay.style.zIndex).toBe('50');
+    });
+
+    it('flips above cell when no room below', () => {
+      const ctx = makeContext();
+      // Override container to be small (height=100) so overlay won't fit below
+      Object.defineProperty(ctx.container, 'getBoundingClientRect', {
+        value: () => ({
+          x: 0, y: 0, width: 800, height: 100,
+          top: 0, left: 0, right: 800, bottom: 100,
+        }),
+      });
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      // Below: 50+24=74 → 74+250=324 > 100 → flip above: 50-0-250=-200 → clamped to 0
+      const top = parseInt(overlay.style.top, 10);
+      expect(top).toBeLessThanOrEqual(0);
+    });
+
+    it('clamps left when overlay exceeds container width', () => {
+      const ctx = makeContext();
+      // Cell at x=700, overlay width=200, container width=800 → clamp
+      (ctx.layoutEngine as { getCellRect: () => unknown }).getCellRect = () => ({
+        x: 700, y: 50, width: 120, height: 24,
+      });
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      expect(overlay.style.left).toBe('600px'); // 800 - 200
+    });
+  });
+
+  // ─── Scroll close ──────────────────────────────────────
+
+  describe('scroll close', () => {
+    it('closes on scroll event', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      ctx.scrollContainer.dispatchEvent(new Event('scroll'));
+      expect(editor.isOpen).toBe(false);
+      expect(closeFn).toHaveBeenCalledWith('scroll');
+    });
+
+    it('does not close frozen cell on scroll', () => {
+      const ctx = makeContext();
+      ctx.frozenRows = 5;
+      ctx.frozenColumns = 5;
+      // row=2, col=3 → both < frozen → exempt from scroll close
+      editor.open(ctx, commitFn, closeFn);
+
+      ctx.scrollContainer.dispatchEvent(new Event('scroll'));
+      expect(editor.isOpen).toBe(true);
+    });
+  });
+
+  // ─── Outside click ──────────────────────────────────────
+
+  describe('outside click', () => {
+    it('closes on mousedown outside overlay', async () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      // Outside click handler is deferred with setTimeout(0)
+      await new Promise((r) => setTimeout(r, 10));
+
+      document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      expect(editor.isOpen).toBe(false);
+      expect(closeFn).toHaveBeenCalledWith('blur');
+    });
+  });
+
+  // ─── Keyboard ──────────────────────────────────────
+
+  describe('keyboard', () => {
+    it('delegates keydown to subclass onKeyDown', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      pressKey(overlay, 'ArrowRight');
+
+      expect(editor.keyDownCalls.length).toBe(1);
+      expect(editor.keyDownCalls[0].key).toBe('ArrowRight');
+    });
+
+    it('Escape closes without commit', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      pressKey(overlay, 'Escape');
+
+      expect(commitFn).not.toHaveBeenCalled();
+      expect(closeFn).toHaveBeenCalledWith('escape');
+      expect(editor.isOpen).toBe(false);
+    });
+  });
+
+  // ─── Base styles ──────────────────────────────────────
+
+  describe('base styles', () => {
+    it('applies theme-based styles to overlay', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      expect(overlay.style.width).toBe('200px');
+      expect(overlay.style.backgroundColor).toBeTruthy();
+      expect(overlay.style.fontFamily).toBe(stubTheme.fonts.cell);
+      expect(overlay.style.borderRadius).toBe('4px');
+    });
+  });
+
+  // ─── Theme & Locale ──────────────────────────────────────
+
+  describe('theme and locale', () => {
+    it('setTheme updates internal theme', () => {
+      const newTheme = { ...stubTheme, colors: { ...stubTheme.colors, cellText: '#f00' } };
+      editor.setTheme(newTheme);
+      const ctx = makeContext();
+      ctx.theme = newTheme;
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+      // JSDOM normalizes #f00 → rgb(255, 0, 0)
+      expect(overlay.style.color).toBeTruthy();
+      expect(overlay.style.color).not.toBe('rgb(0, 0, 0)');
+    });
+
+    it('setLocale updates internal locale', () => {
+      const newLocale = {
+        ...stubLocale,
+        select: {
+          ariaLabel: 'Выберите',
+          searchPlaceholder: 'Поиск...',
+          noResults: 'Нет результатов',
+        },
+      } as ResolvedLocale;
+      editor.setLocale(newLocale);
+
+      const ctx = makeContext();
+      ctx.locale = newLocale;
+      editor.open(ctx, commitFn, closeFn);
+
+      // Locale is set on the editor — verify it's stored properly
+      // (the overlay renders with subclass content, locale accessible internally)
+      expect(editor.isOpen).toBe(true);
+    });
+  });
+});

--- a/packages/core/tests/batch-atomic-apis.test.ts
+++ b/packages/core/tests/batch-atomic-apis.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { MergeManager } from '../src/merge/merge-manager';
+import type { MergedRegion } from '../src/types/interfaces';
+import {
+  ContextMenuManager,
+  DEFAULT_MENU_ITEM_IDS,
+} from '../src/context-menu/context-menu-manager';
+import type { ContextMenuItem } from '../src/context-menu/context-menu-manager';
+import { EventBus } from '../src/events/event-bus';
+import type { SpreadsheetEngine } from '../src/engine/spreadsheet-engine';
+import { lightTheme } from '../src/themes/built-in-themes';
+import { createDefaultMenuItems } from '../src/context-menu/default-items';
+
+// ─── MergeManager.setRegions ─────────────────────────────────────────────────
+
+describe('MergeManager.setRegions', () => {
+  it('replaces all regions atomically', () => {
+    const mm = new MergeManager();
+    mm.merge({ startRow: 0, startCol: 0, endRow: 1, endCol: 1 });
+    expect(mm.getAllRegions()).toHaveLength(1);
+
+    const result = mm.setRegions([
+      { startRow: 5, startCol: 5, endRow: 6, endCol: 6 },
+      { startRow: 10, startCol: 0, endRow: 11, endCol: 2 },
+    ]);
+
+    expect(result.accepted).toHaveLength(2);
+    expect(result.rejected).toHaveLength(0);
+    expect(mm.getAllRegions()).toHaveLength(2);
+    // Old region gone
+    expect(mm.getMergedRegion(0, 0)).toBeNull();
+    // New regions present
+    expect(mm.getMergedRegion(5, 5)).toBeTruthy();
+    expect(mm.getMergedRegion(10, 1)).toBeTruthy();
+  });
+
+  it('validates overlap within the new set', () => {
+    const mm = new MergeManager();
+    const result = mm.setRegions([
+      { startRow: 0, startCol: 0, endRow: 2, endCol: 2 },
+      { startRow: 1, startCol: 1, endRow: 3, endCol: 3 }, // overlaps with first
+    ]);
+
+    expect(result.accepted).toHaveLength(1);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].error).toContain('overlaps');
+    expect(mm.getAllRegions()).toHaveLength(1);
+  });
+
+  it('rejects invalid regions (single cell, inverted coords)', () => {
+    const mm = new MergeManager();
+    const result = mm.setRegions([
+      { startRow: 0, startCol: 0, endRow: 0, endCol: 0 }, // single cell
+      { startRow: 5, startCol: 0, endRow: 2, endCol: 2 }, // inverted rows
+      { startRow: 0, startCol: 0, endRow: 1, endCol: 1 }, // valid
+    ]);
+
+    expect(result.accepted).toHaveLength(1);
+    expect(result.rejected).toHaveLength(2);
+    expect(mm.getAllRegions()).toHaveLength(1);
+  });
+
+  it('validates frozen pane boundaries', () => {
+    const mm = new MergeManager();
+    const result = mm.setRegions(
+      [
+        { startRow: 0, startCol: 0, endRow: 3, endCol: 1 }, // crosses frozen row boundary
+        { startRow: 5, startCol: 5, endRow: 6, endCol: 6 }, // valid (outside frozen)
+      ],
+      2, // frozenRows
+      0,
+    );
+
+    expect(result.accepted).toHaveLength(1);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].error).toContain('frozen row');
+  });
+
+  it('empty array clears all regions', () => {
+    const mm = new MergeManager();
+    mm.merge({ startRow: 0, startCol: 0, endRow: 1, endCol: 1 });
+    mm.merge({ startRow: 5, startCol: 5, endRow: 6, endCol: 6 });
+    expect(mm.getAllRegions()).toHaveLength(2);
+
+    const result = mm.setRegions([]);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.rejected).toHaveLength(0);
+    expect(mm.getAllRegions()).toHaveLength(0);
+    expect(mm.hasAnyRegions()).toBe(false);
+  });
+
+  it('rebuilds spatial index correctly after replacement', () => {
+    const mm = new MergeManager();
+    mm.merge({ startRow: 0, startCol: 0, endRow: 2, endCol: 2 });
+    // Cell (1,1) should be in old region
+    expect(mm.getMergedRegion(1, 1)).toBeTruthy();
+
+    mm.setRegions([{ startRow: 10, startCol: 10, endRow: 11, endCol: 11 }]);
+
+    // Old spatial index entries gone
+    expect(mm.getMergedRegion(0, 0)).toBeNull();
+    expect(mm.getMergedRegion(1, 1)).toBeNull();
+    // New spatial index entries present
+    expect(mm.getMergedRegion(10, 10)).toBeTruthy();
+    expect(mm.getMergedRegion(11, 11)).toBeTruthy();
+    expect(mm.isAnchorCell(10, 10)).toBe(true);
+    expect(mm.isHiddenCell(11, 11)).toBe(true);
+  });
+
+  it('mixed valid and invalid regions: valid ones are all added', () => {
+    const mm = new MergeManager();
+    const regions: MergedRegion[] = [
+      { startRow: 0, startCol: 0, endRow: 1, endCol: 1 },
+      { startRow: 0, startCol: 0, endRow: 0, endCol: 0 }, // invalid single cell
+      { startRow: 5, startCol: 5, endRow: 6, endCol: 6 },
+      { startRow: 0, startCol: 0, endRow: 2, endCol: 2 }, // overlaps first
+      { startRow: 10, startCol: 0, endRow: 11, endCol: 3 },
+    ];
+    const result = mm.setRegions(regions);
+
+    expect(result.accepted).toHaveLength(3);
+    expect(result.rejected).toHaveLength(2);
+    expect(mm.getAllRegions()).toHaveLength(3);
+  });
+});
+
+// ─── ContextMenuManager.setItems ─────────────────────────────────────────────
+
+function createContextMenuManager(): ContextMenuManager {
+  const container = document.createElement('div');
+  const eventBus = new EventBus();
+  const mgr = new ContextMenuManager({
+    container,
+    engine: {} as SpreadsheetEngine,
+    eventBus,
+    theme: lightTheme,
+  });
+  // Simulate engine behavior: register default items
+  for (const item of createDefaultMenuItems()) {
+    mgr.registerItem(item);
+  }
+  return mgr;
+}
+
+describe('ContextMenuManager.setItems', () => {
+  it('replaces custom items while preserving defaults', () => {
+    const mgr = createContextMenuManager();
+
+    // Register some custom items
+    mgr.registerItem({
+      id: 'old-custom',
+      label: 'Old Custom',
+      contexts: ['cell'],
+    });
+
+    // setItems replaces with new custom items
+    mgr.setItems([
+      { id: 'new-custom-1', label: 'New 1', contexts: ['cell'] },
+      { id: 'new-custom-2', label: 'New 2', contexts: ['header'] },
+    ]);
+
+    const items = mgr.getItems();
+    // Old custom gone
+    expect(items.has('old-custom')).toBe(false);
+    // New custom present
+    expect(items.has('new-custom-1')).toBe(true);
+    expect(items.has('new-custom-2')).toBe(true);
+    // Defaults preserved
+    for (const id of DEFAULT_MENU_ITEM_IDS) {
+      expect(items.has(id)).toBe(true);
+    }
+  });
+
+  it('empty array clears all custom items, keeps defaults', () => {
+    const mgr = createContextMenuManager();
+
+    mgr.registerItem({
+      id: 'my-action',
+      label: 'My Action',
+      contexts: ['cell'],
+    });
+
+    mgr.setItems([]);
+
+    const items = mgr.getItems();
+    expect(items.has('my-action')).toBe(false);
+    // All 8 default items still there
+    expect(items.size).toBe(DEFAULT_MENU_ITEM_IDS.size);
+    for (const id of DEFAULT_MENU_ITEM_IDS) {
+      expect(items.has(id)).toBe(true);
+    }
+  });
+
+  it('allows overriding default items by id', () => {
+    const mgr = createContextMenuManager();
+    const customCut: ContextMenuItem = {
+      id: 'cut',
+      label: 'Custom Cut',
+      contexts: ['cell', 'header'],
+    };
+
+    mgr.setItems([customCut]);
+
+    const items = mgr.getItems();
+    // 'cut' now has custom label
+    expect(items.get('cut')!.label).toBe('Custom Cut');
+    // Other defaults still present
+    expect(items.has('copy')).toBe(true);
+    expect(items.has('paste')).toBe(true);
+  });
+
+  it('multiple setItems calls replace each time', () => {
+    const mgr = createContextMenuManager();
+
+    mgr.setItems([
+      { id: 'a', label: 'A', contexts: ['cell'] },
+      { id: 'b', label: 'B', contexts: ['cell'] },
+    ]);
+    expect(mgr.getItems().has('a')).toBe(true);
+    expect(mgr.getItems().has('b')).toBe(true);
+
+    mgr.setItems([{ id: 'c', label: 'C', contexts: ['cell'] }]);
+    expect(mgr.getItems().has('a')).toBe(false);
+    expect(mgr.getItems().has('b')).toBe(false);
+    expect(mgr.getItems().has('c')).toBe(true);
+  });
+
+  it('registerItem after setItems adds to current custom set', () => {
+    const mgr = createContextMenuManager();
+
+    mgr.setItems([{ id: 'x', label: 'X', contexts: ['cell'] }]);
+    mgr.registerItem({ id: 'y', label: 'Y', contexts: ['cell'] });
+
+    expect(mgr.getItems().has('x')).toBe(true);
+    expect(mgr.getItems().has('y')).toBe(true);
+  });
+});
+
+// ─── DEFAULT_MENU_ITEM_IDS export ────────────────────────────────────────────
+
+describe('DEFAULT_MENU_ITEM_IDS', () => {
+  it('contains all 8 known default item ids', () => {
+    expect(DEFAULT_MENU_ITEM_IDS.size).toBe(8);
+    expect(DEFAULT_MENU_ITEM_IDS.has('cut')).toBe(true);
+    expect(DEFAULT_MENU_ITEM_IDS.has('copy')).toBe(true);
+    expect(DEFAULT_MENU_ITEM_IDS.has('paste')).toBe(true);
+    expect(DEFAULT_MENU_ITEM_IDS.has('sort-asc')).toBe(true);
+    expect(DEFAULT_MENU_ITEM_IDS.has('sort-desc')).toBe(true);
+    expect(DEFAULT_MENU_ITEM_IDS.has('insert-row-above')).toBe(true);
+    expect(DEFAULT_MENU_ITEM_IDS.has('insert-row-below')).toBe(true);
+    expect(DEFAULT_MENU_ITEM_IDS.has('delete-row')).toBe(true);
+  });
+});

--- a/packages/core/tests/clipboard-manager.test.ts
+++ b/packages/core/tests/clipboard-manager.test.ts
@@ -36,6 +36,7 @@ function createTestSetup() {
     commandManager,
     eventBus,
     isEditing,
+    isCellEditable: () => true,
     onDataChange,
   });
   clipboardManager.attach(container);
@@ -302,7 +303,12 @@ describe('ClipboardManager', () => {
       setup.container.dispatchEvent(
         createClipboardEvent('paste', { 'text/plain': 'A\tB\nC\tD' }),
       );
-      expect(handler).toHaveBeenCalledWith({ rowCount: 2, colCount: 2 });
+      expect(handler).toHaveBeenCalledWith({
+        rowCount: 2,
+        colCount: 2,
+        startRow: 3,
+        startCol: 0,
+      });
     });
 
     it('does not intercept when editing', () => {

--- a/packages/core/tests/data-management-api.test.ts
+++ b/packages/core/tests/data-management-api.test.ts
@@ -1,0 +1,352 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SpreadsheetEngine } from '../src/engine/spreadsheet-engine';
+import type { CellData, ColumnDef } from '../src/types/interfaces';
+
+function makeColumns(): ColumnDef[] {
+  return [
+    { key: 'name', title: 'Name', width: 120 },
+    { key: 'age', title: 'Age', width: 80, type: 'number' },
+  ];
+}
+
+function makeData(): Record<string, unknown>[] {
+  return [
+    { name: 'Alice', age: 30 },
+    { name: 'Bob', age: 25 },
+  ];
+}
+
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    setTransform: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    clearRect: vi.fn(),
+    measureText: vi.fn().mockReturnValue({ width: 40 }),
+    canvas: {} as HTMLCanvasElement,
+    font: '',
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
+    globalAlpha: 1,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('Data Management API', () => {
+  let container: HTMLDivElement;
+  let origGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+  beforeEach(() => {
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    })) as unknown as typeof ResizeObserver;
+
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(createMockCtx()) as any;
+
+    container = document.createElement('div');
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      value: () => ({
+        width: 800, height: 600, top: 0, left: 0, right: 800, bottom: 600, x: 0, y: 0,
+        toJSON: () => {},
+      }),
+    });
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    document.body.removeChild(container);
+  });
+
+  function createEngine(data?: Record<string, unknown>[]): SpreadsheetEngine {
+    const engine = new SpreadsheetEngine({
+      columns: makeColumns(),
+      data: data ?? makeData(),
+      editable: true,
+    });
+    engine.mount(container);
+    return engine;
+  }
+
+  describe('setData', () => {
+    it('replaces all data atomically', () => {
+      const engine = createEngine();
+      expect(engine.getCell(0, 0)!.value).toBe('Alice');
+
+      engine.setData([
+        { name: 'Charlie', age: 35 },
+        { name: 'Diana', age: 28 },
+        { name: 'Eve', age: 22 },
+      ]);
+
+      expect(engine.getCell(0, 0)!.value).toBe('Charlie');
+      expect(engine.getCell(1, 0)!.value).toBe('Diana');
+      expect(engine.getCell(2, 0)!.value).toBe('Eve');
+      expect(engine.getRowCount()).toBe(3);
+      engine.destroy();
+    });
+
+    it('clears old data when replacing', () => {
+      const engine = createEngine();
+      expect(engine.getCellStore().size).toBe(4); // 2 rows × 2 cols
+
+      engine.setData([{ name: 'Only', age: 1 }]);
+
+      expect(engine.getCellStore().size).toBe(2); // 1 row × 2 cols
+      expect(engine.getCell(1, 0)).toBeUndefined(); // old row 1 gone
+      expect(engine.getRowCount()).toBe(1);
+      engine.destroy();
+    });
+
+    it('derives column keys from config when not provided', () => {
+      const engine = createEngine();
+      engine.setData([{ name: 'Test', age: 99, extra: 'ignored' }]);
+
+      expect(engine.getCell(0, 0)!.value).toBe('Test');
+      expect(engine.getCell(0, 1)!.value).toBe(99);
+      expect(engine.getCellStore().size).toBe(2); // 'extra' not loaded
+      engine.destroy();
+    });
+
+    it('accepts explicit column keys', () => {
+      const engine = createEngine();
+      engine.setData([{ name: 'Test', age: 99 }], ['age']);
+
+      // Only 'age' column loaded (at col index 0 since keys=[age])
+      expect(engine.getCell(0, 0)!.value).toBe(99);
+      expect(engine.getCellStore().size).toBe(1);
+      engine.destroy();
+    });
+
+    it('handles empty data', () => {
+      const engine = createEngine();
+      expect(engine.getCellStore().size).toBe(4);
+
+      engine.setData([]);
+
+      expect(engine.getCellStore().size).toBe(0);
+      expect(engine.getRowCount()).toBe(0);
+      engine.destroy();
+    });
+
+    it('updates row count correctly', () => {
+      const engine = createEngine();
+      expect(engine.getRowCount()).toBe(2);
+
+      engine.setData([
+        { name: 'A', age: 1 },
+        { name: 'B', age: 2 },
+        { name: 'C', age: 3 },
+        { name: 'D', age: 4 },
+        { name: 'E', age: 5 },
+      ]);
+
+      expect(engine.getRowCount()).toBe(5);
+      engine.destroy();
+    });
+  });
+
+  describe('setDataCellData', () => {
+    it('replaces all data with CellData arrays', () => {
+      const engine = createEngine();
+
+      engine.setDataCellData([
+        [{ value: 'X' }, { value: 100 }],
+        [{ value: 'Y' }, { value: 200 }],
+      ]);
+
+      expect(engine.getCell(0, 0)!.value).toBe('X');
+      expect(engine.getCell(0, 1)!.value).toBe(100);
+      expect(engine.getCell(1, 0)!.value).toBe('Y');
+      expect(engine.getRowCount()).toBe(2);
+      engine.destroy();
+    });
+
+    it('preserves styles and metadata', () => {
+      const engine = createEngine();
+
+      const cellData: CellData = {
+        value: 'Styled',
+        style: { backgroundColor: '#ff0000' },
+        metadata: { validated: true },
+        custom: { source: 'import' },
+        readOnly: true,
+      };
+      engine.setDataCellData([[cellData]]);
+
+      const cell = engine.getCell(0, 0)!;
+      expect(cell.value).toBe('Styled');
+      expect(cell.style?.backgroundColor).toBe('#ff0000');
+      expect(cell.metadata?.validated).toBe(true);
+      expect(cell.custom?.source).toBe('import');
+      expect(cell.readOnly).toBe(true);
+      engine.destroy();
+    });
+
+    it('clears old data when replacing', () => {
+      const engine = createEngine();
+      expect(engine.getCellStore().size).toBe(4);
+
+      engine.setDataCellData([[{ value: 'only' }]]);
+
+      expect(engine.getCellStore().size).toBe(1);
+      expect(engine.getCell(1, 0)).toBeUndefined();
+      engine.destroy();
+    });
+
+    it('supports startRow offset', () => {
+      const engine = createEngine();
+
+      engine.setDataCellData([[{ value: 'Offset' }]], 5);
+
+      expect(engine.getCell(5, 0)!.value).toBe('Offset');
+      expect(engine.getRowCount()).toBe(6); // startRow(5) + data.length(1)
+      engine.destroy();
+    });
+
+    it('handles empty data', () => {
+      const engine = createEngine();
+      engine.setDataCellData([]);
+
+      expect(engine.getCellStore().size).toBe(0);
+      expect(engine.getRowCount()).toBe(0);
+      engine.destroy();
+    });
+  });
+
+  describe('appendRows', () => {
+    it('adds rows after existing data', () => {
+      const engine = createEngine();
+      expect(engine.getRowCount()).toBe(2);
+
+      engine.appendRows([
+        { name: 'Charlie', age: 35 },
+        { name: 'Diana', age: 28 },
+      ]);
+
+      expect(engine.getRowCount()).toBe(4);
+      expect(engine.getCell(0, 0)!.value).toBe('Alice'); // original preserved
+      expect(engine.getCell(2, 0)!.value).toBe('Charlie'); // appended
+      expect(engine.getCell(3, 0)!.value).toBe('Diana');
+      engine.destroy();
+    });
+
+    it('preserves existing data', () => {
+      const engine = createEngine();
+      const originalSize = engine.getCellStore().size;
+
+      engine.appendRows([{ name: 'New', age: 1 }]);
+
+      // Original 4 cells + 2 new cells = 6
+      expect(engine.getCellStore().size).toBe(originalSize + 2);
+      expect(engine.getCell(0, 0)!.value).toBe('Alice');
+      expect(engine.getCell(1, 0)!.value).toBe('Bob');
+      engine.destroy();
+    });
+
+    it('handles empty append gracefully', () => {
+      const engine = createEngine();
+      const countBefore = engine.getRowCount();
+      const sizeBefore = engine.getCellStore().size;
+
+      engine.appendRows([]);
+
+      expect(engine.getRowCount()).toBe(countBefore);
+      expect(engine.getCellStore().size).toBe(sizeBefore);
+      engine.destroy();
+    });
+
+    it('derives column keys from config', () => {
+      const engine = createEngine();
+      engine.appendRows([{ name: 'Test', age: 42, extra: 'skip' }]);
+
+      expect(engine.getCell(2, 0)!.value).toBe('Test');
+      expect(engine.getCell(2, 1)!.value).toBe(42);
+      // 'extra' not loaded — only 2 cols per row
+      expect(engine.getCellStore().size).toBe(6); // 4 original + 2 new
+      engine.destroy();
+    });
+  });
+
+  describe('replaceRows', () => {
+    it('replaces rows at a specific offset', () => {
+      const engine = createEngine();
+
+      engine.replaceRows(1, [{ name: 'Replaced', age: 99 }]);
+
+      expect(engine.getCell(0, 0)!.value).toBe('Alice'); // row 0 untouched
+      expect(engine.getCell(1, 0)!.value).toBe('Replaced'); // row 1 replaced
+      expect(engine.getCell(1, 1)!.value).toBe(99);
+      expect(engine.getRowCount()).toBe(2);
+      engine.destroy();
+    });
+
+    it('extends row count if replacement exceeds current bounds', () => {
+      const engine = createEngine();
+      expect(engine.getRowCount()).toBe(2);
+
+      engine.replaceRows(3, [{ name: 'Extended', age: 50 }]);
+
+      expect(engine.getRowCount()).toBe(4); // 3 + 1
+      expect(engine.getCell(3, 0)!.value).toBe('Extended');
+      engine.destroy();
+    });
+
+    it('does not shrink row count', () => {
+      const engine = createEngine();
+      expect(engine.getRowCount()).toBe(2);
+
+      engine.replaceRows(0, [{ name: 'Single', age: 1 }]);
+
+      expect(engine.getRowCount()).toBe(2); // still 2, not shrunk to 1
+      engine.destroy();
+    });
+
+    it('handles empty replacement gracefully', () => {
+      const engine = createEngine();
+      const countBefore = engine.getRowCount();
+
+      engine.replaceRows(0, []);
+
+      expect(engine.getRowCount()).toBe(countBefore);
+      engine.destroy();
+    });
+
+    it('preserves data in non-replaced rows', () => {
+      const engine = createEngine();
+
+      engine.replaceRows(0, [{ name: 'NewFirst', age: 100 }]);
+
+      expect(engine.getCell(0, 0)!.value).toBe('NewFirst');
+      expect(engine.getCell(1, 0)!.value).toBe('Bob'); // untouched
+      engine.destroy();
+    });
+
+    it('clears stale cells when replacement rows omit columns', () => {
+      const engine = createEngine();
+      expect(engine.getCell(0, 1)!.value).toBe(30); // Alice's age
+
+      engine.replaceRows(0, [{ name: 'Charlie' }]); // no age
+
+      expect(engine.getCell(0, 0)!.value).toBe('Charlie');
+      expect(engine.getCell(0, 1)).toBeUndefined(); // stale age cleared
+      engine.destroy();
+    });
+  });
+});

--- a/packages/core/tests/date-format.test.ts
+++ b/packages/core/tests/date-format.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { formatDate, parseDateString, toDate } from '../src/utils/date-format';
+import { CellTypeRegistry } from '../src/types/cell-type-registry';
+import type { ColumnDef } from '../src/types/interfaces';
+
+// ─── formatDate ────────────────────────────────────────────
+
+describe('formatDate', () => {
+  const date = new Date(2025, 0, 15); // Jan 15, 2025
+
+  it('formats YYYY-MM-DD', () => {
+    expect(formatDate(date, 'YYYY-MM-DD')).toBe('2025-01-15');
+  });
+
+  it('formats DD.MM.YYYY', () => {
+    expect(formatDate(date, 'DD.MM.YYYY')).toBe('15.01.2025');
+  });
+
+  it('formats MM/DD/YYYY', () => {
+    expect(formatDate(date, 'MM/DD/YYYY')).toBe('01/15/2025');
+  });
+
+  it('formats DD/MM/YYYY', () => {
+    expect(formatDate(date, 'DD/MM/YYYY')).toBe('15/01/2025');
+  });
+
+  it('pads single-digit month and day', () => {
+    const d = new Date(2025, 2, 5); // Mar 5
+    expect(formatDate(d, 'DD.MM.YYYY')).toBe('05.03.2025');
+  });
+});
+
+// ─── parseDateString ───────────────────────────────────────
+
+describe('parseDateString', () => {
+  it('parses YYYY-MM-DD', () => {
+    const result = parseDateString('2025-01-15', 'YYYY-MM-DD');
+    expect(result).toEqual(new Date(2025, 0, 15));
+  });
+
+  it('parses DD.MM.YYYY', () => {
+    const result = parseDateString('15.01.2025', 'DD.MM.YYYY');
+    expect(result).toEqual(new Date(2025, 0, 15));
+  });
+
+  it('parses MM/DD/YYYY', () => {
+    const result = parseDateString('01/15/2025', 'MM/DD/YYYY');
+    expect(result).toEqual(new Date(2025, 0, 15));
+  });
+
+  it('parses DD/MM/YYYY', () => {
+    const result = parseDateString('15/01/2025', 'DD/MM/YYYY');
+    expect(result).toEqual(new Date(2025, 0, 15));
+  });
+
+  it('returns null for invalid date (Feb 30)', () => {
+    expect(parseDateString('30.02.2025', 'DD.MM.YYYY')).toBeNull();
+  });
+
+  it('returns null for wrong separator', () => {
+    expect(parseDateString('15/01/2025', 'DD.MM.YYYY')).toBeNull();
+  });
+
+  it('returns null for non-numeric parts', () => {
+    expect(parseDateString('ab.01.2025', 'DD.MM.YYYY')).toBeNull();
+  });
+
+  it('returns null for month out of range', () => {
+    expect(parseDateString('15.13.2025', 'DD.MM.YYYY')).toBeNull();
+  });
+});
+
+// ─── Round-trip ────────────────────────────────────────────
+
+describe('round-trip format → parse', () => {
+  const formats = ['YYYY-MM-DD', 'DD.MM.YYYY', 'MM/DD/YYYY', 'DD/MM/YYYY'];
+  const date = new Date(2025, 11, 31); // Dec 31, 2025
+
+  for (const fmt of formats) {
+    it(`round-trips with ${fmt}`, () => {
+      const formatted = formatDate(date, fmt);
+      const parsed = parseDateString(formatted, fmt);
+      expect(parsed).toEqual(date);
+    });
+  }
+});
+
+// ─── toDate ────────────────────────────────────────────────
+
+describe('toDate', () => {
+  it('returns Date instances as-is', () => {
+    const d = new Date(2025, 0, 15);
+    expect(toDate(d)).toBe(d);
+  });
+
+  it('parses ISO string without custom format', () => {
+    const result = toDate('2025-01-15');
+    expect(result).toEqual(new Date(2025, 0, 15));
+  });
+
+  it('parses custom format string', () => {
+    const result = toDate('15.01.2025', 'DD.MM.YYYY');
+    expect(result).toEqual(new Date(2025, 0, 15));
+  });
+
+  it('falls back to ISO when custom format fails', () => {
+    const result = toDate('2025-01-15', 'DD.MM.YYYY');
+    expect(result).toEqual(new Date(2025, 0, 15));
+  });
+
+  it('parses numeric timestamp', () => {
+    const ts = new Date(2025, 0, 15).getTime();
+    const result = toDate(ts);
+    expect(result).toEqual(new Date(2025, 0, 15));
+  });
+
+  it('returns null for invalid value', () => {
+    expect(toDate('not-a-date')).toBeNull();
+  });
+
+  it('returns null for null', () => {
+    expect(toDate(null)).toBeNull();
+  });
+});
+
+// ─── CellTypeRegistry with dateFormat ──────────────────────
+
+describe('CellTypeRegistry date format integration', () => {
+  it('formats date with dateFormat from ColumnDef', () => {
+    const registry = new CellTypeRegistry();
+    const renderer = registry.get('date');
+    const col: ColumnDef = { key: 'date', title: 'Date', width: 100, type: 'date', dateFormat: 'DD.MM.YYYY' };
+    expect(renderer.format('2025-01-15', undefined, 0, 0, col)).toBe('15.01.2025');
+  });
+
+  it('formats Date object with dateFormat', () => {
+    const registry = new CellTypeRegistry();
+    const renderer = registry.get('date');
+    const col: ColumnDef = { key: 'date', title: 'Date', width: 100, type: 'date', dateFormat: 'MM/DD/YYYY' };
+    const date = new Date(2025, 11, 25);
+    expect(renderer.format(date, undefined, 0, 0, col)).toBe('12/25/2025');
+  });
+
+  it('falls back to locale when no dateFormat', () => {
+    const registry = new CellTypeRegistry();
+    const renderer = registry.get('date');
+    const col: ColumnDef = { key: 'date', title: 'Date', width: 100, type: 'date' };
+    const result = renderer.format('2025-01-15', undefined, 0, 0, col);
+    // Default locale is en-US, toLocaleDateString produces "1/15/2025"
+    expect(result).toBe('1/15/2025');
+  });
+
+  it('uses dateFormat after setFormatLocale', () => {
+    const registry = new CellTypeRegistry();
+    registry.setFormatLocale('ru-RU');
+    const renderer = registry.get('date');
+    const col: ColumnDef = { key: 'date', title: 'Date', width: 100, type: 'date', dateFormat: 'DD.MM.YYYY' };
+    expect(renderer.format('2025-01-15', undefined, 0, 0, col)).toBe('15.01.2025');
+  });
+
+  it('falls back to locale format when dateFormat not set (after setFormatLocale)', () => {
+    const registry = new CellTypeRegistry();
+    registry.setFormatLocale('en-US');
+    const renderer = registry.get('date');
+    const col: ColumnDef = { key: 'date', title: 'Date', width: 100, type: 'date' };
+    const result = renderer.format('2025-01-15', undefined, 0, 0, col);
+    expect(result).toBe('1/15/2025');
+  });
+
+  it('parses custom-formatted stored value', () => {
+    const registry = new CellTypeRegistry();
+    const renderer = registry.get('date');
+    const col: ColumnDef = { key: 'date', title: 'Date', width: 100, type: 'date', dateFormat: 'DD.MM.YYYY' };
+    // Value stored in custom format from a previous commit
+    expect(renderer.format('15.01.2025', undefined, 0, 0, col)).toBe('15.01.2025');
+  });
+
+  it('returns empty string for null value', () => {
+    const registry = new CellTypeRegistry();
+    const renderer = registry.get('date');
+    const col: ColumnDef = { key: 'date', title: 'Date', width: 100, type: 'date', dateFormat: 'DD.MM.YYYY' };
+    expect(renderer.format(null, undefined, 0, 0, col)).toBe('');
+  });
+
+  it('backwards compatible — format works without columnDef', () => {
+    const registry = new CellTypeRegistry();
+    const renderer = registry.get('date');
+    expect(renderer.format('2025-01-15')).toBe('1/15/2025');
+  });
+});

--- a/packages/core/tests/editing-access-control.test.ts
+++ b/packages/core/tests/editing-access-control.test.ts
@@ -1,0 +1,351 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SpreadsheetEngine } from '../src/engine/spreadsheet-engine';
+import type { ColumnDef, CellData } from '../src/types/interfaces';
+
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    setTransform: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    clearRect: vi.fn(),
+    measureText: vi.fn().mockReturnValue({ width: 40 }),
+    canvas: {} as HTMLCanvasElement,
+    font: '',
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
+    globalAlpha: 1,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function makeColumns(overrides?: Partial<ColumnDef>[]): ColumnDef[] {
+  const base: ColumnDef[] = [
+    { key: 'a', title: 'A', width: 100 },
+    { key: 'b', title: 'B', width: 100 },
+    { key: 'c', title: 'C', width: 100 },
+  ];
+  if (overrides) {
+    return base.map((col, i) => ({ ...col, ...overrides[i] }));
+  }
+  return base;
+}
+
+function makeData(): Record<string, unknown>[] {
+  return [
+    { a: 'A0', b: 'B0', c: 'C0' },
+    { a: 'A1', b: 'B1', c: 'C1' },
+    { a: 'A2', b: 'B2', c: 'C2' },
+  ];
+}
+
+describe('Editing Access Control', () => {
+  let container: HTMLDivElement;
+  let origGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+  beforeEach(() => {
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    })) as unknown as typeof ResizeObserver;
+
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(createMockCtx()) as any;
+
+    container = document.createElement('div');
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      value: () => ({
+        width: 800,
+        height: 600,
+        top: 0,
+        left: 0,
+        right: 800,
+        bottom: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }),
+    });
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    document.body.removeChild(container);
+  });
+
+  describe('isCellEditable priority chain', () => {
+    it('returns false when global editable is false (default)', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+      });
+      engine.mount(container);
+
+      // Default editable is false
+      expect(engine.isCellEditable(0, 0)).toBe(false);
+      expect(engine.isCellEditable(1, 1)).toBe(false);
+      engine.destroy();
+    });
+
+    it('returns true when global editable is true', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+        editable: true,
+      });
+      engine.mount(container);
+
+      expect(engine.isCellEditable(0, 0)).toBe(true);
+      expect(engine.isCellEditable(1, 2)).toBe(true);
+      engine.destroy();
+    });
+
+    it('column editable=false overrides global editable=true', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns([{}, { editable: false }, {}]),
+        data: makeData(),
+        editable: true,
+      });
+      engine.mount(container);
+
+      expect(engine.isCellEditable(0, 0)).toBe(true); // column A: inherits global
+      expect(engine.isCellEditable(0, 1)).toBe(false); // column B: editable=false
+      expect(engine.isCellEditable(0, 2)).toBe(true); // column C: inherits global
+      engine.destroy();
+    });
+
+    it('column editable=true overrides global editable=false', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns([{}, { editable: true }, {}]),
+        data: makeData(),
+        editable: false,
+      });
+      engine.mount(container);
+
+      expect(engine.isCellEditable(0, 0)).toBe(false); // column A: inherits global
+      expect(engine.isCellEditable(0, 1)).toBe(true); // column B: editable=true
+      expect(engine.isCellEditable(0, 2)).toBe(false); // column C: inherits global
+      engine.destroy();
+    });
+
+    it('cell readOnly=true overrides column editable=true', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+        editable: true,
+      });
+      engine.mount(container);
+
+      // Set cell (0,0) as readOnly using CellStore.set
+      const physRow = 0; // no sorting, physical = visual
+      engine.getCellStore().set(physRow, 0, { value: 'A0', readOnly: true });
+
+      expect(engine.isCellEditable(0, 0)).toBe(false); // cell readOnly overrides
+      expect(engine.isCellEditable(0, 1)).toBe(true); // other cells unaffected
+      engine.destroy();
+    });
+
+    it('cell readOnly=false overrides column editable=false', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns([{ editable: false }, {}, {}]),
+        data: makeData(),
+        editable: true,
+      });
+      engine.mount(container);
+
+      // Set cell (0,0) as explicitly not readOnly
+      engine.getCellStore().set(0, 0, { value: 'A0', readOnly: false });
+
+      expect(engine.isCellEditable(0, 0)).toBe(true); // cell readOnly=false overrides column
+      expect(engine.isCellEditable(1, 0)).toBe(false); // other cells in column still blocked
+      engine.destroy();
+    });
+
+    it('full priority chain: cell > column > global', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns([{ editable: false }, { editable: true }, {}]),
+        data: makeData(),
+        editable: false,
+      });
+      engine.mount(container);
+
+      // Row 0, Col 0: column=false, global=false → false
+      expect(engine.isCellEditable(0, 0)).toBe(false);
+
+      // Row 0, Col 1: column=true → true
+      expect(engine.isCellEditable(0, 1)).toBe(true);
+
+      // Row 0, Col 2: column=undefined, global=false → false
+      expect(engine.isCellEditable(0, 2)).toBe(false);
+
+      // Override at cell level
+      engine.getCellStore().set(0, 0, { value: 'A0', readOnly: false });
+      expect(engine.isCellEditable(0, 0)).toBe(true); // cell overrides column
+
+      engine.getCellStore().set(0, 1, { value: 'B0', readOnly: true });
+      expect(engine.isCellEditable(0, 1)).toBe(false); // cell overrides column
+
+      engine.destroy();
+    });
+  });
+
+  describe('CellData.readOnly field', () => {
+    it('readOnly is preserved through CellStore.set', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+      });
+      engine.mount(container);
+
+      engine.getCellStore().set(0, 0, { value: 'test', readOnly: true });
+      const cell = engine.getCell(0, 0);
+      expect(cell?.readOnly).toBe(true);
+      expect(cell?.value).toBe('test');
+
+      engine.destroy();
+    });
+
+    it('readOnly=false is distinct from undefined', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+      });
+      engine.mount(container);
+
+      engine.getCellStore().set(0, 0, { value: 'test', readOnly: false });
+      const cell = engine.getCell(0, 0);
+      expect(cell?.readOnly).toBe(false);
+
+      // Cell without readOnly has undefined
+      const otherCell = engine.getCell(0, 1);
+      expect(otherCell?.readOnly).toBeUndefined();
+
+      engine.destroy();
+    });
+
+    it('readOnly is preserved through bulkLoadCellData', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+      });
+      engine.mount(container);
+
+      const cellData: (CellData | null)[][] = [
+        [{ value: 'X', readOnly: true }, { value: 'Y' }, null],
+      ];
+      engine.bulkLoadCellData(cellData, 0);
+
+      expect(engine.getCell(0, 0)?.readOnly).toBe(true);
+      expect(engine.getCell(0, 1)?.readOnly).toBeUndefined();
+
+      engine.destroy();
+    });
+  });
+
+  describe('clipboard respects editability', () => {
+    it('read-only cells are protected from modification', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+        editable: true,
+      });
+      engine.mount(container);
+
+      // Make cell (0,0) read-only
+      engine.getCellStore().set(0, 0, { value: 'A0', readOnly: true });
+
+      // Verify editability
+      expect(engine.isCellEditable(0, 0)).toBe(false);
+      expect(engine.isCellEditable(0, 1)).toBe(true);
+
+      // Verify cell value is preserved
+      expect(engine.getCell(0, 0)?.value).toBe('A0');
+      expect(engine.getCell(0, 1)?.value).toBe('B0');
+
+      engine.destroy();
+    });
+
+    it('paste respects read-only cells via isCellEditable', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+        editable: true,
+      });
+      engine.mount(container);
+
+      // Make cell (0,1) read-only
+      engine.getCellStore().set(0, 1, { value: 'B0', readOnly: true });
+
+      // Verify read-only cell is protected
+      expect(engine.isCellEditable(0, 0)).toBe(true);
+      expect(engine.isCellEditable(0, 1)).toBe(false);
+
+      engine.destroy();
+    });
+
+    it('column-level editable=false blocks editing', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns([{}, { editable: false }, {}]),
+        data: makeData(),
+        editable: true,
+      });
+      engine.mount(container);
+
+      // Column B is not editable
+      expect(engine.isCellEditable(0, 0)).toBe(true);
+      expect(engine.isCellEditable(0, 1)).toBe(false);
+      expect(engine.isCellEditable(0, 2)).toBe(true);
+
+      engine.destroy();
+    });
+  });
+
+  describe('existing editing tests continue to pass', () => {
+    it('editing works when global editable=true', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+        editable: true,
+      });
+      engine.mount(container);
+
+      // All cells should be editable
+      for (let row = 0; row < 3; row++) {
+        for (let col = 0; col < 3; col++) {
+          expect(engine.isCellEditable(row, col)).toBe(true);
+        }
+      }
+      engine.destroy();
+    });
+
+    it('no editing when global editable=false (default)', () => {
+      const engine = new SpreadsheetEngine({
+        columns: makeColumns(),
+        data: makeData(),
+      });
+      engine.mount(container);
+
+      // All cells should be non-editable
+      for (let row = 0; row < 3; row++) {
+        for (let col = 0; col < 3; col++) {
+          expect(engine.isCellEditable(row, col)).toBe(false);
+        }
+      }
+      engine.destroy();
+    });
+  });
+});

--- a/packages/core/tests/image-manager.test.ts
+++ b/packages/core/tests/image-manager.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ImageManager } from '../src/renderer/image-manager';
+
+// Mock HTMLImageElement with controllable load/error behavior
+function createMockImage() {
+  let onload: (() => void) | null = null;
+  let onerror: (() => void) | null = null;
+  let _src = '';
+
+  const img = {
+    get src() {
+      return _src;
+    },
+    set src(value: string) {
+      _src = value;
+      // Trigger load/error asynchronously to simulate real behavior
+      if (value.startsWith('error://')) {
+        queueMicrotask(() => onerror?.());
+      } else {
+        queueMicrotask(() => onload?.());
+      }
+    },
+    set onload(fn: (() => void) | null) {
+      onload = fn;
+    },
+    get onload() {
+      return onload;
+    },
+    set onerror(fn: (() => void) | null) {
+      onerror = fn;
+    },
+    get onerror() {
+      return onerror;
+    },
+  };
+
+  return img as unknown as HTMLImageElement;
+}
+
+// Patch global Image to use our mock
+const originalImage = globalThis.Image;
+
+describe('ImageManager', () => {
+  beforeEach(() => {
+    (globalThis as Record<string, unknown>).Image = class {
+      constructor() {
+        return createMockImage();
+      }
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).Image = originalImage;
+  });
+
+  it('returns null for uncached images and triggers background load', async () => {
+    const mgr = new ImageManager();
+    const result = mgr.getImage('https://example.com/img.png');
+    expect(result).toBeNull();
+    // After microtask, image should be loaded
+    await new Promise((r) => queueMicrotask(r));
+    const loaded = mgr.getImage('https://example.com/img.png');
+    expect(loaded).not.toBeNull();
+  });
+
+  it('returns cached image on subsequent calls', async () => {
+    const mgr = new ImageManager();
+    mgr.getImage('https://example.com/a.png');
+    await new Promise((r) => queueMicrotask(r));
+    const img = mgr.getImage('https://example.com/a.png');
+    expect(img).not.toBeNull();
+  });
+
+  it('calls onLoad callback when image loads', async () => {
+    const onLoad = vi.fn();
+    const mgr = new ImageManager({ onLoad });
+    mgr.getImage('https://example.com/b.png');
+    expect(onLoad).not.toHaveBeenCalled();
+    await new Promise((r) => queueMicrotask(r));
+    expect(onLoad).toHaveBeenCalledOnce();
+  });
+
+  it('returns null for errored images', async () => {
+    const mgr = new ImageManager();
+    mgr.getImage('error://bad');
+    await new Promise((r) => queueMicrotask(r));
+    expect(mgr.getImage('error://bad')).toBeNull();
+    expect(mgr.has('error://bad')).toBe(false);
+  });
+
+  it('has() returns correct status', async () => {
+    const mgr = new ImageManager();
+    expect(mgr.has('https://example.com/x.png')).toBe(false);
+    mgr.getImage('https://example.com/x.png');
+    expect(mgr.has('https://example.com/x.png')).toBe(false); // still loading
+    await new Promise((r) => queueMicrotask(r));
+    expect(mgr.has('https://example.com/x.png')).toBe(true);
+  });
+
+  it('tracks cache size', async () => {
+    const mgr = new ImageManager();
+    expect(mgr.size).toBe(0);
+    mgr.getImage('https://example.com/1.png');
+    mgr.getImage('https://example.com/2.png');
+    expect(mgr.size).toBe(2);
+    await new Promise((r) => queueMicrotask(r));
+    expect(mgr.size).toBe(2);
+  });
+
+  it('evicts LRU entries when cache is full', async () => {
+    const mgr = new ImageManager({ maxSize: 3 });
+    mgr.getImage('https://example.com/1.png');
+    mgr.getImage('https://example.com/2.png');
+    mgr.getImage('https://example.com/3.png');
+    await new Promise((r) => queueMicrotask(r));
+    expect(mgr.size).toBe(3);
+
+    // Adding a 4th should evict the oldest (1.png)
+    mgr.getImage('https://example.com/4.png');
+    await new Promise((r) => queueMicrotask(r));
+    expect(mgr.size).toBe(3);
+    expect(mgr.has('https://example.com/1.png')).toBe(false);
+    expect(mgr.has('https://example.com/4.png')).toBe(true);
+  });
+
+  it('LRU access refreshes entry position', async () => {
+    const mgr = new ImageManager({ maxSize: 3 });
+    mgr.getImage('https://example.com/1.png');
+    mgr.getImage('https://example.com/2.png');
+    mgr.getImage('https://example.com/3.png');
+    await new Promise((r) => queueMicrotask(r));
+
+    // Access 1.png to make it most recently used
+    mgr.getImage('https://example.com/1.png');
+
+    // Adding 4th should evict 2.png (now oldest), not 1.png
+    mgr.getImage('https://example.com/4.png');
+    await new Promise((r) => queueMicrotask(r));
+    expect(mgr.has('https://example.com/1.png')).toBe(true);
+    expect(mgr.has('https://example.com/2.png')).toBe(false);
+  });
+
+  it('evict() removes specific entry', async () => {
+    const mgr = new ImageManager();
+    mgr.getImage('https://example.com/a.png');
+    await new Promise((r) => queueMicrotask(r));
+    expect(mgr.has('https://example.com/a.png')).toBe(true);
+    mgr.evict('https://example.com/a.png');
+    expect(mgr.has('https://example.com/a.png')).toBe(false);
+    expect(mgr.size).toBe(0);
+  });
+
+  it('clear() removes all entries', async () => {
+    const mgr = new ImageManager();
+    mgr.getImage('https://example.com/1.png');
+    mgr.getImage('https://example.com/2.png');
+    await new Promise((r) => queueMicrotask(r));
+    expect(mgr.size).toBe(2);
+    mgr.clear();
+    expect(mgr.size).toBe(0);
+  });
+
+  it('preload() loads multiple images', async () => {
+    const onLoad = vi.fn();
+    const mgr = new ImageManager({ onLoad });
+    await mgr.preload(['https://example.com/a.png', 'https://example.com/b.png']);
+    expect(mgr.has('https://example.com/a.png')).toBe(true);
+    expect(mgr.has('https://example.com/b.png')).toBe(true);
+    expect(onLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it('preload() skips already-cached URLs', async () => {
+    const onLoad = vi.fn();
+    const mgr = new ImageManager({ onLoad });
+    mgr.getImage('https://example.com/a.png');
+    await new Promise((r) => queueMicrotask(r));
+    onLoad.mockClear();
+
+    await mgr.preload(['https://example.com/a.png', 'https://example.com/b.png']);
+    // Only b.png triggers onLoad — a.png was already cached
+    expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it('preload() resolves even if images error', async () => {
+    const mgr = new ImageManager();
+    await mgr.preload(['error://bad1', 'error://bad2']);
+    expect(mgr.has('error://bad1')).toBe(false);
+    expect(mgr.has('error://bad2')).toBe(false);
+    expect(mgr.size).toBe(2); // entries exist but are errored
+  });
+});

--- a/packages/core/tests/render-scheduler-animation.test.ts
+++ b/packages/core/tests/render-scheduler-animation.test.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RenderScheduler } from '../src/renderer/render-scheduler';
+
+describe('RenderScheduler', () => {
+  let mockRaf: (cb: FrameRequestCallback) => number;
+  let mockCancelRaf: (id: number) => void;
+  let rafCallbacks: Map<number, FrameRequestCallback>;
+  let rafId: number;
+
+  beforeEach(() => {
+    rafCallbacks = new Map();
+    rafId = 0;
+    mockRaf = vi.fn((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      rafCallbacks.set(id, cb);
+      return id;
+    });
+    mockCancelRaf = vi.fn((id: number) => {
+      rafCallbacks.delete(id);
+    });
+    vi.stubGlobal('requestAnimationFrame', mockRaf);
+    vi.stubGlobal('cancelAnimationFrame', mockCancelRaf);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function fireRaf(timestamp = 16.67) {
+    const entries = [...rafCallbacks.entries()];
+    for (const [id, cb] of entries) {
+      rafCallbacks.delete(id);
+      cb(timestamp);
+    }
+  }
+
+  it('coalesces multiple requestRender calls into one rAF', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.requestRender();
+    scheduler.requestRender();
+    scheduler.requestRender();
+
+    expect(mockRaf).toHaveBeenCalledTimes(1);
+    fireRaf(100);
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith(100);
+  });
+
+  it('passes timestamp to callback from rAF', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.requestRender();
+    fireRaf(42.5);
+    expect(callback).toHaveBeenCalledWith(42.5);
+  });
+
+  it('allows new request after previous fires', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.requestRender();
+    fireRaf(16);
+    scheduler.requestRender();
+    fireRaf(32);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancel() prevents pending render', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.requestRender();
+    scheduler.cancel();
+    fireRaf();
+    expect(callback).not.toHaveBeenCalled();
+    expect(scheduler.isPending()).toBe(false);
+  });
+
+  it('isPending() reflects state', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    expect(scheduler.isPending()).toBe(false);
+    scheduler.requestRender();
+    expect(scheduler.isPending()).toBe(true);
+    fireRaf();
+    expect(scheduler.isPending()).toBe(false);
+  });
+
+  // ─── Animation loop tests ───
+
+  it('setAnimationLoop(true) starts continuous rendering', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.setAnimationLoop(true);
+    expect(scheduler.isAnimating()).toBe(true);
+    expect(scheduler.isPending()).toBe(true);
+
+    fireRaf(16);
+    expect(callback).toHaveBeenCalledWith(16);
+
+    // Should schedule next frame automatically
+    expect(rafCallbacks.size).toBe(1);
+    fireRaf(32);
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledWith(32);
+  });
+
+  it('setAnimationLoop(false) stops continuous rendering', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.setAnimationLoop(true);
+    fireRaf(16);
+    expect(callback).toHaveBeenCalledOnce();
+
+    scheduler.setAnimationLoop(false);
+    expect(scheduler.isAnimating()).toBe(false);
+    // Pending rAF should be cancelled
+    fireRaf(32);
+    expect(callback).toHaveBeenCalledOnce(); // no additional call
+  });
+
+  it('requestRender() is a no-op during animation loop', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.setAnimationLoop(true);
+    scheduler.requestRender(); // should be ignored
+    expect(mockRaf).toHaveBeenCalledTimes(1); // only the animation frame
+
+    fireRaf(16);
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it('setAnimationLoop(true) cancels pending one-shot request', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.requestRender();
+    expect(mockRaf).toHaveBeenCalledTimes(1);
+
+    scheduler.setAnimationLoop(true);
+    expect(mockCancelRaf).toHaveBeenCalled();
+  });
+
+  it('setAnimationLoop called twice with same value is no-op', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.setAnimationLoop(true);
+    const callsBefore = (mockRaf as ReturnType<typeof vi.fn>).mock.calls.length;
+    scheduler.setAnimationLoop(true);
+    expect((mockRaf as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsBefore);
+  });
+
+  it('cancel() stops animation loop', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.setAnimationLoop(true);
+    scheduler.cancel();
+    expect(scheduler.isAnimating()).toBe(false);
+    fireRaf(16);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('animation loop survives many frames', () => {
+    const callback = vi.fn();
+    const scheduler = new RenderScheduler(callback);
+
+    scheduler.setAnimationLoop(true);
+    for (let i = 0; i < 10; i++) {
+      fireRaf(i * 16.67);
+    }
+    expect(callback).toHaveBeenCalledTimes(10);
+    scheduler.setAnimationLoop(false);
+  });
+});

--- a/packages/core/tests/select-editor.test.ts
+++ b/packages/core/tests/select-editor.test.ts
@@ -1,0 +1,468 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SelectEditor } from '../src/editing/select-editor';
+import type {
+  CellEditorContext,
+  CellEditorCommit,
+  CellEditorClose,
+} from '../src/editing/cell-editor';
+import type { SpreadsheetTheme } from '../src/themes/theme-types';
+import type { ResolvedLocale } from '../src/locale/resolve-locale';
+import type { ColumnDef, SelectOption } from '../src/types/interfaces';
+
+// ─── Stubs ──────────────────────────────────────
+
+const stubTheme: SpreadsheetTheme = {
+  colors: {
+    cellBackground: '#fff',
+    cellText: '#000',
+    cellEditBackground: '#fff',
+    gridLine: '#ccc',
+    headerBackground: '#f5f5f5',
+    headerText: '#333',
+    selectionBorder: 'blue',
+    selectionFill: 'rgba(0,0,255,0.1)',
+    activeCellBorder: '#4a90d9',
+    frozenLineBorder: '#aaa',
+    scrollbarThumb: '#bbb',
+    scrollbarTrack: '#eee',
+  },
+  fonts: {
+    cell: 'Arial',
+    cellSize: 12,
+    header: 'Arial',
+    headerSize: 12,
+  },
+};
+
+const stubLocale: ResolvedLocale = {
+  formatLocale: 'en-US',
+  datePicker: {
+    weekLabels: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+    monthNames: [
+      'January', 'February', 'March', 'April', 'May', 'June',
+      'July', 'August', 'September', 'October', 'November', 'December',
+    ],
+    today: 'Today',
+    ariaLabel: 'Date picker',
+  },
+  dateTimePicker: {
+    hour: 'Hour',
+    minute: 'Minute',
+    now: 'Now',
+    ariaLabel: 'Date and time picker',
+  },
+  select: {
+    ariaLabel: 'Select option',
+    searchPlaceholder: 'Search...',
+    noResults: 'No results',
+  },
+  contextMenu: {
+    cut: 'Cut', copy: 'Copy', paste: 'Paste',
+    sortAscending: 'Sort Ascending', sortDescending: 'Sort Descending',
+    insertRowAbove: 'Insert Row Above', insertRowBelow: 'Insert Row Below',
+    deleteRow: 'Delete Row',
+  },
+  filter: {
+    equals: 'Equals', notEquals: 'Not equals', contains: 'Contains',
+    startsWith: 'Starts with', endsWith: 'Ends with',
+    greaterThan: 'Greater than', lessThan: 'Less than',
+    greaterOrEqual: 'Greater or equal', lessOrEqual: 'Less or equal',
+    between: 'Between', isEmpty: 'Is empty', isNotEmpty: 'Is not empty',
+    valuePlaceholder: '', toValuePlaceholder: '', apply: 'Apply', clear: 'Clear',
+  },
+  grouping: { sum: 'Sum', count: 'Count', avg: 'Avg', min: 'Min', max: 'Max' },
+  emptyState: { noData: 'No data' },
+  print: { showingRows: '' },
+  aria: {
+    cellAnnouncement: '', cellEmpty: '', sortCleared: '',
+    sortAscending: '', sortDescending: '', sortedBy: '',
+    filterCleared: '', filterActive: '',
+  },
+};
+
+const sampleOptions: SelectOption[] = [
+  { value: 'red', label: 'Red' },
+  { value: 'green', label: 'Green' },
+  { value: 'blue', label: 'Blue' },
+  { value: 'yellow', label: 'Yellow' },
+  { value: 'purple', label: 'Purple' },
+];
+
+function makeColumn(options: SelectOption[] = sampleOptions): ColumnDef {
+  return { key: 'color', title: 'Color', type: 'select', selectOptions: options };
+}
+
+// ─── Helpers ──────────────────────────────────────
+
+function makeContext(value: unknown = null, options?: SelectOption[]): CellEditorContext {
+  const container = document.createElement('div');
+  Object.defineProperty(container, 'getBoundingClientRect', {
+    value: () => ({
+      x: 0, y: 0, width: 800, height: 600,
+      top: 0, left: 0, right: 800, bottom: 600,
+    }),
+    configurable: true,
+  });
+  const scrollContainer = document.createElement('div');
+
+  return {
+    row: 1,
+    col: 2,
+    value: value as never,
+    column: makeColumn(options),
+    container,
+    scrollContainer,
+    layoutEngine: {
+      getCellRect: () => ({ x: 100, y: 50, width: 120, height: 24 }),
+    } as never,
+    scrollManager: { scrollX: 0, scrollY: 0 } as never,
+    cellStore: {} as never,
+    dataView: {} as never,
+    theme: stubTheme,
+    locale: stubLocale,
+    mergeManager: null,
+    frozenRows: 0,
+    frozenColumns: 0,
+  };
+}
+
+function pressKey(target: HTMLElement, key: string): void {
+  target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+function getOverlay(ctx: CellEditorContext): HTMLElement {
+  return ctx.container.querySelector('[role="dialog"]') as HTMLElement;
+}
+
+function getOptions(overlay: HTMLElement): NodeListOf<HTMLElement> {
+  return overlay.querySelectorAll('[role="option"]') as NodeListOf<HTMLElement>;
+}
+
+function getSearchInput(overlay: HTMLElement): HTMLInputElement {
+  return overlay.querySelector('input[type="text"]') as HTMLInputElement;
+}
+
+// ─── Tests ──────────────────────────────────────
+
+describe('SelectEditor', () => {
+  let editor: SelectEditor;
+  let commitFn: CellEditorCommit;
+  let closeFn: CellEditorClose;
+
+  beforeEach(() => {
+    editor = new SelectEditor();
+    editor.setTheme(stubTheme);
+    editor.setLocale(stubLocale);
+    commitFn = vi.fn();
+    closeFn = vi.fn();
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  // ─── Rendering ──────────────────────────────────────
+
+  describe('rendering', () => {
+    it('renders overlay with listbox and options', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      expect(overlay).toBeTruthy();
+      expect(overlay.getAttribute('aria-label')).toBe('Select option');
+
+      const listbox = overlay.querySelector('[role="listbox"]');
+      expect(listbox).toBeTruthy();
+
+      const options = getOptions(overlay);
+      expect(options.length).toBe(5);
+      expect(options[0].textContent).toBe('Red');
+      expect(options[4].textContent).toBe('Purple');
+    });
+
+    it('renders search input with placeholder', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const input = getSearchInput(overlay);
+      expect(input).toBeTruthy();
+      expect(input.placeholder).toBe('Search...');
+    });
+
+    it('uses label-less options showing value', () => {
+      const opts: SelectOption[] = [
+        { value: 'a' },
+        { value: 'b' },
+      ];
+      const ctx = makeContext(null, opts);
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const options = getOptions(overlay);
+      expect(options[0].textContent).toBe('a');
+      expect(options[1].textContent).toBe('b');
+    });
+  });
+
+  // ─── Pre-selection ──────────────────────────────────────
+
+  describe('pre-selection', () => {
+    it('highlights current cell value', () => {
+      const ctx = makeContext('green');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const options = getOptions(overlay);
+
+      // "green" is index 1
+      expect(options[1].getAttribute('aria-selected')).toBe('true');
+      expect(options[1].style.backgroundColor).toBeTruthy();
+    });
+
+    it('bolds current value option', () => {
+      const ctx = makeContext('blue');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const options = getOptions(overlay);
+
+      // "blue" is index 2
+      expect(options[2].style.fontWeight).toBe('bold');
+    });
+
+    it('defaults to first option when value not found', () => {
+      const ctx = makeContext('unknown');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const options = getOptions(overlay);
+      expect(options[0].getAttribute('aria-selected')).toBe('true');
+    });
+  });
+
+  // ─── Keyboard navigation ──────────────────────────────
+
+  describe('keyboard navigation', () => {
+    it('ArrowDown moves highlight forward', () => {
+      const ctx = makeContext('red');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      pressKey(overlay, 'ArrowDown');
+
+      const options = getOptions(overlay);
+      expect(options[0].getAttribute('aria-selected')).toBe('false');
+      expect(options[1].getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('ArrowUp moves highlight backward', () => {
+      const ctx = makeContext('green');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      pressKey(overlay, 'ArrowUp');
+
+      const options = getOptions(overlay);
+      expect(options[0].getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('ArrowDown wraps to first option', () => {
+      const ctx = makeContext('purple');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      pressKey(overlay, 'ArrowDown');
+
+      const options = getOptions(overlay);
+      expect(options[0].getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('ArrowUp wraps to last option', () => {
+      const ctx = makeContext('red');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      pressKey(overlay, 'ArrowUp');
+
+      const options = getOptions(overlay);
+      expect(options[4].getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('Enter commits highlighted option', () => {
+      const ctx = makeContext('red');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      pressKey(overlay, 'ArrowDown');
+      pressKey(overlay, 'Enter');
+
+      expect(commitFn).toHaveBeenCalledWith(1, 2, 'red', 'green');
+      expect(closeFn).toHaveBeenCalledWith('enter');
+    });
+
+    it('Tab commits highlighted option', () => {
+      const ctx = makeContext(null);
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      pressKey(overlay, 'Tab');
+
+      expect(commitFn).toHaveBeenCalledWith(1, 2, null, 'red');
+      expect(closeFn).toHaveBeenCalledWith('enter');
+    });
+
+    it('Escape closes without commit', () => {
+      const ctx = makeContext('red');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      pressKey(overlay, 'Escape');
+
+      expect(commitFn).not.toHaveBeenCalled();
+      expect(closeFn).toHaveBeenCalledWith('escape');
+    });
+  });
+
+  // ─── Type-ahead filtering ──────────────────────────────
+
+  describe('type-ahead filtering', () => {
+    it('filters options on input', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const input = getSearchInput(overlay);
+
+      // Simulate typing "gre"
+      input.value = 'gre';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      const options = getOptions(overlay);
+      expect(options.length).toBe(1);
+      expect(options[0].textContent).toBe('Green');
+    });
+
+    it('shows empty state when no match', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const input = getSearchInput(overlay);
+
+      input.value = 'xyz';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      const options = getOptions(overlay);
+      expect(options.length).toBe(0);
+
+      const noResults = overlay.querySelector('[role="listbox"]')!;
+      expect(noResults.textContent).toContain('No results');
+    });
+
+    it('case-insensitive filter', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const input = getSearchInput(overlay);
+
+      input.value = 'BLU';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      const options = getOptions(overlay);
+      expect(options.length).toBe(1);
+      expect(options[0].textContent).toBe('Blue');
+    });
+
+    it('restores full list when search cleared', () => {
+      const ctx = makeContext();
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const input = getSearchInput(overlay);
+
+      input.value = 'red';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      expect(getOptions(overlay).length).toBe(1);
+
+      input.value = '';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      expect(getOptions(overlay).length).toBe(5);
+    });
+  });
+
+  // ─── Mouse interaction ──────────────────────────────
+
+  describe('mouse interaction', () => {
+    it('click on option commits value', () => {
+      const ctx = makeContext('red');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const options = getOptions(overlay);
+
+      options[2].click(); // Click "Blue"
+
+      expect(commitFn).toHaveBeenCalledWith(1, 2, 'red', 'blue');
+      expect(closeFn).toHaveBeenCalledWith('enter');
+    });
+
+    it('mouseenter highlights option', () => {
+      const ctx = makeContext('red');
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const options = getOptions(overlay);
+
+      options[3].dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+
+      expect(options[3].getAttribute('aria-selected')).toBe('true');
+      expect(options[0].getAttribute('aria-selected')).toBe('false');
+    });
+  });
+
+  // ─── Empty options ──────────────────────────────────
+
+  describe('empty options', () => {
+    it('handles column with no selectOptions', () => {
+      const ctx = makeContext(null, []);
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      const options = getOptions(overlay);
+      expect(options.length).toBe(0);
+    });
+  });
+
+  // ─── Locale ──────────────────────────────────
+
+  describe('locale', () => {
+    it('uses locale strings', () => {
+      const ruLocale = {
+        ...stubLocale,
+        select: {
+          ariaLabel: 'Выберите значение',
+          searchPlaceholder: 'Поиск...',
+          noResults: 'Нет результатов',
+        },
+      } as ResolvedLocale;
+      editor.setLocale(ruLocale);
+
+      const ctx = makeContext();
+      ctx.locale = ruLocale;
+      editor.open(ctx, commitFn, closeFn);
+
+      const overlay = getOverlay(ctx);
+      expect(overlay.getAttribute('aria-label')).toBe('Выберите значение');
+
+      const input = getSearchInput(overlay);
+      expect(input.placeholder).toBe('Поиск...');
+    });
+  });
+});

--- a/packages/core/tests/show-column-headers.test.ts
+++ b/packages/core/tests/show-column-headers.test.ts
@@ -1,0 +1,399 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SpreadsheetEngine } from '../src/engine/spreadsheet-engine';
+import { GridGeometry } from '../src/renderer/grid-geometry';
+import { LayoutEngine } from '../src/renderer/layout-engine';
+import { EventTranslator } from '../src/events/event-translator';
+import { ScrollManager } from '../src/renderer/scroll-manager';
+import { EventBus } from '../src/events/event-bus';
+import { CellStore } from '../src/model/cell-store';
+import { DataView } from '../src/dataview/data-view';
+import { lightTheme } from '../src/themes/built-in-themes';
+import type { ColumnDef } from '../src/types/interfaces';
+
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    setTransform: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    clearRect: vi.fn(),
+    measureText: vi.fn().mockReturnValue({ width: 40 }),
+    canvas: {} as HTMLCanvasElement,
+    font: '',
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    strokeRect: vi.fn(),
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
+    globalAlpha: 1,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+const columns: ColumnDef[] = [
+  { key: 'a', title: 'A', width: 100 },
+  { key: 'b', title: 'B', width: 120 },
+  { key: 'c', title: 'C', width: 80 },
+];
+
+function makeData(): Record<string, unknown>[] {
+  return [
+    { a: 'A0', b: 'B0', c: 'C0' },
+    { a: 'A1', b: 'B1', c: 'C1' },
+    { a: 'A2', b: 'B2', c: 'C2' },
+  ];
+}
+
+function createEngine(config: Partial<ConstructorParameters<typeof SpreadsheetEngine>[0]> = {}) {
+  return new SpreadsheetEngine({
+    columns,
+    data: makeData(),
+    ...config,
+  });
+}
+
+describe('showColumnHeaders', () => {
+  let container: HTMLDivElement;
+  let origGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+  beforeEach(() => {
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    })) as unknown as typeof ResizeObserver;
+
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(createMockCtx()) as any;
+
+    container = document.createElement('div');
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      value: () => ({
+        width: 800,
+        height: 600,
+        top: 0,
+        left: 0,
+        right: 800,
+        bottom: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }),
+    });
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    document.body.removeChild(container);
+  });
+
+  describe('default behavior (showColumnHeaders=true)', () => {
+    it('shows headers by default', () => {
+      const engine = createEngine();
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      expect(le.headerHeight).toBe(lightTheme.dimensions.headerHeight);
+      expect(le.headerHeight).toBeGreaterThan(0);
+      engine.destroy();
+    });
+
+    it('cell y-positions are offset by header height', () => {
+      const engine = createEngine();
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      const rect = le.getCellRect(0, 0);
+      expect(rect.y).toBe(lightTheme.dimensions.headerHeight);
+      engine.destroy();
+    });
+  });
+
+  describe('showColumnHeaders=false', () => {
+    it('sets header height to zero in LayoutEngine', () => {
+      const engine = createEngine({ showColumnHeaders: false });
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      expect(le.headerHeight).toBe(0);
+      engine.destroy();
+    });
+
+    it('data renders from y=0', () => {
+      const engine = createEngine({ showColumnHeaders: false });
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      const rect = le.getCellRect(0, 0);
+      expect(rect.y).toBe(0);
+      engine.destroy();
+    });
+
+    it('total height excludes header height', () => {
+      const engine = createEngine({ showColumnHeaders: false });
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      const totalWithout = le.totalHeight;
+
+      engine.destroy();
+
+      const engine2 = createEngine({ showColumnHeaders: true });
+      engine2.mount(container);
+
+      const le2 = engine2.getLayoutEngine();
+      const totalWith = le2.totalHeight;
+
+      expect(totalWithout).toBe(totalWith - lightTheme.dimensions.headerHeight);
+      engine2.destroy();
+    });
+
+    it('selection still works without headers', () => {
+      const engine = createEngine({ showColumnHeaders: false, editable: true });
+      engine.mount(container);
+
+      const sm = engine.getSelectionManager();
+      sm.selectCell(1, 1);
+      const sel = sm.getSelection();
+      expect(sel.activeCell).toEqual({ row: 1, col: 1 });
+      expect(sel.type).toBe('cell');
+      engine.destroy();
+    });
+
+    it('frozen rows position from y=0', () => {
+      const engine = createEngine({
+        showColumnHeaders: false,
+        frozenRows: 1,
+      });
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      const rect = le.getCellRect(0, 0);
+      expect(rect.y).toBe(0);
+      engine.destroy();
+    });
+
+    it('second row y = first row height when headers hidden', () => {
+      const engine = createEngine({ showColumnHeaders: false });
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      const rect0 = le.getCellRect(0, 0);
+      const rect1 = le.getCellRect(1, 0);
+      expect(rect1.y).toBe(rect0.y + rect0.height);
+      engine.destroy();
+    });
+
+    it('mounts and renders without error', () => {
+      const engine = createEngine({ showColumnHeaders: false });
+      expect(() => engine.mount(container)).not.toThrow();
+      engine.destroy();
+    });
+  });
+
+  describe('GridGeometry integration', () => {
+    it('returns headerHeight=0 when showColumnHeaders=false', () => {
+      const geo = new GridGeometry({
+        columns,
+        theme: lightTheme,
+        showRowNumbers: false,
+        showColumnHeaders: false,
+      });
+      expect(geo.headerHeight).toBe(0);
+    });
+
+    it('returns theme headerHeight when showColumnHeaders=true', () => {
+      const geo = new GridGeometry({
+        columns,
+        theme: lightTheme,
+        showRowNumbers: false,
+        showColumnHeaders: true,
+      });
+      expect(geo.headerHeight).toBe(lightTheme.dimensions.headerHeight);
+    });
+
+    it('defaults to showing headers', () => {
+      const geo = new GridGeometry({
+        columns,
+        theme: lightTheme,
+        showRowNumbers: false,
+      });
+      expect(geo.headerHeight).toBe(lightTheme.dimensions.headerHeight);
+    });
+
+    it('cell rects start at y=0 without headers', () => {
+      const geo = new GridGeometry({
+        columns,
+        theme: lightTheme,
+        showRowNumbers: false,
+        showColumnHeaders: false,
+      });
+      const rect = geo.computeCellRect(0, 0);
+      expect(rect.y).toBe(0);
+    });
+
+    it('column header rects have height 0 without headers', () => {
+      const geo = new GridGeometry({
+        columns,
+        theme: lightTheme,
+        showRowNumbers: false,
+        showColumnHeaders: false,
+      });
+      const colRects = geo.computeColumnRects();
+      expect(colRects[0].height).toBe(0);
+    });
+  });
+
+  describe('event translation', () => {
+    it('click at y=0 hits data area when headers hidden (via LayoutEngine)', () => {
+      const engine = createEngine({ showColumnHeaders: false });
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      expect(le!.headerHeight).toBe(0);
+      const rect = le!.getCellRect(0, 0);
+      expect(rect.y).toBe(0);
+      engine.destroy();
+    });
+
+    it('header area has positive height when headers shown', () => {
+      const engine = createEngine({ showColumnHeaders: true });
+      engine.mount(container);
+
+      const le = engine.getLayoutEngine();
+      expect(le!.headerHeight).toBeGreaterThan(0);
+      const rect = le!.getCellRect(0, 0);
+      expect(rect.y).toBe(le!.headerHeight);
+      engine.destroy();
+    });
+  });
+
+  describe('EventTranslator with hidden headers', () => {
+    it('hitTest returns cell region at y=5 when headerHeight=0', () => {
+      const le = new LayoutEngine({
+        columns,
+        rowCount: 10,
+        rowHeight: 28,
+        headerHeight: 0,
+        rowNumberWidth: 0,
+      });
+
+      const scrollMgr = new ScrollManager({
+        container,
+        totalWidth: le.totalWidth,
+        totalHeight: le.totalHeight,
+        onScroll: () => {},
+      });
+
+      const eventBus = new EventBus();
+      const cellStore = new CellStore();
+      cellStore.bulkLoad([{ a: 'x', b: 'y', c: 'z' }], ['a', 'b', 'c']);
+
+      const translator = new EventTranslator({
+        scrollContainer: scrollMgr.getElement(),
+        layoutEngine: le,
+        scrollManager: scrollMgr,
+        eventBus,
+        cellStore,
+        dataView: new DataView({ totalRowCount: 1 }),
+        columns,
+      });
+
+      const hit = translator.hitTest(50, 5, 0, 0);
+      expect(hit.region).toBe('cell');
+      expect(hit.row).toBe(0);
+      expect(hit.col).toBe(0);
+
+      translator.detach();
+      scrollMgr.destroy();
+    });
+
+    it('hitTest never returns header region when headerHeight=0', () => {
+      const le = new LayoutEngine({
+        columns,
+        rowCount: 10,
+        rowHeight: 28,
+        headerHeight: 0,
+        rowNumberWidth: 0,
+      });
+
+      const scrollMgr = new ScrollManager({
+        container,
+        totalWidth: le.totalWidth,
+        totalHeight: le.totalHeight,
+        onScroll: () => {},
+      });
+
+      const eventBus = new EventBus();
+      const cellStore = new CellStore();
+
+      const translator = new EventTranslator({
+        scrollContainer: scrollMgr.getElement(),
+        layoutEngine: le,
+        scrollManager: scrollMgr,
+        eventBus,
+        cellStore,
+        dataView: new DataView({ totalRowCount: 10 }),
+        columns,
+      });
+
+      // Test various y positions — none should return header
+      for (const y of [0, 1, 10, 28, 100]) {
+        const hit = translator.hitTest(50, y, 0, 0);
+        expect(hit.region).not.toBe('header');
+        expect(hit.region).not.toBe('header-sort-icon');
+        expect(hit.region).not.toBe('header-filter-icon');
+      }
+
+      translator.detach();
+      scrollMgr.destroy();
+    });
+
+    it('hitTest returns header region for normal headerHeight=32', () => {
+      const le = new LayoutEngine({
+        columns,
+        rowCount: 10,
+        rowHeight: 28,
+        headerHeight: 32,
+        rowNumberWidth: 0,
+      });
+
+      const scrollMgr = new ScrollManager({
+        container,
+        totalWidth: le.totalWidth,
+        totalHeight: le.totalHeight,
+        onScroll: () => {},
+      });
+
+      const eventBus = new EventBus();
+      const cellStore = new CellStore();
+
+      const translator = new EventTranslator({
+        scrollContainer: scrollMgr.getElement(),
+        layoutEngine: le,
+        scrollManager: scrollMgr,
+        eventBus,
+        cellStore,
+        dataView: new DataView({ totalRowCount: 10 }),
+        columns,
+      });
+
+      const hit = translator.hitTest(50, 10, 0, 0);
+      expect(hit.region).toBe('header');
+
+      translator.detach();
+      scrollMgr.destroy();
+    });
+  });
+});

--- a/packages/core/tests/small-api-enhancements.test.ts
+++ b/packages/core/tests/small-api-enhancements.test.ts
@@ -1,0 +1,378 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventTranslator } from '../src/events/event-translator';
+import { EventBus } from '../src/events/event-bus';
+import { LayoutEngine } from '../src/renderer/layout-engine';
+import { ScrollManager } from '../src/renderer/scroll-manager';
+import { CellStore } from '../src/model/cell-store';
+import { DataView } from '../src/dataview/data-view';
+import { CellTypeRegistry } from '../src/types/cell-type-registry';
+import { ClipboardManager } from '../src/clipboard/clipboard-manager';
+import { SelectionManager } from '../src/selection/selection-manager';
+import { CommandManager } from '../src/commands/command-manager';
+import type { CellTypeRenderer, HitZone } from '../src/types/cell-type-registry';
+import type { ColumnDef } from '../src/types/interfaces';
+import type { ClipboardPasteEvent, CellEvent } from '../src/events/event-types';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeColumns(): ColumnDef[] {
+  return [
+    { key: 'name', title: 'Name', width: 120 },
+    { key: 'age', title: 'Age', width: 80, type: 'number' },
+    { key: 'city', title: 'City', width: 100 },
+  ];
+}
+
+function mouseEvent(
+  type: string,
+  offsetX: number,
+  offsetY: number,
+  opts?: { shiftKey?: boolean; ctrlKey?: boolean },
+): MouseEvent {
+  const e = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: offsetX,
+    clientY: offsetY,
+    shiftKey: opts?.shiftKey,
+    ctrlKey: opts?.ctrlKey,
+  });
+  Object.defineProperty(e, 'offsetX', { value: offsetX });
+  Object.defineProperty(e, 'offsetY', { value: offsetY });
+  return e;
+}
+
+function createClipboardEvent(
+  type: 'copy' | 'cut' | 'paste',
+  data?: Record<string, string>,
+): ClipboardEvent {
+  const clipboardData: DataTransfer = {
+    data: {} as Record<string, string>,
+    setData(format: string, value: string) {
+      this.data[format] = value;
+    },
+    getData(format: string) {
+      return this.data[format] ?? '';
+    },
+  } as unknown as DataTransfer;
+
+  if (data) {
+    for (const [key, value] of Object.entries(data)) {
+      clipboardData.setData(key, value);
+    }
+  }
+
+  const event = new Event(type, { bubbles: true, cancelable: true }) as ClipboardEvent;
+  Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+  return event;
+}
+
+// =============================================================================
+// 1. HitZone Padding
+// =============================================================================
+
+describe('HitZone Padding', () => {
+  const headerHeight = 32;
+  const rowHeight = 28;
+  const rowNumberWidth = 50;
+  let container: HTMLDivElement;
+  let scrollContainer: HTMLDivElement;
+  let layoutEngine: LayoutEngine;
+  let scrollManager: ScrollManager;
+  let eventBus: EventBus;
+  let cellStore: CellStore;
+  let cellTypeRegistry: CellTypeRegistry;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      value: () => ({
+        width: 800,
+        height: 600,
+        top: 0,
+        left: 0,
+        right: 800,
+        bottom: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }),
+    });
+    document.body.appendChild(container);
+
+    eventBus = new EventBus();
+    cellStore = new CellStore();
+    cellTypeRegistry = new CellTypeRegistry();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function createTranslator(zones: HitZone[]): EventTranslator {
+    const cols: ColumnDef[] = [
+      { key: 'action', title: 'Action', width: 120, type: 'custom' },
+    ];
+
+    const renderer: CellTypeRenderer = {
+      format: (v) => String(v ?? ''),
+      render: () => {},
+      getHitZones: () => zones,
+    };
+    cellTypeRegistry.register('custom', renderer);
+
+    layoutEngine = new LayoutEngine({
+      columns: cols,
+      rowCount: 100,
+      rowHeight,
+      headerHeight,
+      rowNumberWidth,
+    });
+
+    scrollManager = new ScrollManager({
+      container,
+      totalWidth: layoutEngine.totalWidth,
+      totalHeight: layoutEngine.totalHeight,
+      onScroll: () => {},
+    });
+    scrollContainer = scrollManager.getElement();
+
+    cellStore.setValue(0, 0, 'test');
+
+    const translator = new EventTranslator({
+      scrollContainer,
+      layoutEngine,
+      scrollManager,
+      eventBus,
+      cellStore,
+      dataView: new DataView({ totalRowCount: 100 }),
+      columns: cols,
+      cellTypeRegistry,
+    });
+
+    return translator;
+  }
+
+  it('detects hit inside zone without padding', () => {
+    // Zone at (10, 5) size 20x20 in cell (0,0)
+    const translator = createTranslator([{ id: 'btn', x: 10, y: 5, width: 20, height: 20 }]);
+    // Cell (0,0): x starts at rowNumberWidth(50), y at headerHeight(32)
+    // relX = offsetX - rowNumberWidth - cellX = offsetX - 50 - 0
+    // relY = offsetY - headerHeight - cellY = offsetY - 32 - 0
+    // For relX=15, relY=10 → offsetX=65, offsetY=42
+    const result = translator.hitTest(65, 42);
+    expect(result.region).toBe('cell');
+    expect(result.hitZone).toBe('btn');
+    translator.detach();
+    scrollManager.destroy();
+  });
+
+  it('misses zone without padding', () => {
+    const translator = createTranslator([{ id: 'btn', x: 10, y: 5, width: 20, height: 20 }]);
+    // relX=5 (before zone.x=10) → offsetX=55
+    const result = translator.hitTest(55, 42);
+    expect(result.region).toBe('cell');
+    expect(result.hitZone).toBeUndefined();
+    translator.detach();
+    scrollManager.destroy();
+  });
+
+  it('detects hit in padding area with uniform padding', () => {
+    const translator = createTranslator([
+      { id: 'btn', x: 10, y: 5, width: 20, height: 20, padding: 8 },
+    ]);
+    // Zone x range: 10..30, with padding=8 → effective: 2..38
+    // relX=5 is inside effective range (>= 2)
+    // offsetX = 50 + 5 = 55
+    const result = translator.hitTest(55, 42);
+    expect(result.region).toBe('cell');
+    expect(result.hitZone).toBe('btn');
+    translator.detach();
+    scrollManager.destroy();
+  });
+
+  it('detects hit in padding area with per-side padding', () => {
+    const translator = createTranslator([
+      {
+        id: 'btn',
+        x: 10,
+        y: 5,
+        width: 20,
+        height: 20,
+        padding: { top: 0, right: 0, bottom: 0, left: 15 },
+      },
+    ]);
+    // Zone x range: 10..30, with left padding=15 → effective left starts at -5
+    // relX=0 is inside effective range (>= -5)
+    // offsetX = 50 + 0 = 50
+    const result = translator.hitTest(50, 42);
+    expect(result.region).toBe('cell');
+    expect(result.hitZone).toBe('btn');
+    translator.detach();
+    scrollManager.destroy();
+  });
+
+  it('misses zone even with padding when far outside', () => {
+    const translator = createTranslator([
+      { id: 'btn', x: 50, y: 5, width: 20, height: 20, padding: 5 },
+    ]);
+    // Zone effective x range: 45..75
+    // relX=10 is well outside (< 45)
+    // offsetX = 50 + 10 = 60
+    const result = translator.hitTest(60, 42);
+    expect(result.region).toBe('cell');
+    expect(result.hitZone).toBeUndefined();
+    translator.detach();
+    scrollManager.destroy();
+  });
+
+  it('carries padded hit zone in cellClick event', () => {
+    const translator = createTranslator([
+      { id: 'btn', x: 10, y: 5, width: 20, height: 20, padding: 8 },
+    ]);
+    translator.attach();
+
+    const handler = vi.fn<[CellEvent]>();
+    eventBus.on('cellClick', handler);
+
+    // Click in padding area: relX=5 → offsetX=55
+    scrollContainer.dispatchEvent(mouseEvent('mousedown', 55, 42));
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][0].hitZone).toBe('btn');
+
+    translator.detach();
+    scrollManager.destroy();
+  });
+
+  it('padding does not change zone visual dimensions', () => {
+    const zone: HitZone = { id: 'btn', x: 10, y: 5, width: 20, height: 20, padding: 100 };
+    // Padding only affects hit-testing, not the zone's reported visual dimensions
+    expect(zone.width).toBe(20);
+    expect(zone.height).toBe(20);
+    expect(zone.x).toBe(10);
+    expect(zone.y).toBe(5);
+  });
+});
+
+// =============================================================================
+// 2. Paste Event Coordinates
+// =============================================================================
+
+describe('ClipboardPasteEvent coordinates', () => {
+  let setup: ReturnType<typeof createPasteSetup>;
+
+  function createPasteSetup() {
+    const cellStore = new CellStore();
+    cellStore.setValue(0, 0, 'Alice');
+    cellStore.setValue(1, 0, 'Bob');
+
+    const selectionManager = new SelectionManager({
+      rowCount: 10,
+      colCount: 5,
+    });
+
+    const commandManager = new CommandManager({ historyLimit: 100 });
+    const eventBus = new EventBus();
+    const onDataChange = vi.fn();
+    const isEditing = vi.fn(() => false);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const clipboardManager = new ClipboardManager({
+      cellStore,
+      dataView: new DataView({ totalRowCount: 10 }),
+      selectionManager,
+      commandManager,
+      eventBus,
+      isEditing,
+      isCellEditable: () => true,
+      onDataChange,
+    });
+    clipboardManager.attach(container);
+
+    return {
+      cellStore,
+      selectionManager,
+      commandManager,
+      eventBus,
+      onDataChange,
+      container,
+      clipboardManager,
+      cleanup() {
+        clipboardManager.detach();
+        document.body.removeChild(container);
+      },
+    };
+  }
+
+  beforeEach(() => {
+    setup = createPasteSetup();
+  });
+
+  afterEach(() => {
+    setup.cleanup();
+  });
+
+  it('includes startRow and startCol in clipboardPaste event', () => {
+    const handler = vi.fn();
+    setup.eventBus.on('clipboardPaste', handler);
+    setup.selectionManager.selectCell(2, 3);
+    setup.container.dispatchEvent(
+      createClipboardEvent('paste', { 'text/plain': 'X\tY\nZ\tW' }),
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event: ClipboardPasteEvent = handler.mock.calls[0][0];
+    expect(event.startRow).toBe(2);
+    expect(event.startCol).toBe(3);
+    expect(event.rowCount).toBe(2);
+    expect(event.colCount).toBe(2);
+  });
+
+  it('reports coordinates from active cell at paste time', () => {
+    const handler = vi.fn();
+    setup.eventBus.on('clipboardPaste', handler);
+    setup.selectionManager.selectCell(5, 2);
+    setup.container.dispatchEvent(
+      createClipboardEvent('paste', { 'text/plain': 'val' }),
+    );
+
+    const event: ClipboardPasteEvent = handler.mock.calls[0][0];
+    expect(event.startRow).toBe(5);
+    expect(event.startCol).toBe(2);
+  });
+
+  it('reports (0,0) when pasting at origin', () => {
+    const handler = vi.fn();
+    setup.eventBus.on('clipboardPaste', handler);
+    setup.selectionManager.selectCell(0, 0);
+    setup.container.dispatchEvent(
+      createClipboardEvent('paste', { 'text/plain': 'A' }),
+    );
+
+    const event: ClipboardPasteEvent = handler.mock.calls[0][0];
+    expect(event.startRow).toBe(0);
+    expect(event.startCol).toBe(0);
+  });
+});
+
+// =============================================================================
+// 3. getScrollContainer Convenience
+// =============================================================================
+
+describe('SpreadsheetEngine.getScrollContainer()', () => {
+  it('returns null before mount', async () => {
+    const { SpreadsheetEngine } = await import('../src/engine/spreadsheet-engine');
+    const engine = new SpreadsheetEngine({
+      columns: makeColumns(),
+      data: [{ name: 'A', age: 1, city: 'B' }],
+    });
+    expect(engine.getScrollContainer()).toBeNull();
+    engine.destroy();
+  });
+});

--- a/packages/core/tests/viewport-rendering.test.ts
+++ b/packages/core/tests/viewport-rendering.test.ts
@@ -1,0 +1,459 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SpreadsheetEngine } from '../src/engine/spreadsheet-engine';
+import { lightTheme } from '../src/themes/built-in-themes';
+import type { ColumnDef } from '../src/types/interfaces';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function createMockContainer(): HTMLElement {
+  const container = document.createElement('div');
+  Object.defineProperty(container, 'clientWidth', { value: 800, writable: true });
+  Object.defineProperty(container, 'clientHeight', { value: 600, writable: true });
+  Object.defineProperty(container, 'offsetWidth', { value: 800, writable: true });
+  Object.defineProperty(container, 'offsetHeight', { value: 600, writable: true });
+  container.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+      top: 0,
+      right: 800,
+      bottom: 600,
+      left: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return container;
+}
+
+function setupCanvasMocks() {
+  const drawCalls: { method: string; args: unknown[]; fillStyle?: string }[] = [];
+
+  let _fillStyle = '';
+  const ctxProxy = {
+    scale: vi.fn(),
+    clearRect: vi.fn((...args: unknown[]) => drawCalls.push({ method: 'clearRect', args })),
+    fillRect: vi.fn((...args: unknown[]) =>
+      drawCalls.push({ method: 'fillRect', args, fillStyle: _fillStyle }),
+    ),
+    fillText: vi.fn(),
+    strokeRect: vi.fn(),
+    measureText: vi
+      .fn()
+      .mockReturnValue({ width: 50, actualBoundingBoxAscent: 10, actualBoundingBoxDescent: 2 }),
+    beginPath: vi.fn(),
+    moveTo: vi.fn((...args: unknown[]) => drawCalls.push({ method: 'moveTo', args })),
+    lineTo: vi.fn((...args: unknown[]) => drawCalls.push({ method: 'lineTo', args })),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    closePath: vi.fn(),
+    arc: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    clip: vi.fn(),
+    rect: vi.fn(),
+    setLineDash: vi.fn(),
+    getLineDash: vi.fn().mockReturnValue([]),
+    canvas: { width: 800, height: 600 },
+    font: '',
+    get fillStyle() {
+      return _fillStyle;
+    },
+    set fillStyle(v: string) {
+      _fillStyle = v;
+    },
+    strokeStyle: '',
+    textAlign: 'left',
+    textBaseline: 'top',
+    lineWidth: 1,
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over',
+    setTransform: vi.fn(),
+    getTransform: vi.fn().mockReturnValue({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
+    resetTransform: vi.fn(),
+    createLinearGradient: vi.fn().mockReturnValue({ addColorStop: vi.fn() }),
+  };
+
+  HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(ctxProxy);
+
+  return drawCalls;
+}
+
+const columns: ColumnDef[] = [
+  { key: 'name', title: 'Name', width: 150 },
+  { key: 'value', title: 'Value', width: 100 },
+  { key: 'city', title: 'City', width: 120 },
+];
+
+const data = [
+  { name: 'Alice', value: 100, city: 'NYC' },
+  { name: 'Bob', value: 200, city: 'LA' },
+  { name: 'Carol', value: 300, city: 'Chicago' },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Viewport Rendering', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    container = createMockContainer();
+  });
+
+  describe('clipGridLinesToData', () => {
+    it('grid lines extend to canvas edges by default', () => {
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({ columns, data });
+      engine.mount(container);
+
+      // Find lineTo calls that go to canvas width (800) or height (600)
+      const toCanvasWidth = drawCalls.filter((c) => c.method === 'lineTo' && c.args[0] === 800);
+      const toCanvasHeight = drawCalls.filter((c) => c.method === 'lineTo' && c.args[1] === 600);
+
+      expect(toCanvasWidth.length).toBeGreaterThan(0);
+      expect(toCanvasHeight.length).toBeGreaterThan(0);
+      engine.destroy();
+    });
+
+    it('grid lines stop at data boundary when clipGridLinesToData=true', () => {
+      // First render without clipping to get baseline
+      const defaultCalls = setupCanvasMocks();
+      const defaultEngine = new SpreadsheetEngine({ columns, data });
+      defaultEngine.mount(container);
+      const defaultToWidth = defaultCalls.filter(
+        (c) => c.method === 'lineTo' && c.args[0] === 800,
+      ).length;
+      defaultEngine.destroy();
+
+      // Now render with clipping
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({
+        columns,
+        data,
+        clipGridLinesToData: true,
+      });
+      engine.mount(container);
+
+      const clippedToWidth = drawCalls.filter(
+        (c) => c.method === 'lineTo' && c.args[0] === 800,
+      ).length;
+
+      // Clipping should result in significantly fewer lines reaching canvas width
+      // (header layer still draws to full width, but grid lines should stop at data boundary)
+      expect(clippedToWidth).toBeLessThan(defaultToWidth);
+      engine.destroy();
+    });
+
+    it('clipGridLinesToData defaults to false', () => {
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({ columns, data });
+      engine.mount(container);
+
+      // Default behavior: lines extend to canvas edges
+      const toCanvasWidth = drawCalls.filter((c) => c.method === 'lineTo' && c.args[0] === 800);
+      expect(toCanvasWidth.length).toBeGreaterThan(0);
+      engine.destroy();
+    });
+
+    it('phantom grid lines are not drawn when clipGridLinesToData=true and no data', () => {
+      // First render without clipping to get baseline
+      const defaultCalls = setupCanvasMocks();
+      const defaultEngine = new SpreadsheetEngine({
+        columns,
+        data: [],
+        rowCount: 0,
+      });
+      defaultEngine.mount(container);
+      const defaultToWidth = defaultCalls.filter(
+        (c) => c.method === 'lineTo' && c.args[0] === 800,
+      ).length;
+      defaultEngine.destroy();
+
+      // Now render with clipping
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({
+        columns,
+        data: [],
+        rowCount: 0,
+        clipGridLinesToData: true,
+      });
+      engine.mount(container);
+
+      // With no data and clipToData, phantom grid lines should not be drawn
+      const clippedToWidth = drawCalls.filter(
+        (c) => c.method === 'lineTo' && c.args[0] === 800,
+      ).length;
+      // Should have fewer lines to canvas width (phantom lines suppressed)
+      expect(clippedToWidth).toBeLessThan(defaultToWidth);
+      engine.destroy();
+    });
+
+    it('phantom grid lines are drawn when clipGridLinesToData=false and no data', () => {
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({
+        columns,
+        data: [],
+        rowCount: 0,
+        clipGridLinesToData: false,
+      });
+      engine.mount(container);
+
+      // Default: phantom grid lines fill the canvas
+      const hLines = drawCalls.filter((c) => c.method === 'lineTo' && c.args[0] === 800);
+      expect(hLines.length).toBeGreaterThan(0);
+      engine.destroy();
+    });
+
+    it('vertical grid lines stop at last data row boundary when clipped', () => {
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({
+        columns,
+        data,
+        clipGridLinesToData: true,
+      });
+      engine.mount(container);
+
+      // Vertical lines should NOT go to canvas height (600)
+      const toCanvasHeight = drawCalls.filter((c) => c.method === 'lineTo' && c.args[1] === 600);
+      expect(toCanvasHeight.length).toBe(0);
+      engine.destroy();
+    });
+
+    it('gutter border clips to data boundary when clipped', () => {
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({
+        columns,
+        data,
+        clipGridLinesToData: true,
+        showRowNumbers: true,
+      });
+      engine.mount(container);
+
+      // Gutter right border should NOT extend to canvas height
+      const toCanvasHeight = drawCalls.filter((c) => c.method === 'lineTo' && c.args[1] === 600);
+      expect(toCanvasHeight.length).toBe(0);
+      engine.destroy();
+    });
+  });
+
+  describe('transparent background', () => {
+    it('uses fillRect with solid background color by default', () => {
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({ columns, data });
+      engine.mount(container);
+
+      // Default theme uses solid background
+      const fillRects = drawCalls.filter(
+        (c) =>
+          c.method === 'fillRect' &&
+          c.args[0] === 0 &&
+          c.args[1] === 0 &&
+          c.args[2] === 800 &&
+          c.args[3] === 600,
+      );
+      expect(fillRects.length).toBeGreaterThan(0);
+      engine.destroy();
+    });
+
+    it('uses clearRect when background is transparent', () => {
+      const drawCalls = setupCanvasMocks();
+
+      const transparentTheme = {
+        ...lightTheme,
+        colors: {
+          ...lightTheme.colors,
+          background: 'transparent',
+        },
+      };
+      const engine = new SpreadsheetEngine({
+        columns,
+        data,
+        theme: transparentTheme,
+      });
+      engine.mount(container);
+
+      // Should use clearRect instead of fillRect for canvas-wide background
+      const clearRects = drawCalls.filter(
+        (c) =>
+          c.method === 'clearRect' &&
+          c.args[0] === 0 &&
+          c.args[1] === 0 &&
+          c.args[2] === 800 &&
+          c.args[3] === 600,
+      );
+      expect(clearRects.length).toBeGreaterThan(0);
+
+      // Should NOT have fillRect for canvas-wide background
+      const fillRects = drawCalls.filter(
+        (c) =>
+          c.method === 'fillRect' &&
+          c.args[0] === 0 &&
+          c.args[1] === 0 &&
+          c.args[2] === 800 &&
+          c.args[3] === 600,
+      );
+      expect(fillRects.length).toBe(0);
+      engine.destroy();
+    });
+
+    it('cells with bgColor still render their background when canvas is transparent', () => {
+      const drawCalls = setupCanvasMocks();
+
+      const transparentTheme = {
+        ...lightTheme,
+        colors: {
+          ...lightTheme.colors,
+          background: 'transparent',
+        },
+      };
+
+      const engine = new SpreadsheetEngine({
+        columns,
+        data: [{ name: 'Alice', value: 100, city: 'NYC' }],
+        theme: transparentTheme,
+      });
+      engine.mount(container);
+
+      // Canvas-wide clearRect should exist (transparent background)
+      const clearRects = drawCalls.filter(
+        (c) =>
+          c.method === 'clearRect' &&
+          c.args[0] === 0 &&
+          c.args[1] === 0 &&
+          c.args[2] === 800 &&
+          c.args[3] === 600,
+      );
+      expect(clearRects.length).toBeGreaterThan(0);
+
+      // No opaque canvas-wide fillRect (background is transparent, not solid)
+      const opaqueBackgrounds = drawCalls.filter(
+        (c) =>
+          c.method === 'fillRect' &&
+          c.args[0] === 0 &&
+          c.args[1] === 0 &&
+          c.args[2] === 800 &&
+          c.args[3] === 600,
+      );
+      expect(opaqueBackgrounds.length).toBe(0);
+
+      // Per-cell fillRect calls still work (BackgroundLayer per-cell logic unchanged)
+      // Cells with bgColor would get fillRect with cell dimensions, not canvas-wide
+      // This is verified by existing BackgroundLayer tests; here we confirm
+      // that transparent canvas doesn't suppress the fillRect mechanism
+      const cellFills = drawCalls.filter(
+        (c) =>
+          c.method === 'fillRect' && (c.args[2] as number) < 800 && (c.args[3] as number) < 600,
+      );
+      // At minimum, row number gutter background fills exist
+      expect(cellFills.length).toBeGreaterThan(0);
+
+      engine.destroy();
+    });
+
+    it('canvas is transparent (no solid fill) with transparent background', () => {
+      const drawCalls = setupCanvasMocks();
+
+      const transparentTheme = {
+        ...lightTheme,
+        colors: {
+          ...lightTheme.colors,
+          background: 'transparent',
+        },
+      };
+      const engine = new SpreadsheetEngine({
+        columns,
+        data,
+        theme: transparentTheme,
+      });
+      engine.mount(container);
+
+      // No canvas-wide fillRect (which would be opaque)
+      const opaqueBackground = drawCalls.filter(
+        (c) =>
+          c.method === 'fillRect' &&
+          c.args[0] === 0 &&
+          c.args[1] === 0 &&
+          c.args[2] === 800 &&
+          c.args[3] === 600,
+      );
+      expect(opaqueBackground.length).toBe(0);
+      engine.destroy();
+    });
+  });
+
+  describe('combined features', () => {
+    it('clipGridLinesToData works with transparent background', () => {
+      // Get baseline without clipping
+      const defaultCalls = setupCanvasMocks();
+      const transparentTheme = {
+        ...lightTheme,
+        colors: {
+          ...lightTheme.colors,
+          background: 'transparent',
+        },
+      };
+      const defaultEngine = new SpreadsheetEngine({
+        columns,
+        data,
+        theme: transparentTheme,
+      });
+      defaultEngine.mount(container);
+      const defaultToWidth = defaultCalls.filter(
+        (c) => c.method === 'lineTo' && c.args[0] === 800,
+      ).length;
+      defaultEngine.destroy();
+
+      // Now with clipping
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({
+        columns,
+        data,
+        theme: transparentTheme,
+        clipGridLinesToData: true,
+      });
+      engine.mount(container);
+
+      // Fewer lines to canvas width (grid lines clipped, only header lines remain)
+      const clippedToWidth = drawCalls.filter(
+        (c) => c.method === 'lineTo' && c.args[0] === 800,
+      ).length;
+      expect(clippedToWidth).toBeLessThan(defaultToWidth);
+
+      // clearRect used (transparent)
+      const clearRects = drawCalls.filter(
+        (c) => c.method === 'clearRect' && c.args[0] === 0 && c.args[1] === 0,
+      );
+      expect(clearRects.length).toBeGreaterThan(0);
+
+      engine.destroy();
+    });
+
+    it('clipGridLinesToData works with showColumnHeaders=false', () => {
+      const drawCalls = setupCanvasMocks();
+      const engine = new SpreadsheetEngine({
+        columns,
+        data,
+        clipGridLinesToData: true,
+        showColumnHeaders: false,
+      });
+      engine.mount(container);
+
+      // No lines to canvas edges
+      const toCanvasWidth = drawCalls.filter((c) => c.method === 'lineTo' && c.args[0] === 800);
+      expect(toCanvasWidth.length).toBe(0);
+
+      engine.destroy();
+    });
+  });
+});

--- a/packages/demo/src/visual-tests/index.ts
+++ b/packages/demo/src/visual-tests/index.ts
@@ -42,6 +42,7 @@ import { DemoExcel } from './scenarios/demo-excel';
 import { DemoEventBus } from './scenarios/demo-event-bus';
 import { DemoPluginShowcase } from './scenarios/demo-plugin-showcase';
 import { DemoHero } from './scenarios/demo-hero';
+import { DemoDecorators } from './scenarios/demo-decorators';
 
 export interface Scenario {
   id: string;
@@ -161,4 +162,9 @@ export const scenarios: Scenario[] = [
     component: DemoPluginShowcase,
   },
   { id: 'demo-hero', description: 'Demo: hero business data table', component: DemoHero },
+  {
+    id: 'demo-decorators',
+    description: 'Demo: cell decorators (tree, sort, progress, link, spinner)',
+    component: DemoDecorators,
+  },
 ];

--- a/packages/demo/src/visual-tests/scenarios/demo-decorators.tsx
+++ b/packages/demo/src/visual-tests/scenarios/demo-decorators.tsx
@@ -1,0 +1,120 @@
+import { useRef, useEffect } from 'react';
+import { Spreadsheet } from '@witqq/spreadsheet-react';
+import type { SpreadsheetRef } from '@witqq/spreadsheet-react';
+import type { ColumnDef } from '@witqq/spreadsheet';
+import { DecoratorsPlugin } from '@witqq/spreadsheet-plugins';
+import { ScenarioContainer, tableStyle } from './shared';
+
+const columns: ColumnDef[] = [
+  { key: 'task', title: 'Task', width: 180 },
+  { key: 'assignee', title: 'Assignee', width: 120 },
+  { key: 'progress', title: 'Progress', width: 130, type: 'number' },
+  { key: 'priority', title: 'Priority', width: 100 },
+  { key: 'link', title: 'Documentation', width: 150 },
+  { key: 'status', title: 'Status', width: 100 },
+];
+
+const data = [
+  { task: 'Platform Migration', assignee: 'Alice', progress: 100, priority: 'High', link: 'Migration Guide', status: 'Complete' },
+  { task: '  Auth Module', assignee: 'Bob', progress: 95, priority: 'High', link: 'Auth Docs', status: 'Complete' },
+  { task: '    OAuth Provider', assignee: 'Carol', progress: 100, priority: 'Medium', link: '', status: 'Complete' },
+  { task: '    Session Store', assignee: 'Dave', progress: 90, priority: 'Medium', link: '', status: 'Complete' },
+  { task: '  Data Layer', assignee: 'Eve', progress: 60, priority: 'High', link: 'Data Docs', status: 'Active' },
+  { task: '    Query Engine', assignee: 'Frank', progress: 45, priority: 'High', link: '', status: 'Active' },
+  { task: '    Cache Layer', assignee: 'Grace', progress: 75, priority: 'Low', link: '', status: 'Active' },
+  { task: '  UI Components', assignee: 'Henry', progress: 30, priority: 'Medium', link: 'UI Docs', status: 'Active' },
+  { task: '    Grid Widget', assignee: 'Ivy', progress: 10, priority: 'Medium', link: '', status: 'Syncing' },
+  { task: '    Charts', assignee: 'Jack', progress: 5, priority: 'Low', link: '', status: 'Syncing' },
+];
+
+export function DemoDecorators() {
+  const ref = useRef<SpreadsheetRef>(null);
+
+  useEffect(() => {
+    const engine = ref.current?.getInstance();
+    if (!engine) return;
+
+    engine.installPlugin(new DecoratorsPlugin());
+
+    const cellStore = engine.getCellStore();
+
+    // TreeExpander: hierarchical task list (col 0)
+    const treeLevels = [0, 1, 2, 2, 1, 2, 2, 1, 2, 2];
+    const treeExpanded = [true, true, true, true, true, true, true, true, true, true];
+    for (let row = 0; row < data.length; row++) {
+      cellStore.setMetadata(row, 0, {
+        treeLevel: treeLevels[row],
+        treeExpanded: treeExpanded[row],
+      });
+    }
+
+    // ProgressBar: show progress percentage (col 2)
+    for (let row = 0; row < data.length; row++) {
+      cellStore.setMetadata(row, 2, {
+        progress: data[row].progress / 100,
+      });
+    }
+
+    // SortIcon: priority column header indication (col 3)
+    const sortDirs: Array<'asc' | 'desc' | undefined> = [
+      'desc', undefined, undefined, undefined, 'asc',
+      undefined, undefined, undefined, undefined, undefined,
+    ];
+    for (let row = 0; row < data.length; row++) {
+      if (sortDirs[row]) {
+        cellStore.setMetadata(row, 3, { sortDirection: sortDirs[row] });
+      }
+    }
+
+    // Link: documentation links (col 4)
+    const links = [
+      'https://example.com/migration',
+      'https://example.com/auth',
+      '', '', 
+      'https://example.com/data',
+      '', '',
+      'https://example.com/ui',
+      '', '',
+    ];
+    for (let row = 0; row < data.length; row++) {
+      if (links[row]) {
+        cellStore.setMetadata(row, 4, {
+          link: { url: links[row], label: data[row].link },
+        });
+      }
+    }
+
+    // Spinner: loading indicator for syncing rows (col 5)
+    for (let row = 0; row < data.length; row++) {
+      if (data[row].status === 'Syncing') {
+        cellStore.setMetadata(row, 5, { loading: true });
+      }
+    }
+
+    // Image: avatar thumbnails for assignees (col 1)
+    // Small SVG data URIs as placeholder avatars with initials
+    const colors = ['#4CAF50', '#2196F3', '#FF9800', '#9C27B0', '#F44336', '#00BCD4', '#795548', '#607D8B', '#E91E63', '#3F51B5'];
+    for (let row = 0; row < data.length; row++) {
+      const name = data[row].assignee;
+      const initial = name.charAt(0);
+      const color = colors[row % colors.length];
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><rect width="24" height="24" rx="4" fill="${color}"/><text x="12" y="17" text-anchor="middle" fill="white" font-size="14" font-family="sans-serif">${initial}</text></svg>`;
+      const dataUri = `data:image/svg+xml;base64,${btoa(svg)}`;
+      cellStore.setMetadata(row, 1, { imageUrl: dataUri });
+    }
+
+    engine.requestRender();
+  }, []);
+
+  return (
+    <ScenarioContainer width={900} height={400}>
+      <Spreadsheet
+        ref={ref}
+        columns={columns}
+        data={data}
+        showRowNumbers
+        style={tableStyle}
+      />
+    </ScenarioContainer>
+  );
+}

--- a/packages/plugins/decorators/src/decorators-plugin.ts
+++ b/packages/plugins/decorators/src/decorators-plugin.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import type {
+  SpreadsheetPlugin,
+  PluginAPI,
+  CellDecoratorRegistration,
+  CellData,
+  CellEvent,
+} from '@witqq/spreadsheet';
+
+import { TreeExpanderDecorator, TREE_TOGGLE_HIT_ZONE } from './tree-expander-decorator';
+import { SortIconDecorator, SORT_HIT_ZONE } from './sort-icon-decorator';
+import { ProgressBarDecorator, type ProgressBarOptions } from './progress-bar-decorator';
+import { LinkDecorator, LINK_HIT_ZONE } from './link-decorator';
+import { ImageDecorator, type ImageDecoratorOptions } from './image-decorator';
+import { SpinnerDecorator } from './spinner-decorator';
+
+export const DECORATORS_PLUGIN_NAME = 'decorators';
+
+export interface DecoratorsPluginConfig {
+  /** Enable tree expander. Default: true */
+  treeExpander?: boolean;
+  /** Enable sort icon. Default: true */
+  sortIcon?: boolean;
+  /** Enable progress bar. Default: true */
+  progressBar?: boolean | ProgressBarOptions;
+  /** Enable link decorator. Default: true */
+  link?: boolean;
+  /** Enable image thumbnail. Default: true */
+  image?: boolean | ImageDecoratorOptions;
+  /** Enable spinner. Default: true */
+  spinner?: boolean;
+}
+
+type EventHandler = (...args: unknown[]) => void;
+
+/**
+ * Built-in decorators plugin that bundles six reusable cell decorators.
+ *
+ * Decorators:
+ * - **TreeExpander** (left): expand/collapse toggle with indentation
+ * - **SortIcon** (right): sort direction indicator
+ * - **ProgressBar** (underlay): percentage bar behind cell text
+ * - **Link** (overlay): clickable URL icon
+ * - **Image** (left): thumbnail using ImageManager
+ * - **Spinner** (overlay, animated): loading spinner
+ */
+export class DecoratorsPlugin implements SpreadsheetPlugin {
+  readonly name = DECORATORS_PLUGIN_NAME;
+  readonly version = '1.0.0';
+
+  private api: PluginAPI | null = null;
+  private registeredIds: string[] = [];
+  private clickHandler: EventHandler | null = null;
+  private config: Required<{
+    treeExpander: boolean;
+    sortIcon: boolean;
+    progressBar: boolean | ProgressBarOptions;
+    link: boolean;
+    image: boolean | ImageDecoratorOptions;
+    spinner: boolean;
+  }>;
+
+  constructor(config: DecoratorsPluginConfig = {}) {
+    this.config = {
+      treeExpander: config.treeExpander ?? true,
+      sortIcon: config.sortIcon ?? true,
+      progressBar: config.progressBar ?? true,
+      link: config.link ?? true,
+      image: config.image ?? true,
+      spinner: config.spinner ?? true,
+    };
+  }
+
+  install(api: PluginAPI): void {
+    this.api = api;
+    const registry = api.engine.getCellTypeRegistry();
+
+    if (this.config.treeExpander) {
+      const decorator = new TreeExpanderDecorator();
+      const reg: CellDecoratorRegistration = {
+        decorator,
+        appliesTo: (_row: number, _col: number, cellData: CellData) =>
+          cellData.metadata?.treeLevel != null,
+      };
+      registry.addDecorator(reg);
+      this.registeredIds.push(decorator.id);
+    }
+
+    if (this.config.sortIcon) {
+      const decorator = new SortIconDecorator();
+      const reg: CellDecoratorRegistration = {
+        decorator,
+        appliesTo: (_row: number, _col: number, cellData: CellData) =>
+          cellData.metadata?.sortDirection != null &&
+          cellData.metadata.sortDirection !== 'none',
+      };
+      registry.addDecorator(reg);
+      this.registeredIds.push(decorator.id);
+    }
+
+    if (this.config.progressBar) {
+      const options = typeof this.config.progressBar === 'object'
+        ? this.config.progressBar
+        : {};
+      const decorator = new ProgressBarDecorator(options);
+      const reg: CellDecoratorRegistration = {
+        decorator,
+        appliesTo: (_row: number, _col: number, cellData: CellData) => {
+          const progress = cellData.metadata?.progress;
+          return typeof progress === 'number' && progress > 0;
+        },
+      };
+      registry.addDecorator(reg);
+      this.registeredIds.push(decorator.id);
+    }
+
+    if (this.config.link) {
+      const decorator = new LinkDecorator();
+      const reg: CellDecoratorRegistration = {
+        decorator,
+        appliesTo: (_row: number, _col: number, cellData: CellData) => {
+          const link = cellData.metadata?.link;
+          return link != null && typeof link === 'object' && 'url' in link &&
+            typeof link.url === 'string' && link.url.length > 0;
+        },
+      };
+      registry.addDecorator(reg);
+      this.registeredIds.push(decorator.id);
+    }
+
+    if (this.config.image) {
+      const options = typeof this.config.image === 'object'
+        ? this.config.image
+        : {};
+      const decorator = new ImageDecorator(options);
+      const urlField = options.urlField ?? 'imageUrl';
+
+      // Wire ImageManager from the engine
+      const imageManager = api.engine.getImageManager();
+      decorator.setImageManager(imageManager);
+
+      const reg: CellDecoratorRegistration = {
+        decorator,
+        appliesTo: (_row: number, _col: number, cellData: CellData) => {
+          const meta = cellData.metadata;
+          if (!meta) return false;
+          const val = meta[urlField];
+          return typeof val === 'string' && val.length > 0;
+        },
+      };
+      registry.addDecorator(reg);
+      this.registeredIds.push(decorator.id);
+    }
+
+    if (this.config.spinner) {
+      const decorator = new SpinnerDecorator();
+      const reg: CellDecoratorRegistration = {
+        decorator,
+        appliesTo: (_row: number, _col: number, cellData: CellData) =>
+          cellData.metadata?.loading === true,
+        animated: true,
+      };
+      registry.addDecorator(reg);
+      this.registeredIds.push(decorator.id);
+    }
+
+    // Wire up click handlers for interactive decorators
+    this.clickHandler = (event: unknown) => {
+      const cellEvent = event as CellEvent;
+      if (!cellEvent.hitZone) return;
+
+      const eventBus = api.engine.getEventBus();
+      if (cellEvent.hitZone === TREE_TOGGLE_HIT_ZONE) {
+        eventBus.emit('treeToggle', cellEvent);
+      } else if (cellEvent.hitZone === SORT_HIT_ZONE) {
+        eventBus.emit('sortRequest', cellEvent);
+      } else if (cellEvent.hitZone === LINK_HIT_ZONE) {
+        eventBus.emit('linkClick', cellEvent);
+      }
+    };
+    api.engine.on('cellClick', this.clickHandler as never);
+
+    api.engine.requestRender();
+  }
+
+  destroy(): void {
+    if (!this.api) return;
+
+    const registry = this.api.engine.getCellTypeRegistry();
+    for (const id of this.registeredIds) {
+      registry.removeDecorator(id);
+    }
+    this.registeredIds = [];
+
+    if (this.clickHandler) {
+      this.api.engine.off('cellClick', this.clickHandler as never);
+      this.clickHandler = null;
+    }
+
+    this.api.engine.requestRender();
+    this.api = null;
+  }
+}

--- a/packages/plugins/decorators/src/image-decorator.ts
+++ b/packages/plugins/decorators/src/image-decorator.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import type {
+  CellData,
+  CellDecorator,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet';
+import type { ImageManager } from '@witqq/spreadsheet';
+
+export interface ImageDecoratorOptions {
+  /** Thumbnail size in pixels. Default: 24 */
+  size?: number;
+  /** Metadata field containing the image URL. Default: 'imageUrl' */
+  urlField?: string;
+  /** Border radius for the thumbnail. Default: 2 */
+  borderRadius?: number;
+}
+
+const DEFAULT_SIZE = 24;
+const DEFAULT_FIELD = 'imageUrl';
+const DEFAULT_RADIUS = 2;
+const PLACEHOLDER_COLOR = '#E0E0E0';
+
+/**
+ * Renders a thumbnail image using ImageManager for async loading.
+ * Image URL from cell metadata. Shows placeholder while loading.
+ */
+export class ImageDecorator implements CellDecorator {
+  readonly id = 'image-thumbnail';
+  readonly position = 'left' as const;
+
+  private readonly size: number;
+  private readonly urlField: string;
+  private readonly borderRadius: number;
+  private imageManager: ImageManager | null = null;
+
+  constructor(options: ImageDecoratorOptions = {}) {
+    this.size = options.size ?? DEFAULT_SIZE;
+    this.urlField = options.urlField ?? DEFAULT_FIELD;
+    this.borderRadius = options.borderRadius ?? DEFAULT_RADIUS;
+  }
+
+  /** Set the ImageManager instance. Called by the plugin during install. */
+  setImageManager(manager: ImageManager): void {
+    this.imageManager = manager;
+  }
+
+  getWidth(): number {
+    return this.size + 4; // 2px padding on each side
+  }
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    cellData: CellData,
+    x: number,
+    y: number,
+    _width: number,
+    height: number,
+    _theme: SpreadsheetTheme,
+  ): void {
+    const url = this.getUrl(cellData);
+    if (!url) return;
+
+    const imgY = y + (height - this.size) / 2;
+    const imgX = x + 2;
+
+    const img = this.imageManager?.getImage(url) ?? null;
+
+    if (img) {
+      ctx.save();
+      if (this.borderRadius > 0) {
+        this.clipRoundRect(ctx, imgX, imgY, this.size, this.size, this.borderRadius);
+      }
+      ctx.drawImage(img, imgX, imgY, this.size, this.size);
+      ctx.restore();
+    } else {
+      // Placeholder rectangle
+      ctx.fillStyle = PLACEHOLDER_COLOR;
+      if (this.borderRadius > 0) {
+        this.fillRoundRect(ctx, imgX, imgY, this.size, this.size, this.borderRadius);
+      } else {
+        ctx.fillRect(imgX, imgY, this.size, this.size);
+      }
+    }
+  }
+
+  private getUrl(cellData: CellData): string | undefined {
+    const meta = cellData.metadata;
+    if (!meta) return undefined;
+    const url = meta[this.urlField];
+    return typeof url === 'string' && url.length > 0 ? url : undefined;
+  }
+
+  private clipRoundRect(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    r: number,
+  ): void {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+    ctx.lineTo(x + r, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+    ctx.clip();
+  }
+
+  private fillRoundRect(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    r: number,
+  ): void {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+    ctx.lineTo(x + r, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+    ctx.fill();
+  }
+}

--- a/packages/plugins/decorators/src/index.ts
+++ b/packages/plugins/decorators/src/index.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+export { DecoratorsPlugin, DECORATORS_PLUGIN_NAME } from './decorators-plugin';
+export type { DecoratorsPluginConfig } from './decorators-plugin';
+
+export { TreeExpanderDecorator, TREE_TOGGLE_HIT_ZONE } from './tree-expander-decorator';
+export { SortIconDecorator, SORT_HIT_ZONE } from './sort-icon-decorator';
+export type { SortDirection } from './sort-icon-decorator';
+export { ProgressBarDecorator } from './progress-bar-decorator';
+export type { ProgressBarOptions } from './progress-bar-decorator';
+export { LinkDecorator, LINK_HIT_ZONE } from './link-decorator';
+export { ImageDecorator } from './image-decorator';
+export type { ImageDecoratorOptions } from './image-decorator';
+export { SpinnerDecorator } from './spinner-decorator';

--- a/packages/plugins/decorators/src/link-decorator.ts
+++ b/packages/plugins/decorators/src/link-decorator.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import type {
+  CellData,
+  CellDecorator,
+  HitZone,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet';
+
+const ICON_SIZE = 14;
+const LINK_COLOR = '#1976D2';
+
+export const LINK_HIT_ZONE = 'link-open';
+
+/**
+ * Renders a link icon for cells with `metadata.link`. Clicking the hit zone
+ * opens the URL. Cursor changes to pointer on hover.
+ */
+export class LinkDecorator implements CellDecorator {
+  readonly id = 'link';
+  readonly position = 'overlay' as const;
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    cellData: CellData,
+    x: number,
+    y: number,
+    width: number,
+    _height: number,
+    _theme: SpreadsheetTheme,
+  ): void {
+    const link = this.getLink(cellData);
+    if (!link) return;
+
+    // Draw a small link icon at top-right corner
+    const iconX = x + width - ICON_SIZE - 2;
+    const iconY = y + 2;
+    const iconSize = ICON_SIZE - 2;
+
+    ctx.strokeStyle = LINK_COLOR;
+    ctx.lineWidth = 1.5;
+    ctx.lineCap = 'round';
+
+    // Simplified external link icon: box with arrow
+    const bx = iconX + 1;
+    const by = iconY + 3;
+    const bs = iconSize - 4;
+
+    // Box (bottom-left part)
+    ctx.beginPath();
+    ctx.moveTo(bx + bs * 0.4, by);
+    ctx.lineTo(bx, by);
+    ctx.lineTo(bx, by + bs);
+    ctx.lineTo(bx + bs, by + bs);
+    ctx.lineTo(bx + bs, by + bs * 0.6);
+    ctx.stroke();
+
+    // Arrow (top-right)
+    ctx.beginPath();
+    ctx.moveTo(bx + bs * 0.5, by + bs * 0.5);
+    ctx.lineTo(bx + bs, by);
+    ctx.stroke();
+
+    // Arrow head
+    ctx.beginPath();
+    ctx.moveTo(bx + bs * 0.65, by);
+    ctx.lineTo(bx + bs, by);
+    ctx.lineTo(bx + bs, by + bs * 0.35);
+    ctx.stroke();
+  }
+
+  getHitZones(
+    width: number,
+    _height: number,
+    cellData: CellData,
+  ): HitZone[] {
+    const link = this.getLink(cellData);
+    if (!link) return [];
+
+    return [
+      {
+        id: LINK_HIT_ZONE,
+        x: width - ICON_SIZE - 2,
+        y: 0,
+        width: ICON_SIZE + 2,
+        height: ICON_SIZE + 2,
+        cursor: 'pointer',
+        padding: 3,
+      },
+    ];
+  }
+
+  private getLink(cellData: CellData): string | undefined {
+    const link = cellData.metadata?.link;
+    if (link && typeof link === 'object' && 'url' in link) {
+      return typeof link.url === 'string' && link.url.length > 0 ? link.url : undefined;
+    }
+    return undefined;
+  }
+}

--- a/packages/plugins/decorators/src/progress-bar-decorator.ts
+++ b/packages/plugins/decorators/src/progress-bar-decorator.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import type {
+  CellData,
+  CellDecorator,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet';
+
+export interface ProgressBarOptions {
+  /** Bar color. Default: theme accent or '#4CAF50' */
+  color?: string;
+  /** Bar height in pixels. Default: 4 */
+  height?: number;
+  /** Corner radius. Default: 2 */
+  borderRadius?: number;
+  /** Vertical position. Default: 'bottom' */
+  position?: 'top' | 'center' | 'bottom';
+}
+
+const DEFAULT_COLOR = '#4CAF50';
+const DEFAULT_HEIGHT = 4;
+const DEFAULT_RADIUS = 2;
+const INSET = 2;
+
+/**
+ * Renders a colored bar behind cell text showing progress percentage.
+ * Value comes from cell data (0-100 numeric or 0.0-1.0 fraction).
+ */
+export class ProgressBarDecorator implements CellDecorator {
+  readonly id = 'progress-bar';
+  readonly position = 'underlay' as const;
+
+  constructor(private readonly options: ProgressBarOptions = {}) {}
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    cellData: CellData,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    _theme: SpreadsheetTheme,
+  ): void {
+    const progress = this.getProgress(cellData);
+    if (progress <= 0) return;
+
+    const barHeight = this.options.height ?? DEFAULT_HEIGHT;
+    const radius = this.options.borderRadius ?? DEFAULT_RADIUS;
+    const color = this.options.color ?? DEFAULT_COLOR;
+    const pos = this.options.position ?? 'bottom';
+
+    let barY: number;
+    if (pos === 'top') {
+      barY = y + INSET;
+    } else if (pos === 'center') {
+      barY = y + (height - barHeight) / 2;
+    } else {
+      barY = y + height - barHeight - INSET;
+    }
+
+    const barX = x + INSET;
+    const maxBarWidth = width - INSET * 2;
+    const barWidth = maxBarWidth * Math.min(progress, 1);
+
+    ctx.fillStyle = color;
+    ctx.globalAlpha = 0.3;
+
+    if (radius > 0) {
+      this.roundRect(ctx, barX, barY, barWidth, barHeight, radius);
+      ctx.fill();
+    } else {
+      ctx.fillRect(barX, barY, barWidth, barHeight);
+    }
+
+    ctx.globalAlpha = 1;
+  }
+
+  private getProgress(cellData: CellData): number {
+    const raw = cellData.metadata?.progress as number | undefined;
+    if (raw == null || typeof raw !== 'number' || isNaN(raw)) return 0;
+    // Support both 0-100 and 0-1 ranges
+    return raw > 1 ? raw / 100 : raw;
+  }
+
+  private roundRect(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    r: number,
+  ): void {
+    const radius = Math.min(r, w / 2, h / 2);
+    ctx.beginPath();
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + w - radius, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+    ctx.lineTo(x + w, y + h - radius);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+    ctx.lineTo(x + radius, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
+    ctx.lineTo(x, y + radius);
+    ctx.quadraticCurveTo(x, y, x + radius, y);
+    ctx.closePath();
+  }
+}

--- a/packages/plugins/decorators/src/sort-icon-decorator.ts
+++ b/packages/plugins/decorators/src/sort-icon-decorator.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import type {
+  CellData,
+  CellDecorator,
+  HitZone,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet';
+
+const ICON_WIDTH = 14;
+const ARROW_SIZE = 5;
+
+export const SORT_HIT_ZONE = 'sort-request';
+
+export type SortDirection = 'asc' | 'desc' | 'none';
+
+/**
+ * Renders a sort direction arrow (ascending/descending/none) based on
+ * `metadata.sortDirection`. Provides a HitZone for click-to-sort interaction.
+ */
+export class SortIconDecorator implements CellDecorator {
+  readonly id = 'sort-icon';
+  readonly position = 'right' as const;
+
+  getWidth(): number {
+    return ICON_WIDTH;
+  }
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    cellData: CellData,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    theme: SpreadsheetTheme,
+  ): void {
+    const direction = this.getDirection(cellData);
+    if (direction === 'none') return;
+
+    const centerX = x + width / 2;
+    const centerY = y + height / 2;
+
+    ctx.fillStyle = theme.colors.cellText;
+    ctx.globalAlpha = 0.6;
+    ctx.beginPath();
+
+    if (direction === 'asc') {
+      // Up arrow (▲)
+      ctx.moveTo(centerX, centerY - ARROW_SIZE);
+      ctx.lineTo(centerX + ARROW_SIZE, centerY + ARROW_SIZE);
+      ctx.lineTo(centerX - ARROW_SIZE, centerY + ARROW_SIZE);
+    } else {
+      // Down arrow (▼)
+      ctx.moveTo(centerX - ARROW_SIZE, centerY - ARROW_SIZE);
+      ctx.lineTo(centerX + ARROW_SIZE, centerY - ARROW_SIZE);
+      ctx.lineTo(centerX, centerY + ARROW_SIZE);
+    }
+
+    ctx.closePath();
+    ctx.fill();
+    ctx.globalAlpha = 1;
+  }
+
+  getHitZones(
+    width: number,
+    height: number,
+  ): HitZone[] {
+    return [
+      {
+        id: SORT_HIT_ZONE,
+        x: 0,
+        y: 0,
+        width,
+        height,
+        cursor: 'pointer',
+        padding: 2,
+      },
+    ];
+  }
+
+  private getDirection(cellData: CellData): SortDirection {
+    return (cellData.metadata?.sortDirection as SortDirection) ?? 'none';
+  }
+}

--- a/packages/plugins/decorators/src/spinner-decorator.ts
+++ b/packages/plugins/decorators/src/spinner-decorator.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import type {
+  CellData,
+  CellDecorator,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet';
+
+const SPINNER_RADIUS = 6;
+const SPINNER_LINE_WIDTH = 2;
+const ARC_LENGTH = Math.PI * 1.4;
+const ROTATION_SPEED = 0.003; // radians per ms
+
+/**
+ * Renders a spinning loading indicator for cells with `metadata.loading === true`.
+ * Demonstrates animation support via the `timestamp` parameter from Step 10.
+ */
+export class SpinnerDecorator implements CellDecorator {
+  readonly id = 'spinner';
+  readonly position = 'overlay' as const;
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    _cellData: CellData,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    theme: SpreadsheetTheme,
+    _row?: number,
+    _col?: number,
+    timestamp?: number,
+  ): void {
+    const centerX = x + width - SPINNER_RADIUS - 4;
+    const centerY = y + height / 2;
+    const rotation = ((timestamp ?? 0) * ROTATION_SPEED) % (Math.PI * 2);
+
+    ctx.strokeStyle = theme.colors.cellText;
+    ctx.lineWidth = SPINNER_LINE_WIDTH;
+    ctx.lineCap = 'round';
+    ctx.globalAlpha = 0.7;
+
+    ctx.beginPath();
+    ctx.arc(
+      centerX,
+      centerY,
+      SPINNER_RADIUS,
+      rotation,
+      rotation + ARC_LENGTH,
+    );
+    ctx.stroke();
+
+    ctx.globalAlpha = 1;
+  }
+}

--- a/packages/plugins/decorators/src/tree-expander-decorator.ts
+++ b/packages/plugins/decorators/src/tree-expander-decorator.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import type {
+  CellData,
+  CellDecorator,
+  HitZone,
+  SpreadsheetTheme,
+} from '@witqq/spreadsheet';
+
+const ICON_SIZE = 10;
+const INDENT_PER_LEVEL = 16;
+const HIT_ZONE_PADDING = 4;
+
+export const TREE_TOGGLE_HIT_ZONE = 'tree-toggle';
+
+/**
+ * Renders an expand/collapse triangle icon with indentation based on a `treeLevel`
+ * property in cell metadata. Uses HitZone with padding for easy clicking.
+ */
+export class TreeExpanderDecorator implements CellDecorator {
+  readonly id = 'tree-expander';
+  readonly position = 'left' as const;
+
+  getWidth(
+    cellData: CellData,
+    _cellHeight: number,
+    _ctx?: CanvasRenderingContext2D,
+    _theme?: SpreadsheetTheme,
+  ): number {
+    const level = this.getLevel(cellData);
+    return level * INDENT_PER_LEVEL + ICON_SIZE + HIT_ZONE_PADDING;
+  }
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    cellData: CellData,
+    x: number,
+    y: number,
+    _width: number,
+    height: number,
+    theme: SpreadsheetTheme,
+  ): void {
+    const level = this.getLevel(cellData);
+    const expanded = this.isExpanded(cellData);
+    const indent = level * INDENT_PER_LEVEL;
+    const centerX = x + indent + ICON_SIZE / 2;
+    const centerY = y + height / 2;
+
+    ctx.fillStyle = theme.colors.cellText;
+    ctx.beginPath();
+
+    if (expanded) {
+      // Downward triangle (▼)
+      ctx.moveTo(centerX - ICON_SIZE / 2, centerY - ICON_SIZE / 4);
+      ctx.lineTo(centerX + ICON_SIZE / 2, centerY - ICON_SIZE / 4);
+      ctx.lineTo(centerX, centerY + ICON_SIZE / 4);
+    } else {
+      // Right triangle (▶)
+      ctx.moveTo(centerX - ICON_SIZE / 4, centerY - ICON_SIZE / 2);
+      ctx.lineTo(centerX + ICON_SIZE / 4, centerY);
+      ctx.lineTo(centerX - ICON_SIZE / 4, centerY + ICON_SIZE / 2);
+    }
+
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  getHitZones(
+    _width: number,
+    height: number,
+    cellData: CellData,
+  ): HitZone[] {
+    const level = this.getLevel(cellData);
+    const indent = level * INDENT_PER_LEVEL;
+    return [
+      {
+        id: TREE_TOGGLE_HIT_ZONE,
+        x: indent,
+        y: (height - ICON_SIZE) / 2,
+        width: ICON_SIZE,
+        height: ICON_SIZE,
+        cursor: 'pointer',
+        padding: HIT_ZONE_PADDING,
+      },
+    ];
+  }
+
+  private getLevel(cellData: CellData): number {
+    return (cellData.metadata?.treeLevel as number) ?? 0;
+  }
+
+  private isExpanded(cellData: CellData): boolean {
+    return (cellData.metadata?.treeExpanded as boolean) ?? false;
+  }
+}

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -50,3 +50,22 @@ export {
   PROGRESSIVE_LOADER_PLUGIN_NAME,
 } from '../progressive-loader/src/index';
 export type { ProgressiveLoaderConfig } from '../progressive-loader/src/index';
+export {
+  DecoratorsPlugin,
+  DECORATORS_PLUGIN_NAME,
+  TreeExpanderDecorator,
+  TREE_TOGGLE_HIT_ZONE,
+  SortIconDecorator,
+  SORT_HIT_ZONE,
+  ProgressBarDecorator,
+  LinkDecorator,
+  LINK_HIT_ZONE,
+  ImageDecorator,
+  SpinnerDecorator,
+} from '../decorators/src/index';
+export type {
+  DecoratorsPluginConfig,
+  SortDirection,
+  ProgressBarOptions,
+  ImageDecoratorOptions,
+} from '../decorators/src/index';

--- a/packages/plugins/tests/decorators-plugin.test.ts
+++ b/packages/plugins/tests/decorators-plugin.test.ts
@@ -1,0 +1,565 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 witqq contributors
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TreeExpanderDecorator, TREE_TOGGLE_HIT_ZONE } from '../decorators/src/tree-expander-decorator';
+import { SortIconDecorator, SORT_HIT_ZONE } from '../decorators/src/sort-icon-decorator';
+import { ProgressBarDecorator } from '../decorators/src/progress-bar-decorator';
+import { LinkDecorator, LINK_HIT_ZONE } from '../decorators/src/link-decorator';
+import { ImageDecorator } from '../decorators/src/image-decorator';
+import { SpinnerDecorator } from '../decorators/src/spinner-decorator';
+import { DecoratorsPlugin, DECORATORS_PLUGIN_NAME } from '../decorators/src/decorators-plugin';
+import type { CellData, SpreadsheetTheme, ImageManager } from '@witqq/spreadsheet';
+
+// --- Helpers ---
+
+function makeTheme(overrides: Partial<SpreadsheetTheme['colors']> = {}): SpreadsheetTheme {
+  return {
+    name: 'test',
+    colors: {
+      gridLine: '#ccc',
+      background: '#fff',
+      headerBackground: '#f5f5f5',
+      headerText: '#333',
+      headerBorder: '#ddd',
+      selectionFill: 'rgba(0,0,255,0.1)',
+      selectionBorder: '#0000ff',
+      activeCellBorder: '#000',
+      fillHandle: '#000',
+      cellText: '#333333',
+      cellBorder: '#e0e0e0',
+      cellEditBackground: '#fff',
+      alternateRowBackground: '#fafafa',
+      hoverRowBackground: '#f0f0f0',
+      frozenSeparator: '#999',
+      scrollbarTrack: '#f0f0f0',
+      scrollbarThumb: '#ccc',
+      scrollbarThumbHover: '#aaa',
+      errorBackground: '#fdd',
+      warningBackground: '#ffd',
+      changedIndicator: '#2196F3',
+      savedIndicator: '#4CAF50',
+      cellPlaceholder: '#999',
+      ...overrides,
+    },
+    fonts: { cell: 'Arial', header: 'Arial', cellSize: 13, headerSize: 13 },
+    dimensions: {
+      rowHeight: 28, headerHeight: 32, minColumnWidth: 50,
+      scrollbarWidth: 14, cellPadding: 6, borderWidth: 1, rowNumberWidth: 50,
+    },
+    borders: { gridLineWidth: 1, selectionWidth: 2, activeCellWidth: 2, frozenPaneWidth: 2 },
+  };
+}
+
+function makeCellData(metadata?: Record<string, unknown>): CellData {
+  return { value: 'test', metadata: metadata as CellData['metadata'] };
+}
+
+function makeCtx(): CanvasRenderingContext2D {
+  return {
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    lineCap: 'butt',
+    globalAlpha: 1,
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    fillRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    clip: vi.fn(),
+    drawImage: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+const theme = makeTheme();
+
+// ===================================================================
+// TreeExpanderDecorator
+// ===================================================================
+describe('TreeExpanderDecorator', () => {
+  let dec: TreeExpanderDecorator;
+  let ctx: CanvasRenderingContext2D;
+
+  beforeEach(() => {
+    dec = new TreeExpanderDecorator();
+    ctx = makeCtx();
+  });
+
+  it('has correct id and position', () => {
+    expect(dec.id).toBe('tree-expander');
+    expect(dec.position).toBe('left');
+  });
+
+  it('getWidth increases with tree level', () => {
+    const w0 = dec.getWidth!(makeCellData({ treeLevel: 0 }), 28);
+    const w2 = dec.getWidth!(makeCellData({ treeLevel: 2 }), 28);
+    expect(w2).toBeGreaterThan(w0);
+  });
+
+  it('getWidth returns base size for no metadata', () => {
+    const w = dec.getWidth!(makeCellData(), 28);
+    expect(w).toBeGreaterThan(0);
+  });
+
+  it('renders collapsed triangle (right-pointing)', () => {
+    dec.render(ctx, makeCellData({ treeLevel: 1, treeExpanded: false }), 0, 0, 100, 28, theme);
+    expect(ctx.beginPath).toHaveBeenCalled();
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it('renders expanded triangle (down-pointing)', () => {
+    dec.render(ctx, makeCellData({ treeLevel: 1, treeExpanded: true }), 0, 0, 100, 28, theme);
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it('provides hit zone with correct id', () => {
+    const zones = dec.getHitZones!(100, 28, makeCellData({ treeLevel: 1 }));
+    expect(zones).toHaveLength(1);
+    expect(zones[0].id).toBe(TREE_TOGGLE_HIT_ZONE);
+    expect(zones[0].cursor).toBe('pointer');
+    expect(zones[0].padding).toBeGreaterThan(0);
+  });
+
+  it('hit zone x offset increases with level', () => {
+    const z0 = dec.getHitZones!(100, 28, makeCellData({ treeLevel: 0 }));
+    const z2 = dec.getHitZones!(100, 28, makeCellData({ treeLevel: 2 }));
+    expect(z2[0].x).toBeGreaterThan(z0[0].x);
+  });
+});
+
+// ===================================================================
+// SortIconDecorator
+// ===================================================================
+describe('SortIconDecorator', () => {
+  let dec: SortIconDecorator;
+  let ctx: CanvasRenderingContext2D;
+
+  beforeEach(() => {
+    dec = new SortIconDecorator();
+    ctx = makeCtx();
+  });
+
+  it('has correct id and position', () => {
+    expect(dec.id).toBe('sort-icon');
+    expect(dec.position).toBe('right');
+  });
+
+  it('getWidth returns fixed size', () => {
+    expect(dec.getWidth!()).toBe(14);
+  });
+
+  it('renders ascending arrow', () => {
+    dec.render(ctx, makeCellData({ sortDirection: 'asc' }), 0, 0, 14, 28, theme);
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it('renders descending arrow', () => {
+    dec.render(ctx, makeCellData({ sortDirection: 'desc' }), 0, 0, 14, 28, theme);
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it('does not render when direction is none', () => {
+    dec.render(ctx, makeCellData({ sortDirection: 'none' }), 0, 0, 14, 28, theme);
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it('provides hit zone', () => {
+    const zones = dec.getHitZones!(14, 28);
+    expect(zones).toHaveLength(1);
+    expect(zones[0].id).toBe(SORT_HIT_ZONE);
+    expect(zones[0].cursor).toBe('pointer');
+  });
+});
+
+// ===================================================================
+// ProgressBarDecorator
+// ===================================================================
+describe('ProgressBarDecorator', () => {
+  let ctx: CanvasRenderingContext2D;
+
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+
+  it('has correct id and position', () => {
+    const dec = new ProgressBarDecorator();
+    expect(dec.id).toBe('progress-bar');
+    expect(dec.position).toBe('underlay');
+  });
+
+  it('renders bar for fractional progress (0-1)', () => {
+    const dec = new ProgressBarDecorator();
+    dec.render(ctx, makeCellData({ progress: 0.5 }), 0, 0, 100, 28, theme);
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it('renders bar for percentage progress (0-100)', () => {
+    const dec = new ProgressBarDecorator();
+    dec.render(ctx, makeCellData({ progress: 75 }), 0, 0, 100, 28, theme);
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it('does not render when progress is 0', () => {
+    const dec = new ProgressBarDecorator();
+    dec.render(ctx, makeCellData({ progress: 0 }), 0, 0, 100, 28, theme);
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it('does not render when progress is missing', () => {
+    const dec = new ProgressBarDecorator();
+    dec.render(ctx, makeCellData(), 0, 0, 100, 28, theme);
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it('respects custom color option', () => {
+    const dec = new ProgressBarDecorator({ color: '#FF0000' });
+    dec.render(ctx, makeCellData({ progress: 0.5 }), 0, 0, 100, 28, theme);
+    expect(ctx.fillStyle).toBe('#FF0000');
+  });
+
+  it('caps progress at 100%', () => {
+    const dec = new ProgressBarDecorator({ borderRadius: 0 });
+    dec.render(ctx, makeCellData({ progress: 200 }), 0, 0, 100, 28, theme);
+    // fillRect should use capped bar width (not exceed cell width)
+    expect(ctx.fillRect).toHaveBeenCalled();
+    const callArgs = (ctx.fillRect as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs[2]).toBeLessThanOrEqual(100); // bar width <= cell width
+  });
+});
+
+// ===================================================================
+// LinkDecorator
+// ===================================================================
+describe('LinkDecorator', () => {
+  let dec: LinkDecorator;
+  let ctx: CanvasRenderingContext2D;
+
+  beforeEach(() => {
+    dec = new LinkDecorator();
+    ctx = makeCtx();
+  });
+
+  it('has correct id and position', () => {
+    expect(dec.id).toBe('link');
+    expect(dec.position).toBe('overlay');
+  });
+
+  it('renders link icon when metadata.link exists', () => {
+    dec.render(ctx, makeCellData({ link: { url: 'https://example.com' } }), 0, 0, 100, 28, theme);
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it('does not render when no link', () => {
+    dec.render(ctx, makeCellData(), 0, 0, 100, 28, theme);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it('provides hit zone when link exists', () => {
+    const zones = dec.getHitZones!(100, 28, makeCellData({ link: { url: 'https://example.com' } }));
+    expect(zones).toHaveLength(1);
+    expect(zones[0].id).toBe(LINK_HIT_ZONE);
+    expect(zones[0].cursor).toBe('pointer');
+  });
+
+  it('returns empty hit zones when no link', () => {
+    const zones = dec.getHitZones!(100, 28, makeCellData());
+    expect(zones).toHaveLength(0);
+  });
+});
+
+// ===================================================================
+// ImageDecorator
+// ===================================================================
+describe('ImageDecorator', () => {
+  let dec: ImageDecorator;
+  let ctx: CanvasRenderingContext2D;
+  let mockImageManager: ImageManager;
+
+  beforeEach(() => {
+    dec = new ImageDecorator();
+    ctx = makeCtx();
+    mockImageManager = {
+      getImage: vi.fn().mockReturnValue(null),
+      preload: vi.fn(),
+      has: vi.fn(),
+      evict: vi.fn(),
+      clear: vi.fn(),
+      get size() { return 0; },
+    } as unknown as ImageManager;
+    dec.setImageManager(mockImageManager);
+  });
+
+  it('has correct id and position', () => {
+    expect(dec.id).toBe('image-thumbnail');
+    expect(dec.position).toBe('left');
+  });
+
+  it('getWidth returns size + padding', () => {
+    expect(dec.getWidth!()).toBe(28); // 24 default + 4 padding
+  });
+
+  it('renders placeholder when image not loaded', () => {
+    dec.render(ctx, makeCellData({ imageUrl: 'http://img.png' }), 0, 0, 28, 28, theme);
+    expect(mockImageManager.getImage).toHaveBeenCalledWith('http://img.png');
+    // Placeholder renders fillRect or roundRect → fill
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it('renders image when loaded', () => {
+    const fakeImg = {} as HTMLImageElement;
+    (mockImageManager.getImage as ReturnType<typeof vi.fn>).mockReturnValue(fakeImg);
+
+    dec.render(ctx, makeCellData({ imageUrl: 'http://img.png' }), 0, 0, 28, 28, theme);
+    expect(ctx.drawImage).toHaveBeenCalledWith(fakeImg, expect.any(Number), expect.any(Number), 24, 24);
+  });
+
+  it('does not render when no imageUrl', () => {
+    dec.render(ctx, makeCellData(), 0, 0, 28, 28, theme);
+    expect(mockImageManager.getImage).not.toHaveBeenCalled();
+  });
+
+  it('respects custom urlField option', () => {
+    const customDec = new ImageDecorator({ urlField: 'thumb' });
+    customDec.setImageManager(mockImageManager);
+    customDec.render(ctx, makeCellData({ thumb: 'http://thumb.png' }), 0, 0, 28, 28, theme);
+    expect(mockImageManager.getImage).toHaveBeenCalledWith('http://thumb.png');
+  });
+
+  it('respects custom size option', () => {
+    const customDec = new ImageDecorator({ size: 32 });
+    expect(customDec.getWidth!()).toBe(36); // 32 + 4
+  });
+});
+
+// ===================================================================
+// SpinnerDecorator
+// ===================================================================
+describe('SpinnerDecorator', () => {
+  let dec: SpinnerDecorator;
+  let ctx: CanvasRenderingContext2D;
+
+  beforeEach(() => {
+    dec = new SpinnerDecorator();
+    ctx = makeCtx();
+  });
+
+  it('has correct id and position', () => {
+    expect(dec.id).toBe('spinner');
+    expect(dec.position).toBe('overlay');
+  });
+
+  it('renders arc at given timestamp', () => {
+    dec.render(ctx, makeCellData({ loading: true }), 0, 0, 100, 28, theme, 0, 0, 1000);
+    expect(ctx.arc).toHaveBeenCalled();
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it('renders at different rotation for different timestamps', () => {
+    dec.render(ctx, makeCellData({ loading: true }), 0, 0, 100, 28, theme, 0, 0, 0);
+    const call1 = (ctx.arc as ReturnType<typeof vi.fn>).mock.calls[0];
+
+    (ctx.arc as ReturnType<typeof vi.fn>).mockClear();
+    dec.render(ctx, makeCellData({ loading: true }), 0, 0, 100, 28, theme, 0, 0, 5000);
+    const call2 = (ctx.arc as ReturnType<typeof vi.fn>).mock.calls[0];
+
+    // Start angle should differ for different timestamps
+    expect(call1[3]).not.toBe(call2[3]);
+  });
+
+  it('uses theme text color for stroke', () => {
+    const customTheme = makeTheme({ cellText: '#FF0000' });
+    dec.render(ctx, makeCellData({ loading: true }), 0, 0, 100, 28, customTheme, 0, 0, 0);
+    expect(ctx.strokeStyle).toBe('#FF0000');
+  });
+});
+
+// ===================================================================
+// DecoratorsPlugin — lifecycle
+// ===================================================================
+describe('DecoratorsPlugin', () => {
+  function makeMockEngine() {
+    const decorators = new Map<string, unknown>();
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+    const addDecorator = vi.fn((reg: { decorator: { id: string } }) => {
+      decorators.set(reg.decorator.id, reg);
+    });
+    const removeDecorator = vi.fn((id: string) => {
+      decorators.delete(id);
+    });
+    const registry = { addDecorator, removeDecorator };
+
+    const imageManager = {
+      getImage: vi.fn().mockReturnValue(null),
+      preload: vi.fn(),
+      has: vi.fn(),
+      evict: vi.fn(),
+      clear: vi.fn(),
+      get size() { return 0; },
+    };
+
+    const eventBusEmit = vi.fn();
+    const eventBus = { emit: eventBusEmit };
+
+    return {
+      getCellTypeRegistry: vi.fn(() => registry),
+      getImageManager: vi.fn(() => imageManager),
+      getEventBus: vi.fn(() => eventBus),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        let set = listeners.get(event);
+        if (!set) { set = new Set(); listeners.set(event, set); }
+        set.add(handler);
+      }),
+      off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        listeners.get(event)?.delete(handler);
+      }),
+      requestRender: vi.fn(),
+      decorators,
+      listeners,
+      registry,
+      eventBus,
+    };
+  }
+
+  function makeMockApi(engine: ReturnType<typeof makeMockEngine>) {
+    return {
+      engine: engine as unknown as import('@witqq/spreadsheet').SpreadsheetEngine,
+      getPluginState: vi.fn(),
+      setPluginState: vi.fn(),
+    };
+  }
+
+  it('has correct name and version', () => {
+    const plugin = new DecoratorsPlugin();
+    expect(plugin.name).toBe(DECORATORS_PLUGIN_NAME);
+    expect(plugin.version).toBe('1.0.0');
+  });
+
+  it('registers all 6 decorators by default', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    expect(engine.registry.addDecorator).toHaveBeenCalledTimes(6);
+    expect(engine.decorators.size).toBe(6);
+  });
+
+  it('registers click handler on cellClick', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    expect(engine.on).toHaveBeenCalledWith('cellClick', expect.any(Function));
+    expect(engine.listeners.get('cellClick')?.size).toBe(1);
+  });
+
+  it('destroy removes all decorators and click handler', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    plugin.destroy!();
+
+    expect(engine.registry.removeDecorator).toHaveBeenCalledTimes(6);
+    expect(engine.off).toHaveBeenCalledWith('cellClick', expect.any(Function));
+    expect(engine.requestRender).toHaveBeenCalledTimes(2); // install + destroy
+  });
+
+  it('can disable specific decorators via config', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin({
+      treeExpander: false,
+      sortIcon: false,
+      progressBar: false,
+    });
+    plugin.install(api);
+
+    // Only link + image + spinner = 3
+    expect(engine.registry.addDecorator).toHaveBeenCalledTimes(3);
+  });
+
+  it('click handler emits treeToggle event for tree hit zone', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    const clickHandlers = engine.listeners.get('cellClick')!;
+    const handler = [...clickHandlers][0];
+
+    handler({ row: 0, col: 0, hitZone: TREE_TOGGLE_HIT_ZONE });
+    expect(engine.eventBus.emit).toHaveBeenCalledWith('treeToggle', expect.objectContaining({ hitZone: TREE_TOGGLE_HIT_ZONE }));
+  });
+
+  it('click handler emits sortRequest for sort hit zone', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    const clickHandlers = engine.listeners.get('cellClick')!;
+    const handler = [...clickHandlers][0];
+
+    handler({ row: 0, col: 1, hitZone: SORT_HIT_ZONE });
+    expect(engine.eventBus.emit).toHaveBeenCalledWith('sortRequest', expect.objectContaining({ hitZone: SORT_HIT_ZONE }));
+  });
+
+  it('click handler emits linkClick for link hit zone', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    const clickHandlers = engine.listeners.get('cellClick')!;
+    const handler = [...clickHandlers][0];
+
+    handler({ row: 0, col: 2, hitZone: LINK_HIT_ZONE });
+    expect(engine.eventBus.emit).toHaveBeenCalledWith('linkClick', expect.objectContaining({ hitZone: LINK_HIT_ZONE }));
+  });
+
+  it('click handler ignores non-decorator hit zones', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    const clickHandlers = engine.listeners.get('cellClick')!;
+    const handler = [...clickHandlers][0];
+
+    handler({ row: 0, col: 0, hitZone: 'unknown-zone' });
+    expect(engine.eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it('spinner is registered as animated', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    const spinnerCall = (engine.registry.addDecorator as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: [{ decorator: { id: string }; animated?: boolean }]) => c[0].decorator.id === 'spinner'
+    );
+    expect(spinnerCall).toBeDefined();
+    expect(spinnerCall![0].animated).toBe(true);
+  });
+
+  it('image decorator wires ImageManager', () => {
+    const engine = makeMockEngine();
+    const api = makeMockApi(engine);
+    const plugin = new DecoratorsPlugin();
+    plugin.install(api);
+
+    expect(engine.getImageManager).toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -6,7 +6,7 @@
     "composite": true,
     "emitDeclarationOnly": true
   },
-  "include": ["src", "formula/src", "context-menu/src", "conditional-format/src", "excel/src", "progressive-loader/src"],
+  "include": ["src", "formula/src", "context-menu/src", "conditional-format/src", "excel/src", "progressive-loader/src", "decorators/src"],
   "references": [
     { "path": "../core" }
   ]

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,8 +13,8 @@ npm install @witqq/spreadsheet-react
 
 **Peer dependencies:**
 
-- `react` ^18.0.0 || ^19.0.0
-- `react-dom` ^18.0.0 || ^19.0.0
+- `react` ^17.0.0 || ^18.0.0 || ^19.0.0
+- `react-dom` ^17.0.0 || ^18.0.0 || ^19.0.0
 
 Requires [`@witqq/spreadsheet`](https://www.npmjs.com/package/@witqq/spreadsheet) (installed automatically).
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,8 +31,8 @@
     "@witqq/spreadsheet": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/packages/react/src/components/Spreadsheet.tsx
+++ b/packages/react/src/components/Spreadsheet.tsx
@@ -270,11 +270,7 @@ function SpreadsheetInner<TRow extends Record<string, unknown> = Record<string, 
   useEffect(() => {
     if (!containerRef.current) return;
 
-    const {
-      className: _cls,
-      style: _style,
-      ...configWithCallbacks
-    } = props;
+    const { className: _cls, style: _style, ...configWithCallbacks } = props;
 
     // Strip all callback props from engine config
     const config: Record<string, unknown> = {};
@@ -321,18 +317,14 @@ function SpreadsheetInner<TRow extends Record<string, unknown> = Record<string, 
     }
   }, [props.theme]);
 
-  // Prop update: data (clear + reload)
+  // Prop update: data (atomic replacement via setData)
   useEffect(() => {
     const engine = engineRef.current;
     if (!engine) return;
     const data = props.data;
     if (data === undefined) return;
 
-    const columnKeys = props.columns.map((c) => c.key);
-    engine.getCellStore().clear();
-    engine.getCellStore().bulkLoad(data, columnKeys);
-    engine.setRowCount(data.length);
-    engine.requestRender();
+    engine.setData(data);
   }, [props.data]);
 
   return (

--- a/packages/react/tests/react17-compat.test.tsx
+++ b/packages/react/tests/react17-compat.test.tsx
@@ -1,0 +1,325 @@
+// @vitest-environment jsdom
+/**
+ * React 17 compatibility tests.
+ *
+ * Verifies that the React wrapper uses only APIs available in React 17.0.0+
+ * and that the build output contains no React 18/19-specific imports.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { createRef, useState, useCallback } from 'react';
+import { Spreadsheet } from '../src/components/Spreadsheet';
+import type { SpreadsheetRef } from '../src/components/Spreadsheet';
+import { lightTheme, darkTheme } from '@witqq/spreadsheet';
+import type { ColumnDef, SpreadsheetPlugin } from '@witqq/spreadsheet';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function createMockCtx(): CanvasRenderingContext2D {
+  return {
+    setTransform: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    clearRect: vi.fn(),
+    measureText: vi.fn().mockReturnValue({ width: 40 }),
+    canvas: {} as HTMLCanvasElement,
+    font: '',
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
+    globalAlpha: 1,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('React 17 compatibility', () => {
+  let origGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+  const columns: ColumnDef[] = [
+    { key: 'name', title: 'Name', width: 120 },
+    { key: 'value', title: 'Value', width: 100, type: 'number' as const },
+  ];
+
+  const data = [
+    { name: 'Row1', value: 10 },
+    { name: 'Row2', value: 20 },
+    { name: 'Row3', value: 30 },
+  ];
+
+  beforeEach(() => {
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    })) as unknown as typeof ResizeObserver;
+
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(createMockCtx()) as any;
+
+    Element.prototype.getBoundingClientRect = vi.fn().mockReturnValue({
+      width: 800, height: 600, top: 0, left: 0, right: 800, bottom: 600, x: 0, y: 0,
+      toJSON: () => {},
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+  });
+
+  // ─── Build output analysis ────────────────────────────────
+
+  describe('build output contains no React 18+ APIs', () => {
+    const react18OnlyAPIs = [
+      'useId',
+      'useSyncExternalStore',
+      'useTransition',
+      'useDeferredValue',
+      'useInsertionEffect',
+      'createRoot',
+      'hydrateRoot',
+    ];
+
+    it('source files do not import React 18+ hooks', () => {
+      const srcDir = path.resolve(__dirname, '..', 'src');
+      const files = getAllTsFiles(srcDir);
+
+      for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+        for (const api of react18OnlyAPIs) {
+          expect(content).not.toContain(api);
+        }
+      }
+    });
+
+    it('dist output does not reference React 18+ APIs', () => {
+      const distDir = path.resolve(__dirname, '..', 'dist');
+      if (!fs.existsSync(distDir)) return; // skip if not built
+
+      const files = getAllFiles(distDir).filter(
+        (f) => f.endsWith('.js') || f.endsWith('.cjs') || f.endsWith('.mjs'),
+      );
+
+      for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+        for (const api of react18OnlyAPIs) {
+          expect(content).not.toContain(api);
+        }
+      }
+    });
+  });
+
+  // ─── Core functionality under React 17-compatible patterns ─
+
+  describe('component mounting and lifecycle', () => {
+    it('mounts and renders canvas element', () => {
+      const { container } = render(<Spreadsheet columns={columns} data={data} />);
+      expect(container.querySelector('canvas')).not.toBeNull();
+    });
+
+    it('unmounts cleanly without errors', () => {
+      const { container, unmount } = render(<Spreadsheet columns={columns} data={data} />);
+      expect(container.querySelector('canvas')).not.toBeNull();
+      unmount();
+      expect(container.querySelector('canvas')).toBeNull();
+    });
+
+    it('mounts multiple instances simultaneously', () => {
+      const { container } = render(
+        <div>
+          <Spreadsheet columns={columns} data={data} />
+          <Spreadsheet columns={columns} data={[{ name: 'Other', value: 99 }]} />
+        </div>,
+      );
+      const canvases = container.querySelectorAll('canvas');
+      expect(canvases.length).toBe(2);
+    });
+  });
+
+  describe('ref API works with createRef (React 17 pattern)', () => {
+    it('getInstance returns engine', () => {
+      const ref = createRef<SpreadsheetRef>();
+      render(<Spreadsheet ref={ref} columns={columns} data={data} />);
+      expect(ref.current).not.toBeNull();
+      expect(ref.current!.getInstance()).toBeDefined();
+    });
+
+    it('setCell and getCell roundtrip', () => {
+      const ref = createRef<SpreadsheetRef>();
+      render(<Spreadsheet ref={ref} columns={columns} data={data} />);
+      ref.current!.setCell(0, 0, 'Updated');
+      expect(ref.current!.getCell(0, 0)!.value).toBe('Updated');
+    });
+
+    it('undo/redo do not throw', () => {
+      const ref = createRef<SpreadsheetRef>();
+      render(<Spreadsheet ref={ref} columns={columns} data={data} />);
+      expect(() => ref.current!.undo()).not.toThrow();
+      expect(() => ref.current!.redo()).not.toThrow();
+    });
+
+    it('selectCell updates selection', () => {
+      const ref = createRef<SpreadsheetRef>();
+      render(<Spreadsheet ref={ref} columns={columns} data={data} />);
+      ref.current!.selectCell(2, 1);
+      expect(ref.current!.getSelection().activeCell.row).toBe(2);
+      expect(ref.current!.getSelection().activeCell.col).toBe(1);
+    });
+
+    it('installPlugin and removePlugin work', () => {
+      const ref = createRef<SpreadsheetRef>();
+      render(<Spreadsheet ref={ref} columns={columns} data={data} />);
+      const plugin: SpreadsheetPlugin = {
+        name: 'test-compat-plugin',
+        install: vi.fn(),
+        destroy: vi.fn(),
+      };
+      expect(() => ref.current!.installPlugin(plugin)).not.toThrow();
+      expect(plugin.install).toHaveBeenCalled();
+      expect(() => ref.current!.removePlugin('test-compat-plugin')).not.toThrow();
+    });
+  });
+
+  describe('callback props via event bus', () => {
+    it('onCellChange fires through ref pattern', () => {
+      const onCellChange = vi.fn();
+      const ref = createRef<SpreadsheetRef>();
+      render(<Spreadsheet ref={ref} columns={columns} data={data} onCellChange={onCellChange} />);
+
+      ref.current!.getInstance().getEventBus().emit('cellChange', {
+        row: 0, col: 0, value: 'X', column: columns[0], oldValue: 'Row1', newValue: 'X', source: 'test',
+      });
+      expect(onCellChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('callback ref updates without remount', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const ref = createRef<SpreadsheetRef>();
+
+      function TestApp() {
+        const [v, setV] = useState(0);
+        return (
+          <>
+            <button data-testid="switch" onClick={() => setV(1)}>S</button>
+            <Spreadsheet ref={ref} columns={columns} data={data} onCellClick={v === 0 ? handler1 : handler2} />
+          </>
+        );
+      }
+
+      const { getByTestId } = render(<TestApp />);
+      ref.current!.getInstance().getEventBus().emit('cellClick', { row: 0, col: 0, value: 'Row1', column: columns[0] });
+      expect(handler1).toHaveBeenCalledTimes(1);
+
+      act(() => { getByTestId('switch').click(); });
+      ref.current!.getInstance().getEventBus().emit('cellClick', { row: 0, col: 0, value: 'Row1', column: columns[0] });
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler1).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('theme and data prop updates', () => {
+    it('theme prop switch without remount', () => {
+      const ref = createRef<SpreadsheetRef>();
+
+      function TestApp() {
+        const [dark, setDark] = useState(false);
+        return (
+          <>
+            <button data-testid="t" onClick={() => setDark(true)}>T</button>
+            <Spreadsheet ref={ref} columns={columns} data={data} theme={dark ? darkTheme : lightTheme} />
+          </>
+        );
+      }
+
+      const { getByTestId } = render(<TestApp />);
+      const engine1 = ref.current!.getInstance();
+      expect(engine1.getTheme()).toBe(lightTheme);
+
+      act(() => { getByTestId('t').click(); });
+      expect(ref.current!.getInstance()).toBe(engine1); // same instance
+      expect(engine1.getTheme()).toBe(darkTheme);
+    });
+
+    it('data prop update reloads cells', () => {
+      const ref = createRef<SpreadsheetRef>();
+
+      function TestApp() {
+        const [d, setD] = useState(data);
+        const swap = useCallback(() => setD([{ name: 'New', value: 999 }]), []);
+        return (
+          <>
+            <button data-testid="swap" onClick={swap}>S</button>
+            <Spreadsheet ref={ref} columns={columns} data={d} />
+          </>
+        );
+      }
+
+      const { getByTestId } = render(<TestApp />);
+      expect(ref.current!.getCell(0, 0)!.value).toBe('Row1');
+
+      act(() => { getByTestId('swap').click(); });
+      expect(ref.current!.getCell(0, 0)!.value).toBe('New');
+    });
+  });
+
+  // ─── peerDependency range check ────────────────────────────
+
+  describe('package.json peerDependencies', () => {
+    it('includes React 17 in peer dependency range', () => {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'),
+      );
+      expect(pkg.peerDependencies.react).toContain('^17.0.0');
+      expect(pkg.peerDependencies['react-dom']).toContain('^17.0.0');
+    });
+
+    it('includes React 18 in peer dependency range', () => {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'),
+      );
+      expect(pkg.peerDependencies.react).toContain('^18.0.0');
+      expect(pkg.peerDependencies['react-dom']).toContain('^18.0.0');
+    });
+
+    it('includes React 19 in peer dependency range', () => {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'),
+      );
+      expect(pkg.peerDependencies.react).toContain('^19.0.0');
+      expect(pkg.peerDependencies['react-dom']).toContain('^19.0.0');
+    });
+  });
+});
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+function getAllTsFiles(dir: string): string[] {
+  return getAllFiles(dir).filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'));
+}
+
+function getAllFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...getAllFiles(full));
+    } else {
+      files.push(full);
+    }
+  }
+  return files;
+}

--- a/packages/site/src/content/docs/api/cell-types.mdx
+++ b/packages/site/src/content/docs/api/cell-types.mdx
@@ -55,7 +55,7 @@ Each cell type maps to a renderer:
 
 ```ts
 interface CellTypeRenderer {
-  format(value: CellValue, cellData?: CellData, row?: number, col?: number): string;
+  format(value: CellValue, cellData?: CellData, row?: number, col?: number, columnDef?: ColumnDef): string;
   align: CellAlignment; // 'left' | 'center' | 'right'
   render?: (
     ctx: CanvasRenderingContext2D,
@@ -89,7 +89,7 @@ interface CellTypeRenderer {
 
 | Method | Description |
 |---|---|
-| `format(value, cellData?, row?, col?)` | Convert a `CellValue` to display string. Optional `cellData` provides full cell context |
+| `format(value, cellData?, row?, col?, columnDef?)` | Convert a `CellValue` to display string. Optional `cellData` provides full cell context, `columnDef` provides column definition |
 | `align` | Text alignment within the cell |
 | `render` | Optional custom canvas drawing — receives `CellData` instead of raw value |
 | `measureHeight` | Optional height measurement for auto row sizing |
@@ -180,5 +180,158 @@ Use the custom type in a column:
 const columns: ColumnDef[] = [
   { key: 'progress', title: 'Progress', width: 150, type: 'progressBar' },
   { key: 'rating', title: 'Rating', width: 120, type: 'rating' },
+];
+```
+
+## Hit Zones
+
+Hit zones define interactive sub-cell regions that respond to clicks and show custom cursors. Implement `getHitZones` on a `CellTypeRenderer` to declare clickable areas within a cell.
+
+```ts
+interface HitZone {
+  readonly id: string;
+  readonly x: number;      // relative to cell left edge
+  readonly y: number;      // relative to cell top edge
+  readonly width: number;
+  readonly height: number;
+  readonly cursor?: string; // CSS cursor on hover (e.g. 'pointer')
+  readonly padding?: number | { top: number; right: number; bottom: number; left: number };
+}
+```
+
+The `padding` property expands the interactive area beyond the visual bounds — useful for small click targets.
+
+### Example: Clickable Delete Button
+
+```ts
+engine.getCellTypeRegistry().register('deletable', {
+  format: (value) => String(value),
+  align: 'left',
+  render: (ctx, cellData, x, y, width, height, theme) => {
+    // Render text
+    ctx.fillStyle = theme.colors.cellText;
+    ctx.textAlign = 'left';
+    ctx.fillText(String(cellData.value ?? ''), x + 4, y + height / 2 + 4);
+
+    // Render delete button
+    const btnX = x + width - 24;
+    const btnY = y + (height - 16) / 2;
+    ctx.fillStyle = '#dc3545';
+    ctx.font = '14px sans-serif';
+    ctx.fillText('✕', btnX + 2, btnY + 13);
+  },
+  getHitZones: (cellData, width, height) => [
+    {
+      id: 'delete',
+      x: width - 24,
+      y: (height - 16) / 2,
+      width: 20,
+      height: 16,
+      cursor: 'pointer',
+      padding: 4,
+    },
+  ],
+});
+
+// Listen for hit zone clicks
+engine.on('cellClick', (event) => {
+  if (event.hitZone?.id === 'delete') {
+    console.log('Delete clicked at', event.row, event.col);
+  }
+});
+```
+
+## Auto Row Height with measureHeight
+
+Implement `measureHeight` to support variable row heights based on cell content:
+
+```ts
+engine.getCellTypeRegistry().register('multiline', {
+  format: (value) => String(value),
+  align: 'left',
+  render: (ctx, cellData, x, y, width, height, theme) => {
+    const text = String(cellData.value ?? '');
+    const lines = text.split('\n');
+    const lineHeight = 18;
+    ctx.fillStyle = theme.colors.cellText;
+    ctx.font = theme.fonts.cell;
+    lines.forEach((line, i) => {
+      ctx.fillText(line, x + 4, y + 16 + i * lineHeight);
+    });
+  },
+  measureHeight: (ctx, cellData, width, theme) => {
+    const text = String(cellData.value ?? '');
+    const lineCount = text.split('\n').length;
+    return Math.max(28, lineCount * 18 + 10);
+  },
+});
+```
+
+When `AutoRowSizeManager` is enabled, it calls `measureHeight` on each cell to compute the optimal row height.
+
+## Complete Custom Type Walkthrough
+
+This example creates a `badge` type that renders colored labels:
+
+```ts
+import type { CellTypeRenderer, CellValue, CellData, SpreadsheetTheme } from '@witqq/spreadsheet';
+
+const badgeColors: Record<string, string> = {
+  active: '#198754',
+  inactive: '#6c757d',
+  pending: '#ffc107',
+  error: '#dc3545',
+};
+
+const badgeRenderer: CellTypeRenderer = {
+  // 1. format() converts value to display string (used by clipboard, accessibility)
+  format: (value: CellValue) => String(value ?? ''),
+
+  // 2. align sets text alignment fallback
+  align: 'center',
+
+  // 3. render() draws on canvas — called for every visible cell of this type
+  render: (
+    ctx: CanvasRenderingContext2D,
+    cellData: CellData,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    theme: SpreadsheetTheme,
+  ) => {
+    const label = String(cellData.value ?? '');
+    const color = badgeColors[label.toLowerCase()] ?? theme.colors.cellText;
+
+    // Measure text for pill background
+    ctx.font = '11px sans-serif';
+    const textWidth = ctx.measureText(label).width;
+    const pillWidth = textWidth + 12;
+    const pillHeight = 20;
+    const pillX = x + (width - pillWidth) / 2;
+    const pillY = y + (height - pillHeight) / 2;
+
+    // Draw pill
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.roundRect(pillX, pillY, pillWidth, pillHeight, 10);
+    ctx.fill();
+
+    // Draw label
+    ctx.fillStyle = '#fff';
+    ctx.textAlign = 'center';
+    ctx.fillText(label, x + width / 2, pillY + 14);
+  },
+
+  // 4. getHitZones() — optional, not needed for non-interactive types
+  // 5. measureHeight() — optional, not needed for fixed-height types
+};
+
+// Register the type
+engine.getCellTypeRegistry().register('badge', badgeRenderer);
+
+// Use in columns
+const columns: ColumnDef[] = [
+  { key: 'status', title: 'Status', width: 100, type: 'badge' },
 ];
 ```

--- a/packages/site/src/content/docs/api/types.mdx
+++ b/packages/site/src/content/docs/api/types.mdx
@@ -24,12 +24,12 @@ type CellValue = string | number | boolean | Date | null;
 ```typescript
 interface CellData {
   readonly value: CellValue;
-  readonly displayValue?: string;    // Override default formatting
-  readonly formula?: string;         // Formula expression (e.g. "=SUM(A1:A10)")
-  readonly style?: CellStyleRef;     // Reference to shared style
-  readonly type?: CellType;          // Cell type for rendering
-  readonly metadata?: CellMetadata;  // Status, links, comments
-  readonly custom?: Record<string, unknown>;  // Extensible user data
+  readonly displayValue?: string; // Override default formatting
+  readonly formula?: string; // Formula expression (e.g. "=SUM(A1:A10)")
+  readonly style?: CellStyleRef; // Reference to shared style
+  readonly type?: CellType; // Cell type for rendering
+  readonly metadata?: CellMetadata; // Status, links, comments
+  readonly custom?: Record<string, unknown>; // Extensible user data
 }
 ```
 
@@ -48,9 +48,19 @@ interface CellMetadata {
 
 ```typescript
 type CellType =
-  | 'string' | 'number' | 'boolean' | 'date' | 'datetime'
-  | 'select' | 'dynamicSelect' | 'formula'
-  | 'link' | 'image' | 'progressBar' | 'rating' | 'badge'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'date'
+  | 'datetime'
+  | 'select'
+  | 'dynamicSelect'
+  | 'formula'
+  | 'link'
+  | 'image'
+  | 'progressBar'
+  | 'rating'
+  | 'badge'
   | 'custom';
 ```
 
@@ -92,8 +102,8 @@ interface BorderStyle {
 
 ```typescript
 interface CellStyleRef {
-  readonly ref: string;       // Unique key in StylePool
-  readonly style: CellStyle;  // Resolved style object
+  readonly ref: string; // Unique key in StylePool
+  readonly style: CellStyle; // Resolved style object
 }
 ```
 
@@ -138,22 +148,27 @@ interface CellRect {
 
 ```typescript
 interface ColumnDef {
-  readonly key: string;          // Data binding key
-  readonly title: string;        // Header display text
-  readonly width: number;        // Width in pixels
-  readonly minWidth?: number;    // Minimum resize width
-  readonly maxWidth?: number;    // Maximum resize width
-  readonly type?: CellType;      // Cell type for rendering
-  readonly frozen?: boolean;     // Pin to frozen pane
-  readonly sortable?: boolean;   // Enable header click sorting
+  readonly key: string; // Data binding key
+  readonly title: string; // Header display text
+  readonly width: number; // Width in pixels
+  readonly minWidth?: number; // Minimum resize width
+  readonly maxWidth?: number; // Maximum resize width
+  readonly type?: CellType; // Cell type for rendering
+  readonly frozen?: boolean; // Pin to frozen pane
+  readonly sortable?: boolean; // Enable header click sorting
   readonly filterable?: boolean; // Enable filter panel
-  readonly editable?: boolean;   // Allow inline editing
-  readonly resizable?: boolean;  // Allow drag-to-resize
-  readonly hidden?: boolean;     // Hide from display and print
-  readonly wrapText?: boolean;   // Enable text wrapping
+  readonly editable?: boolean; // Allow inline editing
+  readonly resizable?: boolean; // Allow drag-to-resize
+  readonly hidden?: boolean; // Hide from display and print
+  readonly wrapText?: boolean; // Enable text wrapping
+  readonly dateFormat?: string; // Date format pattern (e.g. 'DD.MM.YYYY')
   readonly validation?: SpreadsheetValidationRule[]; // Cell validation rules
 }
 ```
+
+`dateFormat` applies to columns with `type: 'date'` or `'datetime'`. Supported tokens: `YYYY` (4-digit year), `MM` (2-digit month), `DD` (2-digit day). When set, overrides locale-based date formatting for display and editor commit values. When not set, falls back to `toLocaleDateString()` with the current format locale.
+
+Supported patterns: `'YYYY-MM-DD'`, `'DD.MM.YYYY'`, `'MM/DD/YYYY'`, `'DD/MM/YYYY'`.
 
 ## Selection Types
 
@@ -178,8 +193,30 @@ type SelectionType = 'cell' | 'range' | 'row' | 'column' | 'all';
 interface MergedRegion {
   readonly startRow: number;
   readonly startCol: number;
-  readonly endRow: number;    // inclusive
-  readonly endCol: number;    // inclusive
+  readonly endRow: number; // inclusive
+  readonly endCol: number; // inclusive
+}
+```
+
+### MergeValidationError
+
+Result of a single region that failed validation in `setRegions()`.
+
+```typescript
+interface MergeValidationError {
+  readonly region: MergedRegion;
+  readonly error: string;
+}
+```
+
+### SetRegionsResult
+
+Result returned by `MergeManager.setRegions()`.
+
+```typescript
+interface SetRegionsResult {
+  readonly accepted: ReadonlyArray<MergedRegion>;
+  readonly rejected: ReadonlyArray<MergeValidationError>;
 }
 ```
 
@@ -375,8 +412,8 @@ Column definitions and dimension constants for cumulative position arrays.
 
 ```typescript
 interface ViewportConfig {
-  rowBuffer?: number;   // Default: 10
-  colBuffer?: number;   // Default: 5
+  rowBuffer?: number; // Default: 10
+  colBuffer?: number; // Default: 5
 }
 ```
 
@@ -499,7 +536,7 @@ interface PrintManagerConfig {
   columns: ColumnDef[];
   rowStore: RowStore;
   theme: SpreadsheetTheme;
-  maxPrintRows?: number;  // Default: 10000
+  maxPrintRows?: number; // Default: 10000
 }
 ```
 
@@ -510,7 +547,7 @@ Data sources and row cap for `@media print` DOM table generation.
 ```typescript
 interface CanvasManagerConfig {
   container: HTMLElement;
-  dpr?: number;  // Defaults to window.devicePixelRatio
+  dpr?: number; // Defaults to window.devicePixelRatio
 }
 ```
 
@@ -523,6 +560,7 @@ interface GridGeometryConfig {
   columns: ColumnDef[];
   theme: SpreadsheetTheme;
   showRowNumbers: boolean;
+  showColumnHeaders?: boolean;
   rowPositions?: Float64Array;
   rowHeights?: Float64Array;
 }
@@ -561,6 +599,8 @@ interface GridRenderConfig {
   rowCount: number;
   theme: SpreadsheetTheme;
   showRowNumbers: boolean;
+  showColumnHeaders?: boolean;
+  clipGridLinesToData?: boolean;
   showGridLines: boolean;
   selectionManager?: SelectionManager;
   cellTypeRegistry?: CellTypeRegistry;
@@ -663,10 +703,14 @@ Horizontal text alignment within a cell, used by `CellTypeRenderer`.
 
 ```typescript
 type ComparisonOperator =
-  | 'greaterThan' | 'lessThan'
-  | 'greaterThanOrEqual' | 'lessThanOrEqual'
-  | 'equal' | 'notEqual'
-  | 'between' | 'notBetween';
+  | 'greaterThan'
+  | 'lessThan'
+  | 'greaterThanOrEqual'
+  | 'lessThanOrEqual'
+  | 'equal'
+  | 'notEqual'
+  | 'between'
+  | 'notBetween';
 ```
 
 Comparison operators for conditional formatting value conditions.
@@ -675,8 +719,14 @@ Comparison operators for conditional formatting value conditions.
 
 ```typescript
 type EditorCloseReason =
-  | 'enter' | 'shift-enter' | 'tab' | 'shift-tab'
-  | 'escape' | 'blur' | 'scroll' | 'programmatic';
+  | 'enter'
+  | 'shift-enter'
+  | 'tab'
+  | 'shift-tab'
+  | 'escape'
+  | 'blur'
+  | 'scroll'
+  | 'programmatic';
 ```
 
 Reason the inline editor was closed, determines next-cell navigation direction.
@@ -713,8 +763,14 @@ Result of autofill pattern detection with step increment and source values.
 
 ```typescript
 type HitRegion =
-  | 'cell' | 'header' | 'header-sort-icon' | 'header-filter-icon'
-  | 'row-number' | 'row-group-toggle' | 'corner' | 'outside';
+  | 'cell'
+  | 'header'
+  | 'header-sort-icon'
+  | 'header-filter-icon'
+  | 'row-number'
+  | 'row-group-toggle'
+  | 'corner'
+  | 'outside';
 ```
 
 Region of the grid where a mouse event occurred.
@@ -722,6 +778,10 @@ Region of the grid where a mouse event occurred.
 ### HitZone
 
 ```typescript
+type HitZonePadding =
+  | number
+  | { readonly top: number; readonly right: number; readonly bottom: number; readonly left: number };
+
 interface HitZone {
   readonly id: string;
   readonly x: number;
@@ -729,10 +789,13 @@ interface HitZone {
   readonly width: number;
   readonly height: number;
   readonly cursor?: string;
+  readonly padding?: HitZonePadding;
 }
 ```
 
 Declares a rectangular interactive zone within a cell for sub-cell hit testing. Coordinates are relative to the cell content area. Returned by `CellTypeRenderer.getHitZones()`.
+
+The optional `padding` expands the interactive (hit-test) area beyond the visual bounds. Rendering is unaffected — only click/hover detection grows. Accepts a uniform `number` (all sides) or an object with `{ top, right, bottom, left }`.
 
 ### CellDecoratorPosition
 
@@ -748,9 +811,32 @@ Where a cell decorator renders relative to cell content. `left`/`right` reserve 
 interface CellDecorator {
   readonly id: string;
   readonly position: CellDecoratorPosition;
-  getWidth?(cellData: CellData, cellHeight: number, ctx?: CanvasRenderingContext2D, theme?: SpreadsheetTheme, row?: number, col?: number): number;
-  render(ctx: CanvasRenderingContext2D, cellData: CellData, x: number, y: number, width: number, height: number, theme: SpreadsheetTheme, row?: number, col?: number): void;
-  getHitZones?(width: number, height: number, cellData: CellData, row?: number, col?: number): HitZone[];
+  getWidth?(
+    cellData: CellData,
+    cellHeight: number,
+    ctx?: CanvasRenderingContext2D,
+    theme?: SpreadsheetTheme,
+    row?: number,
+    col?: number,
+  ): number;
+  render(
+    ctx: CanvasRenderingContext2D,
+    cellData: CellData,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    theme: SpreadsheetTheme,
+    row?: number,
+    col?: number,
+  ): void;
+  getHitZones?(
+    width: number,
+    height: number,
+    cellData: CellData,
+    row?: number,
+    col?: number,
+  ): HitZone[];
 }
 ```
 
@@ -784,8 +870,7 @@ const statusDecorator: CellDecoratorRegistration = {
     getWidth: () => 16,
     render: (ctx, cellData, x, y, width, height) => {
       const val = String(cellData.value ?? '');
-      const color = val === 'Active' ? '#63be7b'
-        : val === 'Remote' ? '#5b9bd5' : '#f8696b';
+      const color = val === 'Active' ? '#63be7b' : val === 'Remote' ? '#5b9bd5' : '#f8696b';
       ctx.fillStyle = color;
       ctx.beginPath();
       ctx.arc(x + width / 2, y + height / 2, 4, 0, Math.PI * 2);
@@ -808,9 +893,9 @@ Render order: underlay → left → right → text/custom → overlay. Left/righ
 ```typescript
 interface HitTestResult {
   readonly region: HitRegion;
-  readonly row: number;   // -1 if not applicable
-  readonly col: number;   // -1 if not applicable
-  readonly hitZone?: string;       // Hit zone ID if point is inside a declared zone
+  readonly row: number; // -1 if not applicable
+  readonly col: number; // -1 if not applicable
+  readonly hitZone?: string; // Hit zone ID if point is inside a declared zone
   readonly hitZoneCursor?: string; // Cursor style from the matched hit zone
 }
 ```
@@ -1211,7 +1296,7 @@ interface SpreadsheetEvents {
   commandRedo: (event: CommandEvent) => void;
   clipboardCopy: (event: ClipboardDataEvent) => void;
   clipboardCut: (event: ClipboardDataEvent) => void;
-  clipboardPaste: (event: ClipboardDataEvent) => void;
+  clipboardPaste: (event: ClipboardPasteEvent) => void;
   columnResize: (event: ColumnResizeEvent) => void;
   columnResizeStart: (event: { colIndex: number }) => void;
   columnResizeEnd: (event: ColumnResizeEvent) => void;
@@ -1233,6 +1318,17 @@ interface SpreadsheetEvents {
 ```
 
 Map of all public events emitted by `SpreadsheetEngine`. Use `engine.on(eventName, handler)` to subscribe.
+
+### ClipboardPasteEvent
+
+```typescript
+interface ClipboardPasteEvent extends ClipboardDataEvent {
+  startRow: number;
+  startCol: number;
+}
+```
+
+Extended paste event that includes the active cell position at paste time. `startRow`/`startCol` indicate where pasted data begins. Extends `ClipboardDataEvent` which provides `rowCount` and `colCount`.
 
 ## Benchmark Types
 

--- a/packages/site/src/content/docs/api/wit-engine.mdx
+++ b/packages/site/src/content/docs/api/wit-engine.mdx
@@ -125,6 +125,18 @@ See [Per-Cell Styling](/guides/styling/) for `CellStyle` properties, borders, al
 | `getMergedRegion` | `(row, col) => MergedRegion \| null` | Get merged region containing cell |
 | `getMergeManager` | `() => MergeManager` | Access MergeManager |
 
+### MergeManager Methods
+
+Access via `engine.getMergeManager()`:
+
+| Method | Signature | Description |
+|---|---|---|
+| `setRegions` | `(regions, frozenRows?, frozenCols?) => SetRegionsResult` | Atomically replace all merge regions with validation |
+| `merge` | `(region) => boolean` | Merge a single region |
+| `unmerge` | `(startRow, startCol) => boolean` | Unmerge region at anchor |
+| `clearAll` | `() => void` | Remove all regions |
+| `getAllRegions` | `() => ReadonlyArray<MergedRegion>` | Get all active regions |
+
 ## Row Groups
 
 | Method | Signature | Description |
@@ -154,6 +166,17 @@ See [Per-Cell Styling](/guides/styling/) for `CellStyle` properties, borders, al
 | `registerContextMenuItem` | `(item: ContextMenuItem) => void` | Register a menu item |
 | `unregisterContextMenuItem` | `(id: string) => void` | Remove a menu item |
 | `getContextMenuManager` | `() => ContextMenuManager \| null` | Access ContextMenuManager |
+
+### ContextMenuManager Methods
+
+Access via `engine.getContextMenuManager()`:
+
+| Method | Signature | Description |
+|---|---|---|
+| `setItems` | `(items: ContextMenuItem[]) => void` | Atomically replace all custom items, preserving defaults |
+| `registerItem` | `(item: ContextMenuItem) => void` | Register a single item |
+| `unregisterItem` | `(id: string) => void` | Remove item by id |
+| `getItems` | `() => ReadonlyMap<string, ContextMenuItem>` | Get all registered items |
 
 ## Clipboard
 
@@ -210,6 +233,7 @@ See [Event System](/concepts/events/) for a full list of events.
 | `getViewportManager` | `() => ViewportManager \| null` | Access viewport calculation |
 | `getDirtyTracker` | `() => DirtyTracker \| null` | Access dirty tracking |
 | `getScrollManager` | `() => ScrollManager \| null` | Access scroll container |
+| `getScrollContainer` | `() => HTMLDivElement \| null` | Convenience shortcut for `getScrollManager()?.getElement() ?? null` |
 | `getConfig` | `() => SpreadsheetEngineConfig` | Get engine configuration |
 | `getCanvasElement` | `() => HTMLCanvasElement \| null` | Get the canvas DOM element |
 | `getCellTypeRegistry` | `() => CellTypeRegistry` | Access cell type registry |
@@ -246,4 +270,35 @@ engine.on('cellClick', (event) => {
     console.log('Decorator clicked at row', event.row);
   }
 });
+```
+
+## Date Format Utilities
+
+Zero-dependency utilities for formatting and parsing dates with custom patterns. Exported from `@witqq/spreadsheet`.
+
+```ts
+import { formatDate, parseDateString, toDate } from '@witqq/spreadsheet';
+```
+
+| Function | Signature | Description |
+|---|---|---|
+| `formatDate` | `(date: Date, pattern: string) => string` | Format a Date into a pattern string |
+| `parseDateString` | `(value: string, pattern: string) => Date \| null` | Parse a date string using a pattern |
+| `toDate` | `(value: unknown, pattern?: string) => Date \| null` | Parse any value into a Date, trying custom pattern first |
+
+Supported tokens: `YYYY` (4-digit year), `MM` (2-digit month), `DD` (2-digit day).
+
+```ts
+formatDate(new Date(2025, 0, 15), 'DD.MM.YYYY'); // '15.01.2025'
+parseDateString('15.01.2025', 'DD.MM.YYYY');      // Date(2025, 0, 15)
+toDate('2025-01-15', 'DD.MM.YYYY');               // Date(2025, 0, 15)
+```
+
+Use `ColumnDef.dateFormat` to apply per-column date formatting:
+
+```ts
+const columns: ColumnDef[] = [
+  { key: 'created', title: 'Created', width: 120, type: 'date', dateFormat: 'DD.MM.YYYY' },
+  { key: 'updated', title: 'Updated', width: 120, type: 'date', dateFormat: 'YYYY-MM-DD' },
+];
 ```

--- a/packages/site/src/content/docs/getting-started/configuration.mdx
+++ b/packages/site/src/content/docs/getting-started/configuration.mdx
@@ -11,23 +11,25 @@ The core engine accepts the following configuration:
 
 ```ts
 interface SpreadsheetEngineConfig {
-  columns: ColumnDef[];           // Required. Column definitions.
+  columns: ColumnDef[]; // Required. Column definitions.
   data?: Record<string, unknown>[]; // Initial row data.
-  rowCount?: number;              // Total row count (for virtual scrolling without full data).
-  width?: number | string;        // Container width. Number (px) or CSS string.
-  height?: number | string;       // Container height. Number (px) or CSS string.
-  editable?: boolean;             // Enable cell editing. Default: false.
-  sortable?: boolean;             // Enable column sorting. Default: false.
-  frozenRows?: number;            // Number of rows to freeze at the top.
-  frozenColumns?: number;         // Number of columns to freeze on the left.
-  rowHeight?: number;             // Row height in pixels. Default from theme (28).
-  headerHeight?: number;          // Header row height in pixels. Default from theme.
-  showGridLines?: boolean;        // Show cell grid lines. Default: true.
-  showRowNumbers?: boolean;       // Show row number column. Default: true.
-  theme?: SpreadsheetTheme;       // Custom theme object. Default: lightTheme.
+  rowCount?: number; // Total row count (for virtual scrolling without full data).
+  width?: number | string; // Container width. Number (px) or CSS string.
+  height?: number | string; // Container height. Number (px) or CSS string.
+  editable?: boolean; // Enable cell editing. Default: false.
+  sortable?: boolean; // Enable column sorting. Default: false.
+  frozenRows?: number; // Number of rows to freeze at the top.
+  frozenColumns?: number; // Number of columns to freeze on the left.
+  rowHeight?: number; // Row height in pixels. Default from theme (28).
+  headerHeight?: number; // Header row height in pixels. Default from theme.
+  showGridLines?: boolean; // Show cell grid lines. Default: true.
+  showRowNumbers?: boolean; // Show row number column. Default: true.
+  showColumnHeaders?: boolean; // Show column header row. Default: true.
+  clipGridLinesToData?: boolean; // Stop grid lines at data boundary. Default: false.
+  theme?: SpreadsheetTheme; // Custom theme object. Default: lightTheme.
   autoRowHeight?: boolean | AutoRowSizeConfig; // Auto-calculate row heights from content. Default: false. See [Auto Row Height](/guides/auto-row-height/).
   stretchColumns?: 'all' | 'last'; // Stretch columns to fill container width. See [Column Stretch](/guides/column-stretch/).
-  locale?: SpreadsheetLocale;     // Locale for number/date formatting and UI labels. See [Locale System](/guides/locale/).
+  locale?: SpreadsheetLocale; // Locale for number/date formatting and UI labels. See [Locale System](/guides/locale/).
 }
 ```
 
@@ -37,19 +39,19 @@ Each column is defined with a `ColumnDef` object:
 
 ```ts
 interface ColumnDef {
-  key: string;          // Unique column identifier. Maps to data field.
-  title: string;        // Display title in column header.
-  width: number;        // Column width in pixels.
-  minWidth?: number;    // Minimum width when resizing.
-  maxWidth?: number;    // Maximum width when resizing.
-  type?: CellType;      // Cell data type. Default: 'string'.
-  frozen?: boolean;     // Freeze this column to the left.
-  sortable?: boolean;   // Allow sorting on this column. Overrides table-level setting.
+  key: string; // Unique column identifier. Maps to data field.
+  title: string; // Display title in column header.
+  width: number; // Column width in pixels.
+  minWidth?: number; // Minimum width when resizing.
+  maxWidth?: number; // Maximum width when resizing.
+  type?: CellType; // Cell data type. Default: 'string'.
+  frozen?: boolean; // Freeze this column to the left.
+  sortable?: boolean; // Allow sorting on this column. Overrides table-level setting.
   filterable?: boolean; // Show filter icon in column header.
-  editable?: boolean;   // Allow editing cells in this column. Overrides table-level setting.
-  resizable?: boolean;  // Allow column width resizing via drag.
-  hidden?: boolean;     // Hide this column from view.
-  wrapText?: boolean;   // Enable text wrapping in this column. See [Text Wrapping](/guides/text-wrapping/).
+  editable?: boolean; // Allow editing cells in this column. Overrides table-level setting.
+  resizable?: boolean; // Allow column width resizing via drag.
+  hidden?: boolean; // Hide this column from view.
+  wrapText?: boolean; // Enable text wrapping in this column. See [Text Wrapping](/guides/text-wrapping/).
   validation?: SpreadsheetValidationRule[]; // Column-level validation rules.
 }
 ```
@@ -58,35 +60,29 @@ interface ColumnDef {
 
 The `type` field accepts one of these values:
 
-| Type | Description |
-|------|-------------|
-| `'string'` | Plain text (default) |
-| `'number'` | Numeric values with right-alignment |
-| `'boolean'` | Checkbox rendering |
-| `'date'` | Date values with locale formatting. See [Date Editors](/guides/date-editors/) |
-| `'datetime'` | Date + time with calendar and time picker. See [Date Editors](/guides/date-editors/) |
-| `'select'` | Dropdown with predefined options |
-| `'dynamicSelect'` | Dropdown with runtime-resolved options |
-| `'formula'` | Computed cell (requires formula plugin) |
-| `'link'` | Clickable hyperlink |
-| `'image'` | Image thumbnail in cell |
-| `'progressBar'` | Horizontal progress bar |
-| `'rating'` | Star rating display |
-| `'badge'` | Colored badge/tag |
-| `'custom'` | Custom renderer via CellTypeRegistry |
+| Type              | Description                                                                          |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `'string'`        | Plain text (default)                                                                 |
+| `'number'`        | Numeric values with right-alignment                                                  |
+| `'boolean'`       | Checkbox rendering                                                                   |
+| `'date'`          | Date values with locale formatting. See [Date Editors](/guides/date-editors/)        |
+| `'datetime'`      | Date + time with calendar and time picker. See [Date Editors](/guides/date-editors/) |
+| `'select'`        | Dropdown with predefined options                                                     |
+| `'dynamicSelect'` | Dropdown with runtime-resolved options                                               |
+| `'formula'`       | Computed cell (requires formula plugin)                                              |
+| `'link'`          | Clickable hyperlink                                                                  |
+| `'image'`         | Image thumbnail in cell                                                              |
+| `'progressBar'`   | Horizontal progress bar                                                              |
+| `'rating'`        | Star rating display                                                                  |
+| `'badge'`         | Colored badge/tag                                                                    |
+| `'custom'`        | Custom renderer via CellTypeRegistry                                                 |
 
 ## Common Configurations
 
 ### Read-Only Table
 
 ```tsx
-<Spreadsheet
-  columns={columns}
-  data={data}
-  editable={false}
-  sortable={true}
-  height={500}
-/>
+<Spreadsheet columns={columns} data={data} editable={false} sortable={true} height={500} />
 ```
 
 ### Fully Editable Table
@@ -104,16 +100,54 @@ The `type` field accepts one of these values:
 />
 ```
 
+### Per-Cell Read-Only
+
+Individual cells can be made read-only via the `readOnly` field on `CellData`. This overrides both column-level and table-level editable settings.
+
+The editability priority chain is: `CellData.readOnly` > `ColumnDef.editable` > `config.editable`.
+
+```ts
+// Set a cell as read-only
+engine.getCellStore().set(0, 0, { value: 'Locked', readOnly: true });
+
+// Check if a specific cell is editable
+const canEdit = engine.isCellEditable(row, col);
+```
+
+When a cell is not editable, all editing entry points are blocked: double-click, F2, type-to-edit, paste, cut, and autofill. Copy always works regardless of editability.
+
+### Hiding Column Headers
+
+Set `showColumnHeaders` to `false` to hide the column header row. Data starts from the top of the grid and all header interactions (sort, filter, column resize) are disabled.
+
+```tsx
+<Spreadsheet columns={columns} data={data} showColumnHeaders={false} height={400} />
+```
+
+### Clip Grid Lines to Data
+
+Set `clipGridLinesToData` to `true` so grid lines stop at the last data column/row boundary. Phantom grid lines in empty areas are suppressed. Useful for embedding the grid without the default "infinite sheet" appearance.
+
+```tsx
+<Spreadsheet columns={columns} data={data} clipGridLinesToData={true} height={400} />
+```
+
+### Transparent Background
+
+Set `theme.colors.background` to `'transparent'` to make the canvas background transparent, allowing underlying page elements to show through. Per-cell background colors still render normally.
+
+```tsx
+const transparentTheme = {
+  ...lightTheme,
+  colors: { ...lightTheme.colors, background: 'transparent' },
+};
+<Spreadsheet columns={columns} data={data} theme={transparentTheme} height={400} />
+```
+
 ### Frozen Panes
 
 ```tsx
-<Spreadsheet
-  columns={columns}
-  data={data}
-  frozenRows={1}
-  frozenColumns={2}
-  height={600}
-/>
+<Spreadsheet columns={columns} data={data} frozenRows={1} frozenColumns={2} height={600} />
 ```
 
 Frozen panes create four rendering regions: corner (frozen row + frozen col), frozen-row strip, frozen-col strip, and scrollable main content.
@@ -149,3 +183,35 @@ The React wrapper accepts all `SpreadsheetEngineConfig` fields as props, plus ev
 ```
 
 See [Events](/concepts/events/) for the full list of available callbacks.
+
+## Data Management
+
+Use the engine's data methods to update spreadsheet data after initialization:
+
+```ts
+const engine = spreadsheet.getEngine();
+
+// Full replacement (clears existing data)
+engine.setData([
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+]);
+
+// Full replacement with CellData (preserves styles, metadata, readOnly)
+engine.setDataCellData([
+  [{ value: 'Alice', style: { backgroundColor: '#eef' } }, { value: 30 }],
+  [{ value: 'Bob' }, { value: 25 }],
+]);
+
+// Append rows after existing data
+engine.appendRows([{ name: 'Charlie', age: 35 }]);
+
+// Replace specific rows (row 0 in this example)
+engine.replaceRows(0, [{ name: 'Updated', age: 99 }]);
+```
+
+All methods derive column keys from the configured columns. Pass explicit `columnKeys` to override:
+
+```ts
+engine.setData(rows, ['name', 'age']);
+```

--- a/packages/site/src/content/docs/getting-started/typescript.mdx
+++ b/packages/site/src/content/docs/getting-started/typescript.mdx
@@ -136,6 +136,7 @@ if (engine) {
     console.log(cell.value);         // CellValue (string | number | boolean | Date | null)
     console.log(cell.displayValue);  // string | undefined — formatted string for rendering
     console.log(cell.type);          // CellType | undefined
+    console.log(cell.readOnly);      // boolean | undefined — per-cell editing override
   }
 }
 ```

--- a/packages/site/src/content/docs/guides/cell-editor-registry.mdx
+++ b/packages/site/src/content/docs/guides/cell-editor-registry.mdx
@@ -63,7 +63,7 @@ interface CellEditor {
   readonly editingRow: number;
   readonly editingCol: number;
 
-  open(context: CellEditorContext, commitFn: CellEditorCommit, closeFn): void;
+  open(context: CellEditorContext, commitFn: CellEditorCommit, closeFn: CellEditorClose): void;
   close(reason: EditorCloseReason): void;
   setTheme(theme: SpreadsheetTheme): void;
   setLocale(locale: ResolvedLocale): void;
@@ -115,6 +115,124 @@ The `reason` parameter in `close()` tells the engine how to handle focus after c
 ## Theme and Locale Propagation
 
 When `engine.setTheme()` or `engine.setLocale()` is called, the registry propagates the change to all registered editors via `setTheme()` / `setLocale()`.
+
+## Priority-Based Override Patterns
+
+Priority determines which editor wins when multiple matchers match the same cell. Higher numbers are checked first.
+
+### Override by Column Key
+
+```ts
+const registry = engine.getCellEditorRegistry();
+
+// Default select editor for all 'select' columns (priority 0)
+registry.registerForType(selectEditor, 'select', 0);
+
+// Special select editor for the 'country' column (priority 10 — wins)
+registry.register(
+  countrySelectEditor,
+  (column) => column.key === 'country',
+  10,
+);
+```
+
+### Override by Cell Value
+
+```ts
+// Currency editor for number columns that have currency data
+registry.register(
+  currencyEditor,
+  (column, value) => column.type === 'number' && column.key?.startsWith('price'),
+  5,
+);
+```
+
+### Override by Metadata
+
+```ts
+// Color picker for cells with a 'color' metadata flag
+registry.register(
+  colorPickerEditor,
+  (column, value) => column.metadata?.editorType === 'color',
+  15,
+);
+```
+
+## Creating Custom Overlay Editors
+
+Extend `BaseOverlayEditor` for editors that render as a positioned overlay panel below the cell. `BaseOverlayEditor` provides:
+
+- Overlay positioning relative to the cell (flips above if not enough space below)
+- Auto-close on outside click
+- Auto-close on scroll for non-frozen cells
+- Theme and locale propagation
+- Focus management and z-index (50)
+
+### Abstract Methods to Implement
+
+| Method | Description |
+|---|---|
+| `get overlayWidth(): number` | Width of the overlay panel in pixels |
+| `get overlayHeight(): number` | Height of the overlay panel in pixels |
+| `getAriaLabel(): string` | Accessibility label for the overlay dialog |
+| `initializeFromValue(value: CellValue): void` | Set initial state from cell value |
+| `renderContent(): void` | Build DOM content inside `this.overlay` |
+| `onKeyDown(e: KeyboardEvent): void` | Handle keyboard events |
+
+### Example: Color Picker Overlay
+
+```ts
+import { BaseOverlayEditor, CellValue } from '@witqq/spreadsheet';
+
+class ColorPickerEditor extends BaseOverlayEditor {
+  readonly id = 'color-picker';
+  private selectedColor = '#000000';
+
+  get overlayWidth() { return 200; }
+  get overlayHeight() { return 150; }
+  getAriaLabel() { return 'Color picker'; }
+
+  initializeFromValue(value: CellValue): void {
+    this.selectedColor = String(value || '#000000');
+  }
+
+  renderContent(): void {
+    const input = document.createElement('input');
+    input.type = 'color';
+    input.value = this.selectedColor;
+    input.style.width = '100%';
+    input.style.height = '100px';
+    input.addEventListener('input', () => {
+      this.selectedColor = input.value;
+    });
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.textContent = 'Apply';
+    confirmBtn.style.width = '100%';
+    confirmBtn.addEventListener('click', () => {
+      this.commitFn?.(this.editingRow, this.editingCol, null, this.selectedColor);
+      this.closeFn?.('enter');
+    });
+
+    this.overlay!.appendChild(input);
+    this.overlay!.appendChild(confirmBtn);
+  }
+
+  onKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      this.commitFn?.(this.editingRow, this.editingCol, null, this.selectedColor);
+      this.closeFn?.('enter');
+    } else if (e.key === 'Escape') {
+      this.closeFn?.('escape');
+    }
+  }
+}
+
+// Register for columns with type 'color'
+engine.getCellEditorRegistry().registerForType(new ColorPickerEditor(), 'color', 0);
+```
+
+`commitFn` and `closeFn` are protected fields set by `BaseOverlayEditor` during `open()` — use them to commit values and close the editor.
 
 ## See Also
 

--- a/packages/site/src/content/docs/guides/clipboard.mdx
+++ b/packages/site/src/content/docs/guides/clipboard.mdx
@@ -38,6 +38,8 @@ function App() {
 
 Select a range, press Ctrl+C to copy, click a destination cell, and press Ctrl+V to paste.
 
+Read-only cells (via `CellData.readOnly` or `ColumnDef.editable: false`) are automatically skipped during paste and cut operations. Copy always works regardless of editability.
+
 ## Listening to Clipboard Events
 
 Subscribe to clipboard events via the engine's EventBus:

--- a/packages/site/src/content/docs/guides/date-editors.mdx
+++ b/packages/site/src/content/docs/guides/date-editors.mdx
@@ -22,7 +22,7 @@ No additional configuration is needed — the editor is registered automatically
 
 ## Date Editor
 
-The `DatePickerEditor` renders a calendar grid inside a `<div role="dialog">`.
+The `DatePickerEditor` extends `BaseOverlayEditor` and renders a calendar grid inside a `<div role="dialog">`.
 
 - **Trigger**: Double-click or Enter on a date cell
 - **Positioning**: Below the cell; flips above if no room below; clamped horizontally to container bounds
@@ -37,7 +37,7 @@ Accepts `Date` objects, ISO strings (`YYYY-MM-DD`), and numeric timestamps.
 
 ## DateTime Editor
 
-The `DateTimeEditor` extends the calendar with hour and minute spin groups.
+The `DateTimeEditor` extends `BaseOverlayEditor` and adds hour and minute spin groups to the calendar.
 
 - **Day click**: Sets the selected date but stays open for time editing
 - **Time inputs**: Two spin groups (hour 0–23, minute 0–59) with ▲/▼ buttons and editable text inputs

--- a/packages/site/src/content/docs/guides/editing.mdx
+++ b/packages/site/src/content/docs/guides/editing.mdx
@@ -40,9 +40,28 @@ function App() {
 }
 ```
 
-## Per-Column Editability
+## Editability Priority Chain
 
-Control which columns are editable through `ColumnDef.editable`:
+Editability resolves through a three-level priority chain: **cell → column → global**. A more specific level always overrides a less specific one.
+
+```
+CellData.readOnly  >  ColumnDef.editable  >  config.editable
+  (cell level)         (column level)         (global level)
+```
+
+### Global Level
+
+Set `editable` on the engine config or React component to control the default for all cells:
+
+```tsx
+<Spreadsheet columns={columns} data={data} editable={true} />
+```
+
+Default: `false` (read-only).
+
+### Column Level
+
+Override the global default per column via `ColumnDef.editable`:
 
 ```tsx
 const columns: ColumnDef[] = [
@@ -52,6 +71,43 @@ const columns: ColumnDef[] = [
   { key: 'role', title: 'Role', editable: false },
 ];
 ```
+
+When `ColumnDef.editable` is `undefined`, the column inherits the global `editable` setting.
+
+### Cell Level
+
+Override everything per cell via `CellData.readOnly`:
+
+```ts
+// Make a specific cell read-only regardless of column/global settings
+engine.getCellStore().set(row, col, { value: 'locked', readOnly: true });
+
+// Make a specific cell editable even if column is read-only
+engine.getCellStore().set(row, col, { value: 'editable', readOnly: false });
+```
+
+When `CellData.readOnly` is `undefined`, editability falls through to the column level.
+
+### Priority Truth Table
+
+| `config.editable` | `ColumnDef.editable` | `CellData.readOnly` | Result |
+|---|---|---|---|
+| `false` | `undefined` | `undefined` | **Not editable** |
+| `true` | `undefined` | `undefined` | **Editable** |
+| `false` | `true` | `undefined` | **Editable** |
+| `true` | `false` | `undefined` | **Not editable** |
+| any | any | `true` | **Not editable** |
+| any | any | `false` | **Editable** |
+
+### Checking Editability
+
+Use `isCellEditable` to query the resolved editability for any cell:
+
+```ts
+const canEdit = engine.isCellEditable(row, col); // resolves full chain
+```
+
+This method is used internally by the editor, clipboard (paste/cut skip non-editable cells), autofill, and keyboard handler.
 
 ## Editor Close Reasons
 

--- a/packages/site/src/content/docs/guides/migration-from-handsontable.mdx
+++ b/packages/site/src/content/docs/guides/migration-from-handsontable.mdx
@@ -297,6 +297,80 @@ ref.current?.print();
 | Bundle size | ~800KB min | &lt;300KB gzipped |
 | Dependencies | 0 (but large core) | 0 (core) |
 
+## Context Menu
+
+### Handsontable
+
+```js
+new Handsontable(el, {
+  contextMenu: {
+    items: {
+      'row_above': { name: 'Insert row above' },
+      'row_below': { name: 'Insert row below' },
+      'separator': Handsontable.plugins.ContextMenu.SEPARATOR,
+      'remove_row': { name: 'Remove row' },
+      'custom_action': {
+        name: 'Custom action',
+        callback: function(key, selection) {
+          console.log(selection[0].start.row);
+        },
+        disabled: function() {
+          return this.getSelectedLast()[0] === 0;
+        },
+      },
+    },
+  },
+});
+```
+
+### @witqq/spreadsheet
+
+```ts
+const cm = engine.getContextMenuManager();
+
+cm.registerItem({
+  id: 'insert-row-above',
+  label: 'Insert Row Above',
+  shortcut: 'Ctrl+Shift+I',
+  contexts: ['cell', 'row-number'],
+  action: (ctx) => {
+    // ctx.row, ctx.col, ctx.region, ctx.engine
+    console.log('Insert row above', ctx.row);
+  },
+});
+
+cm.registerItem({
+  id: 'remove-row',
+  label: 'Remove Row',
+  contexts: ['cell', 'row-number'],
+  action: (ctx) => console.log('Remove row', ctx.row),
+  isDisabled: (ctx) => ctx.row === 0,
+});
+
+cm.registerItem({
+  id: 'custom-action',
+  label: 'Custom Action',
+  contexts: ['cell'],
+  action: (ctx) => console.log(ctx.row, ctx.col),
+});
+```
+
+**Key differences:**
+
+| Handsontable | @witqq/spreadsheet |
+|---|---|
+| Configure in constructor `contextMenu.items` | Register via `cm.registerItem()` at any time |
+| `callback(key, selection)` | `action(ctx: MenuActionContext)` |
+| `disabled()` returns boolean | `isDisabled(ctx)` returns boolean |
+| `SEPARATOR` constant | `separator: true` property |
+| Single context (right-click area) | `contexts` array: `'cell'`, `'header'`, `'row-number'`, `'corner'` |
+| No submenu by default | `submenu` array for nested menus |
+| No visibility control | `isVisible(ctx)` to conditionally show/hide |
+
+The `MenuActionContext` provides `row`, `col`, `region`, and `engine` — the engine reference enables full spreadsheet manipulation from within any menu action.
+
+For plugin-based usage: `createContextMenuPlugin` from `@witqq/spreadsheet-plugins`. See [Context Menu guide](/guides/context-menu/).
+
 ## License
 
 - Handsontable: Proprietary (paid) for commercial use

--- a/packages/site/src/content/docs/guides/migration-notes.mdx
+++ b/packages/site/src/content/docs/guides/migration-notes.mdx
@@ -1,0 +1,189 @@
+---
+title: "Migration Notes"
+description: "Already-solved issues and API usage patterns for consumers migrating from other spreadsheet libraries."
+---
+
+# Migration Notes
+
+This document covers common integration concerns that are already solved in `@witqq/spreadsheet`. Each section shows the correct API usage for features that consumers frequently ask about.
+
+## Custom Per-Cell Data (CellData.custom)
+
+Every cell has an optional `custom` slot for consumer-defined data. The engine never reads or modifies this field — it is preserved through all get/set/merge operations.
+
+```ts
+// Set custom data on a cell
+engine.getCellStore().set(row, col, {
+  value: 'Order #1234',
+  custom: { orderId: 1234, priority: 'high', tags: ['urgent'] },
+});
+
+// Read custom data
+const cell = engine.getCell(row, col);
+const orderId = cell?.custom?.orderId; // 1234
+
+// Custom data survives bulk operations
+engine.getCellStore().bulkLoadCellData([
+  [
+    { value: 'A', custom: { source: 'import' } },
+    { value: 'B', custom: { source: 'manual' } },
+  ],
+]);
+```
+
+**Interface:**
+
+```ts
+interface CellData {
+  readonly value: CellValue;
+  readonly custom?: Record<string, unknown>;
+  // ... other fields
+}
+```
+
+Use `custom` for application-specific metadata: row IDs, validation state, source tracking, feature flags per cell.
+
+## Clipboard Normalization
+
+`ClipboardManager` handles copy/cut/paste automatically with cross-application interop. It normalizes clipboard data between TSV (plain text) and HTML table formats for Excel and Google Sheets compatibility.
+
+```ts
+// Clipboard works automatically when engine is mounted
+// Ctrl+C / Ctrl+X / Ctrl+V are handled by ClipboardManager
+
+// Listen to clipboard events
+engine.on('clipboardCopy', (e) => console.log('Copied', e.rowCount, 'x', e.colCount));
+engine.on('clipboardPaste', (e) => console.log('Pasted', e.rowCount, 'x', e.colCount));
+```
+
+**Automatic value coercion on paste:**
+
+Values pasted from text are coerced: empty strings → `null`, numeric strings → `number`, `"true"`/`"false"` → `boolean`, everything else → `string`.
+
+**Serialization utilities** (for custom clipboard handling):
+
+```ts
+import {
+  serializeToTSV,
+  serializeToHTML,
+  parseTSV,
+  parseHTML,
+} from '@witqq/spreadsheet';
+
+// Convert 2D data to TSV or HTML
+const tsv = serializeToTSV([['A', 1], ['B', 2]]);
+const html = serializeToHTML([['A', 1], ['B', 2]]);
+
+// Parse incoming clipboard data
+const data = parseTSV(clipboardText);        // CellValue[][]
+const htmlData = parseHTML(clipboardHtml);    // CellValue[][] | null
+```
+
+Paste and cut operations respect per-cell editability (`isCellEditable`) and are fully undoable via the command manager.
+
+## Bulk Data Loading (bulkLoadCellData)
+
+`bulkLoadCellData` loads complete `CellData` objects (value, type, style, metadata, custom) from a 2D array. Use it for initial data loading, imports, and large data updates.
+
+```ts
+// Load full CellData objects
+engine.bulkLoadCellData([
+  [
+    { value: 'Alice', type: 'string' },
+    { value: 28, type: 'number' },
+    { value: true, type: 'boolean', readOnly: true },
+  ],
+  [
+    { value: 'Bob', type: 'string' },
+    { value: 35, type: 'number', custom: { department: 'Engineering' } },
+    { value: false, type: 'boolean', readOnly: true },
+  ],
+]);
+
+// Load starting from a specific row
+engine.bulkLoadCellData(newRows, 100); // starts at row 100
+```
+
+**Position mapping:** `data[i][j]` → row `(startRow + i)`, column `j`. Null/undefined entries are skipped.
+
+**Related bulk methods on CellStore:**
+
+```ts
+const store = engine.getCellStore();
+
+// Load from row objects using column keys
+store.bulkLoad(
+  [{ name: 'Alice', age: 28 }, { name: 'Bob', age: 35 }],
+  ['name', 'age'],
+);
+
+// Load a chunk at a specific offset (for progressive loading)
+store.bulkLoadChunk(startRow, rows, columnKeys);
+
+// Generate rows with a factory function (for streaming)
+store.bulkGenerate(startRow, count, columnKeys, (rowIndex) => ({
+  name: `Row ${rowIndex}`,
+  age: Math.floor(Math.random() * 100),
+}));
+```
+
+All bulk methods trigger a single version bump and render cycle regardless of data size.
+
+## Style Deduplication (StylePool)
+
+`StylePool` uses the flyweight pattern to deduplicate cell styles. Multiple cells with identical styles share a single style object in memory. Import and use it directly:
+
+```ts
+import { StylePool } from '@witqq/spreadsheet';
+
+const pool = new StylePool();
+
+// Intern a style — returns a ref string (content hash)
+const ref1 = pool.intern({ bold: true, color: '#333' });
+const ref2 = pool.intern({ bold: true, color: '#333' });
+console.log(ref1 === ref2); // true — same style, same ref
+
+// Resolve a ref back to a style object
+const style = pool.resolve(ref1); // { bold: true, color: '#333' }
+
+// Use refs in CellData
+engine.getCellStore().set(row, col, {
+  value: 'Styled cell',
+  style: { ref: ref1 },
+});
+
+// Check pool size (number of unique styles)
+console.log(pool.size); // 1
+```
+
+**API:**
+
+| Method | Description |
+|---|---|
+| `intern(style: CellStyle): string` | Deduplicate and return ref (hash) |
+| `resolve(ref: string): CellStyle \| undefined` | Look up style by ref |
+| `has(ref: string): boolean` | Check if ref exists |
+| `size` | Number of unique styles |
+| `clear()` | Remove all interned styles |
+
+Style refs are stored as `CellData.style.ref`. The pool freezes all interned style objects to prevent accidental mutation.
+
+## Scroll Container Access (getScrollContainer)
+
+`getScrollContainer()` returns the scrollable `<div>` that wraps the canvas. Use it when integrating external UI elements that need to position relative to the spreadsheet or respond to scroll events.
+
+```ts
+const scrollEl = engine.getScrollContainer();
+
+// Position a custom tooltip relative to the spreadsheet
+scrollEl?.addEventListener('scroll', () => {
+  tooltip.style.display = 'none'; // hide on scroll
+});
+
+// Use for custom overlay positioning
+const rect = scrollEl?.getBoundingClientRect();
+```
+
+Equivalent to `engine.getScrollManager()?.getElement() ?? null`.
+
+The scroll container is used internally by `ClipboardManager` (clipboard event listeners), `InlineEditor` (scroll-close behavior), and all overlay editors for positioning calculations.


### PR DESCRIPTION
## Summary

Address all 20 issues from the Planeta Analytics Handsontable migration. Universal API enhancements, editor infrastructure, decorator plugin, React 17 compatibility, and documentation.

## Core API (Steps 1-7)

- **Editing Access Control**: 3-level priority chain (global → column → cell readOnly), `isCellEditable()`, guards on all entry points
- **Data Management**: `setData()`, `setDataCellData()`, `appendRows()`, `replaceRows()` — atomic single-render operations
- **Layout Regions**: `showColumnHeaders` config, `headerHeight` runtime config
- **Viewport Rendering**: `clipGridLinesToData`, transparent background support
- **HitZone padding**: expandable click targets for small interactive elements
- **Paste event coordinates**: `startRow`/`startCol` on `ClipboardPasteEvent`
- **getScrollContainer()**: convenience method on SpreadsheetEngine
- **MergeManager.setRegions()**: atomic region replacement with validation
- **ContextMenuManager.setItems()**: atomic custom item replacement preserving defaults
- **dateFormat on ColumnDef**: per-column date formatting with internal format/parse utility

## Editor Infrastructure (Steps 8-9)

- **BaseOverlayEditor**: abstract class for DOM overlay editors (positioning, scroll-close, click-outside)
- **SelectEditor**: dropdown with keyboard nav, type-ahead filtering

## Plugin (Steps 10-11)

- **@witqq/spreadsheet-decorators**: TreeExpander, SortIcon, ProgressBar, Link, Image, Spinner
- **ImageManager**: async image loading with LRU cache
- **Animated decorator support**: rAF loop for SpinnerDecorator

## Compatibility (Step 12)

- React 17/18/19: peerDependencies `^17.0.0 || ^18.0.0 || ^19.0.0`

## Documentation (Step 13)

- Editability priority chain guide
- Context menu migration from Handsontable
- Cell types: hit zones, measureHeight, badge walkthrough
- Cell editor registry: priority overrides, BaseOverlayEditor
- Migration notes: 5 already-solved issues

## Tests

2120 tests across 94 files — all passing. 79 files changed, +9027/-896 lines.